### PR TITLE
Delete unnecessary checks before some function calls

### DIFF
--- a/libasn1fix/asn1fix_crange.c
+++ b/libasn1fix/asn1fix_crange.c
@@ -673,10 +673,8 @@ _range_canonicalize(asn1cnst_range_t *range) {
 			range->right = tmp;
 		}
 
-		if(range->elements) {
-			free(range->elements);
-			range->elements = 0;
-		}
+		free(range->elements);
+		range->elements = 0;
 		range->el_size = 0;
 		return 0;
 	}

--- a/libasn1fix/asn1fix_tags.c
+++ b/libasn1fix/asn1fix_tags.c
@@ -166,7 +166,7 @@ asn1f_fetch_tags(asn1p_t *asn, asn1p_module_t *mod, asn1p_expr_t *expr, struct a
 	arg.expr = expr;
 
 	count = asn1f_fetch_tags_impl(&arg, &tags, 0, 0, flags);
-	if(count <= 0 && tags) {
+	if (count <= 0) {
 		free(tags);
 		tags = 0;
 	}

--- a/libasn1parser/asn1p_constr.c
+++ b/libasn1parser/asn1p_constr.c
@@ -23,14 +23,10 @@ void
 asn1p_constraint_free(asn1p_constraint_t *ct) {
 	if(ct) {
 
-		if(ct->containedSubtype)
-			asn1p_value_free(ct->containedSubtype);
-		if(ct->value)
-			asn1p_value_free(ct->value);
-		if(ct->range_start)
-			asn1p_value_free(ct->range_start);
-		if(ct->range_stop)
-			asn1p_value_free(ct->range_stop);
+		asn1p_value_free(ct->containedSubtype);
+		asn1p_value_free(ct->value);
+		asn1p_value_free(ct->range_start);
+		asn1p_value_free(ct->range_stop);
 
 		if(ct->elements) {
 			while(ct->el_count--) {

--- a/libasn1parser/asn1p_expr.c
+++ b/libasn1parser/asn1p_expr.c
@@ -246,20 +246,13 @@ asn1p_expr_free(asn1p_expr_t *expr) {
 		}
 
 		free(expr->Identifier);
-		if(expr->reference)
-			asn1p_ref_free(expr->reference);
-		if(expr->constraints)
-			asn1p_constraint_free(expr->constraints);
-		if(expr->combined_constraints)
-			asn1p_constraint_free(expr->combined_constraints);
-		if(expr->lhs_params)
-			asn1p_paramlist_free(expr->lhs_params);
-		if(expr->value)
-			asn1p_value_free(expr->value);
-		if(expr->marker.default_value)
-			asn1p_value_free(expr->marker.default_value);
-		if(expr->with_syntax)
-			asn1p_wsyntx_free(expr->with_syntax);
+		asn1p_ref_free(expr->reference);
+		asn1p_constraint_free(expr->constraints);
+		asn1p_constraint_free(expr->combined_constraints);
+		asn1p_paramlist_free(expr->lhs_params);
+		asn1p_value_free(expr->value);
+		asn1p_value_free(expr->marker.default_value);
+		asn1p_wsyntx_free(expr->with_syntax);
 
 		if(expr->data && expr->data_free)
 			expr->data_free(expr->data);

--- a/libasn1parser/asn1p_param.c
+++ b/libasn1parser/asn1p_param.c
@@ -27,8 +27,7 @@ asn1p_paramlist_free(asn1p_paramlist_t *pl) {
 		if(pl->params) {
 			int i = pl->params_count;
 			while(i--) {
-				if(pl->params[i].governor)
-					asn1p_ref_free(pl->params[i].governor);
+				asn1p_ref_free(pl->params[i].governor);
 				free(pl->params[i].argument);
 				pl->params[i].governor = 0;
 				pl->params[i].argument = 0;
@@ -82,8 +81,7 @@ asn1p_paramlist_add_param(asn1p_paramlist_t *pl, asn1p_ref_t *gov, char *arg) {
 		pl->params_count++;
 		return 0;
 	} else {
-		if(pl->params[pl->params_count].governor)
-			asn1p_ref_free(pl->params[pl->params_count].governor);
+		asn1p_ref_free(pl->params[pl->params_count].governor);
 		return -1;
 	}
 }

--- a/libasn1parser/asn1p_y.c
+++ b/libasn1parser/asn1p_y.c
@@ -2318,8 +2318,7 @@ yyreduce:
     {
 		(yyval.a_oid) = asn1p_oid_new();
 		asn1p_oid_add_arc((yyval.a_oid), &(yyvsp[(1) - (1)].a_oid_arc));
-		if((yyvsp[(1) - (1)].a_oid_arc).name)
-			free((yyvsp[(1) - (1)].a_oid_arc).name);
+		free((yyvsp[(1) - (1)].a_oid_arc).name);
 	}
     break;
 
@@ -2328,8 +2327,7 @@ yyreduce:
     {
 		(yyval.a_oid) = (yyvsp[(1) - (2)].a_oid);
 		asn1p_oid_add_arc((yyval.a_oid), &(yyvsp[(2) - (2)].a_oid_arc));
-		if((yyvsp[(2) - (2)].a_oid_arc).name)
-			free((yyvsp[(2) - (2)].a_oid_arc).name);
+		free((yyvsp[(2) - (2)].a_oid_arc).name);
 	}
     break;
 
@@ -2826,7 +2824,7 @@ yyreduce:
 		ret = asn1p_paramlist_add_param((yyval.a_plist), (yyvsp[(1) - (1)].a_parg).governor, (yyvsp[(1) - (1)].a_parg).argument);
 		checkmem(ret == 0);
 		if((yyvsp[(1) - (1)].a_parg).governor) asn1p_ref_free((yyvsp[(1) - (1)].a_parg).governor);
-		if((yyvsp[(1) - (1)].a_parg).argument) free((yyvsp[(1) - (1)].a_parg).argument);
+		free((yyvsp[(1) - (1)].a_parg).argument);
 	}
     break;
 
@@ -2838,7 +2836,7 @@ yyreduce:
 		ret = asn1p_paramlist_add_param((yyval.a_plist), (yyvsp[(3) - (3)].a_parg).governor, (yyvsp[(3) - (3)].a_parg).argument);
 		checkmem(ret == 0);
 		if((yyvsp[(3) - (3)].a_parg).governor) asn1p_ref_free((yyvsp[(3) - (3)].a_parg).governor);
-		if((yyvsp[(3) - (3)].a_parg).argument) free((yyvsp[(3) - (3)].a_parg).argument);
+		free((yyvsp[(3) - (3)].a_parg).argument);
 	}
     break;
 


### PR DESCRIPTION
- [The function "free"](http://stackoverflow.com/questions/18775608/free-a-null-pointer-anyway-or-check-first) is documented in the way that no action shall occur for a passed null pointer. Redundant safety checks can be avoided.
- The following functions perform also input parameter validation.
  - [asn1p_constraint_free](https://github.com/vlm/asn1c/blob/5c541f119e188d4ada807cc53938fff8a84c88a4/libasn1parser/asn1p_constr.c#L22)
  - [asn1p_paramlist_free](https://github.com/vlm/asn1c/blob/d8b8364c8acea078ff098d8b6fbaa0a29da9346a/libasn1parser/asn1p_param.c#L24)
  - [asn1p_ref_free](https://github.com/vlm/asn1c/blob/d8b8364c8acea078ff098d8b6fbaa0a29da9346a/libasn1parser/asn1p_ref.c#L24)
  - [asn1p_value_free](https://github.com/vlm/asn1c/blob/a9532f4d2bad200422ffacae45342c73f7cb40cb/libasn1parser/asn1p_value.c#L221)
  - [asn1p_wsyntx_free](https://github.com/vlm/asn1c/blob/c46b7cb50041897e2f6d617bdf23582d9462d4e5/libasn1parser/asn1p_class.c#L124)
  
  It is therefore not needed that a function caller repeats a corresponding check.
