### PR TITLE
Fix warning in strict C99 mode

### DIFF
--- a/skeletons/OBJECT_IDENTIFIER.c
+++ b/skeletons/OBJECT_IDENTIFIER.c
@@ -270,7 +270,9 @@ OBJECT_IDENTIFIER__dump_body(const OBJECT_IDENTIFIER_t *st, asn_app_consume_byte
 static enum xer_pbd_rval
 OBJECT_IDENTIFIER__xer_body_decode(asn_TYPE_descriptor_t *td, void *sptr, const void *chunk_buf, size_t chunk_size) {
 	OBJECT_IDENTIFIER_t *st = (OBJECT_IDENTIFIER_t *)sptr;
+#ifndef NDEBUG
 	const char *chunk_end = (const char *)chunk_buf + chunk_size;
+#endif
 	const char *endptr;
 	long s_arcs[10];
 	long *arcs = s_arcs;

--- a/skeletons/OCTET_STRING.c
+++ b/skeletons/OCTET_STRING.c
@@ -157,7 +157,7 @@ OS__add_stack_el(struct _stack *st) {
 }
 
 static struct _stack *
-_new_stack() {
+_new_stack(void) {
 	return (struct _stack *)CALLOC(1, sizeof(struct _stack));
 }
 

--- a/skeletons/per_support.c
+++ b/skeletons/per_support.c
@@ -298,10 +298,12 @@ int uper_put_constrained_whole_number_s(asn_per_outp_t *po, long v, int nbits) {
 	 * The following testing code will likely be optimized out
 	 * by compiler if it is true.
 	 */
+#ifndef NDEBUG
 	unsigned long uvalue1 = ULONG_MAX;
 	         long svalue  = uvalue1;
 	unsigned long uvalue2 = svalue;
 	assert(uvalue1 == uvalue2);
+#endif
 	return uper_put_constrained_whole_number_u(po, v, nbits);
 }
 


### PR DESCRIPTION
"Function definition does not declare prototype"