### PR TITLE
Disable extra portability errors in automake

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_INIT([asn1c], [0.9.28], [vlm@lionet.info])
 
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_HEADER([config.h])
-AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+AM_INIT_AUTOMAKE([-Wall -Wno-extra-portability -Werror foreign])
 AC_CONFIG_MACRO_DIR([m4])
 
 AM_MAINTAINER_MODE


### PR DESCRIPTION
Automake 1.12 complains about a missing AM_PROG_AR for non-POSIX archivers.

This is probably a bug in libtool, or automake, or something else. Whichever,
it means that autoreconf -i fails, which is plain irritating.