### PR TITLE
Avoid memory leak on error

### DIFF
--- a/skeletons/constr_SEQUENCE.c
+++ b/skeletons/constr_SEQUENCE.c
@@ -1148,8 +1148,10 @@ SEQUENCE_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
 		if(!epres) _ASN_DECODE_STARVED;
 
 		/* Get the extensions map */
-		if(per_get_many_bits(pd, epres, 0, bmlength))
+		if(per_get_many_bits(pd, epres, 0, bmlength)) {
+			FREEMEM(epres);
 			_ASN_DECODE_STARVED;
+		}
 
 		memset(&epmd, 0, sizeof(epmd));
 		epmd.buffer = epres;


### PR DESCRIPTION
This was found on an internal Red Hat scan with multiple fuzzers.

Signed-off-by: Simo Sorce <simo@redhat.com>