### PR TITLE
Unify the naming of asn_OCTET_STRING_specifics_t variables

### DIFF
--- a/skeletons/ANY.c
+++ b/skeletons/ANY.c
@@ -6,7 +6,7 @@
 #include <ANY.h>
 #include <errno.h>
 
-static asn_OCTET_STRING_specifics_t asn_DEF_ANY_specs = {
+static asn_OCTET_STRING_specifics_t asn_SPC_ANY_specs = {
 	sizeof(ANY_t),
 	offsetof(ANY_t, _asn_ctx),
 	ASN_OSUBV_ANY
@@ -26,7 +26,7 @@ asn_TYPE_descriptor_t asn_DEF_ANY = {
 	0, 0, 0, 0,
 	0,	/* No PER visible constraints */
 	0, 0,	/* No members */
-	&asn_DEF_ANY_specs,
+	&asn_SPC_ANY_specs,
 };
 
 

--- a/skeletons/BIT_STRING.c
+++ b/skeletons/BIT_STRING.c
@@ -12,7 +12,7 @@
 static const ber_tlv_tag_t asn_DEF_BIT_STRING_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (3 << 2))
 };
-static asn_OCTET_STRING_specifics_t asn_DEF_BIT_STRING_specs = {
+static asn_OCTET_STRING_specifics_t asn_SPC_BIT_STRING_specs = {
 	sizeof(BIT_STRING_t),
 	offsetof(BIT_STRING_t, _asn_ctx),
 	ASN_OSUBV_BIT
@@ -38,7 +38,7 @@ asn_TYPE_descriptor_t asn_DEF_BIT_STRING = {
 	  / sizeof(asn_DEF_BIT_STRING_tags[0]),
 	0,	/* No PER visible constraints */
 	0, 0,	/* No members */
-	&asn_DEF_BIT_STRING_specs
+	&asn_SPC_BIT_STRING_specs
 };
 
 /*

--- a/skeletons/BMPString.c
+++ b/skeletons/BMPString.c
@@ -13,7 +13,7 @@ static const ber_tlv_tag_t asn_DEF_BMPString_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (30 << 2)),	/* [UNIVERSAL 30] IMPLICIT ...*/
 	(ASN_TAG_CLASS_UNIVERSAL | (4 << 2))	/* ... OCTET STRING */
 };
-static asn_OCTET_STRING_specifics_t asn_DEF_BMPString_specs = {
+static asn_OCTET_STRING_specifics_t asn_SPC_BMPString_specs = {
 	sizeof(BMPString_t),
 	offsetof(BMPString_t, _asn_ctx),
 	ASN_OSUBV_U16	/* 16-bits character */
@@ -44,7 +44,7 @@ asn_TYPE_descriptor_t asn_DEF_BMPString = {
 	  / sizeof(asn_DEF_BMPString_tags[0]),
 	&asn_DEF_BMPString_constraints,
 	0, 0,	/* No members */
-	&asn_DEF_BMPString_specs
+	&asn_SPC_BMPString_specs
 };
 
 /*

--- a/skeletons/OCTET_STRING.c
+++ b/skeletons/OCTET_STRING.c
@@ -14,7 +14,7 @@
 static const ber_tlv_tag_t asn_DEF_OCTET_STRING_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (4 << 2))
 };
-static const asn_OCTET_STRING_specifics_t asn_DEF_OCTET_STRING_specs = {
+static const asn_OCTET_STRING_specifics_t asn_SPC_OCTET_STRING_specs = {
 	sizeof(OCTET_STRING_t),
 	offsetof(OCTET_STRING_t, _asn_ctx),
 	ASN_OSUBV_STR
@@ -45,7 +45,7 @@ asn_TYPE_descriptor_t asn_DEF_OCTET_STRING = {
 	  / sizeof(asn_DEF_OCTET_STRING_tags[0]),
 	0,	/* No PER visible constraints */
 	0, 0,	/* No members */
-	&asn_DEF_OCTET_STRING_specs
+	&asn_SPC_OCTET_STRING_specs
 };
 
 #undef	_CH_PHASE
@@ -170,7 +170,7 @@ OCTET_STRING_decode_ber(asn_codec_ctx_t *opt_codec_ctx,
 	void **sptr, const void *buf_ptr, size_t size, int tag_mode) {
 	asn_OCTET_STRING_specifics_t *specs = td->specifics
 				? (asn_OCTET_STRING_specifics_t *)td->specifics
-				: &asn_DEF_OCTET_STRING_specs;
+				: &asn_SPC_OCTET_STRING_specs;
 	BIT_STRING_t *st = (BIT_STRING_t *)*sptr;
 	asn_dec_rval_t rval;
 	asn_struct_ctx_t *ctx;
@@ -519,7 +519,7 @@ OCTET_STRING_encode_der(asn_TYPE_descriptor_t *td, void *sptr,
 	asn_enc_rval_t er;
 	asn_OCTET_STRING_specifics_t *specs = td->specifics
 				? (asn_OCTET_STRING_specifics_t *)td->specifics
-				: &asn_DEF_OCTET_STRING_specs;
+				: &asn_SPC_OCTET_STRING_specs;
 	BIT_STRING_t *st = (BIT_STRING_t *)sptr;
 	enum asn_OS_Subvariant type_variant = specs->subvariant;
 	int fix_last_byte = 0;
@@ -1112,7 +1112,7 @@ OCTET_STRING__decode_xer(asn_codec_ctx_t *opt_codec_ctx,
 	OCTET_STRING_t *st = (OCTET_STRING_t *)*sptr;
 	asn_OCTET_STRING_specifics_t *specs = td->specifics
 				? (asn_OCTET_STRING_specifics_t *)td->specifics
-				: &asn_DEF_OCTET_STRING_specs;
+				: &asn_SPC_OCTET_STRING_specs;
 	const char *xml_tag = opt_mname ? opt_mname : td->xml_tag;
 	asn_struct_ctx_t *ctx;		/* Per-structure parser context */
 	asn_dec_rval_t rval;		/* Return value from the decoder */
@@ -1327,7 +1327,7 @@ OCTET_STRING_decode_uper(asn_codec_ctx_t *opt_codec_ctx,
 
 	asn_OCTET_STRING_specifics_t *specs = td->specifics
 		? (asn_OCTET_STRING_specifics_t *)td->specifics
-		: &asn_DEF_OCTET_STRING_specs;
+		: &asn_SPC_OCTET_STRING_specs;
 	asn_per_constraints_t *pc = constraints ? constraints
 				: td->per_constraints;
 	asn_per_constraint_t *cval;
@@ -1498,7 +1498,7 @@ OCTET_STRING_encode_uper(asn_TYPE_descriptor_t *td,
 
 	asn_OCTET_STRING_specifics_t *specs = td->specifics
 		? (asn_OCTET_STRING_specifics_t *)td->specifics
-		: &asn_DEF_OCTET_STRING_specs;
+		: &asn_SPC_OCTET_STRING_specs;
 	asn_per_constraints_t *pc = constraints ? constraints
 				: td->per_constraints;
 	asn_per_constraint_t *cval;
@@ -1721,7 +1721,7 @@ OCTET_STRING_free(asn_TYPE_descriptor_t *td, void *sptr, int contents_only) {
 
 	specs = td->specifics
 		    ? (asn_OCTET_STRING_specifics_t *)td->specifics
-		    : &asn_DEF_OCTET_STRING_specs;
+		    : &asn_SPC_OCTET_STRING_specs;
 	ctx = (asn_struct_ctx_t *)((char *)st + specs->ctx_offset);
 
 	ASN_DEBUG("Freeing %s as OCTET STRING", td->name);
@@ -1793,7 +1793,7 @@ OCTET_STRING_t *
 OCTET_STRING_new_fromBuf(asn_TYPE_descriptor_t *td, const char *str, int len) {
 	asn_OCTET_STRING_specifics_t *specs = td->specifics
 				? (asn_OCTET_STRING_specifics_t *)td->specifics
-				: &asn_DEF_OCTET_STRING_specs;
+				: &asn_SPC_OCTET_STRING_specs;
 	OCTET_STRING_t *st;
 
 	st = (OCTET_STRING_t *)CALLOC(1, specs->struct_size);

--- a/skeletons/UniversalString.c
+++ b/skeletons/UniversalString.c
@@ -13,7 +13,7 @@ static const ber_tlv_tag_t asn_DEF_UniversalString_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (28 << 2)),	/* [UNIVERSAL 28] IMPLICIT ...*/
 	(ASN_TAG_CLASS_UNIVERSAL | (4 << 2))	/* ... OCTET STRING */
 };
-static asn_OCTET_STRING_specifics_t asn_DEF_UniversalString_specs = {
+static asn_OCTET_STRING_specifics_t asn_SPC_UniversalString_specs = {
 	sizeof(UniversalString_t),
 	offsetof(UniversalString_t, _asn_ctx),
 	ASN_OSUBV_U32	/* 32-bits character */
@@ -44,7 +44,7 @@ asn_TYPE_descriptor_t asn_DEF_UniversalString = {
 	  / sizeof(asn_DEF_UniversalString_tags[0]),
 	&asn_DEF_UniversalString_constraints,
 	0, 0,	/* No members */
-	&asn_DEF_UniversalString_specs
+	&asn_SPC_UniversalString_specs
 };
 
 


### PR DESCRIPTION
Unify the naming of asn_OCTET_STRING_specifics_t with code-generated '_specifics_t' variables to have 'asn_SPC_' prefix instead of 'asn_DEF_' prefix.
