### PR TITLE
Fix sys_ntohl macro; it just replicated the low byte instead of reordering bytes

### DIFF
--- a/skeletons/asn_system.h
+++ b/skeletons/asn_system.h
@@ -29,9 +29,9 @@
 
 /* To avoid linking with ws2_32.lib, here's the definition of ntohl() */
 #define sys_ntohl(l)	((((l) << 24)  & 0xff000000)	\
-			| (((l) << 16) & 0xff0000)	\
-			| (((l) << 8)  & 0xff00)	\
-			| ((l) & 0xff))
+			| (((l) << 8) & 0xff0000)	\
+			| (((l) >> 8)  & 0xff00)	\
+			| ((l >> 24) & 0xff))
 
 #ifdef _MSC_VER			/* MSVS.Net */
 #ifndef __cplusplus


### PR DESCRIPTION
Hi. The macro didn't work properly in Visual C.
It converted 0xaabbccdd into 0xdddddddd.

For that reason the function _SET_is_populated() was failing.
