### PR TITLE
Include the module name in the extracted ASN.1 file.

### DIFF
--- a/examples/crfc2asn1.pl
+++ b/examples/crfc2asn1.pl
@@ -44,14 +44,15 @@ while(<>) {
 			$inasn = 1;
 		} elsif(/^[ \t]*([A-Z][A-Za-z0-9-]*).*{[ \t]*iso/
 		|| /^[ \t]*{[ \t]*iso/) {
+			my @a = ($_);
 			$modName = $1;
 			unless(length($modName)) {
 				next unless $prevLine =~
 					/^[ \t]*([A-Z][A-Za-z0-9-]*)[ \t]*$/;
 				$modName = $1;
+				unshift(@a, $prevLine);
 			}
 			$currentFname = $rfcid . $modName . ".asn1";
-			my @a = ($_);
 			my $i;
 			for($i = 0; $i < 8; $i++) {
 				$_ = <>;


### PR DESCRIPTION
This code path was looking backwards to find `$modName`, but never writing it to the output file.
