### PR TITLE
Removed code outputting extraneous parentheses.

### DIFF
--- a/libasn1compiler/asn1c_constraint.c
+++ b/libasn1compiler/asn1c_constraint.c
@@ -169,9 +169,7 @@ asn1c_emit_constraint_checking_code(arg_t *arg) {
 	INDENT(+1);
 		if(r_size) {
 			if(got_something++) { OUT("\n"); OUT(" && "); }
-			/*OUT("(");*/
 			emit_range_comparison_code(arg, r_size, "size", 0, -1);
-			/*OUT(")");*/
 		}
 		if(r_value) {
 			if(got_something++) { OUT("\n"); OUT(" && "); }


### PR DESCRIPTION
Removed code outputting extraneous parentheses.  This eliminates warnings when compiling the generated source files.  For example:

GeohashPointHighFidelity.c:30:11: warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
        if((size == 35)) {
            ~~~~~^~~~~
GeohashPointHighFidelity.c:30:11: note: remove extraneous parentheses around the comparison to silence this warning
        if((size == 35)) {
           ~     ^    ~
GeohashPointHighFidelity.c:30:11: note: use '=' to turn this equality comparison into an assignment
        if((size == 35)) {
                 ^~
                 =
1 warning generated.
