### PR TITLE
Simplify finding decoder logic

### DIFF
--- a/asn1c/log2diff.pl
+++ b/asn1c/log2diff.pl
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+#
+# Convert check-parsing.sh log to diff format
+#
+
+if(-t STDIN && $#ARGV == -1) {
+	print STDERR "Usage : log2diff.pl < check-parsing.sh.log > diff.patch\n";
+	exit(1);
+}
+
+$state = 0;
+while(<>) {
+	if ($state == 0) {
+		if (/^Checking\s*(.+?)\s*against\s*(.+?)$/) {
+			$source = $1;
+			$target = $2;
+		} elsif (/^\-\-\-\s(.+?)\s.*/) {
+			print "--- a/dev/null " . "\n";
+		} elsif (/^\+\+\+\s(.+?)\s.*/) {
+			print "+++ b" . $target . "\n";
+			$state = 1;
+		}
+	} else {
+		if (/^Checking\s*(.+?)\s*against\s*(.+?)$/) {
+			$source = $1;
+			$target = $2;
+			$state = 0;
+		} else {
+			print $_;
+		}
+	}
+}

--- a/examples/sample.source.RRC/Makefile
+++ b/examples/sample.source.RRC/Makefile
@@ -4825,7 +4825,7 @@ check-per:
 	done; done; fi
 	@if test -f sample-DL-DCCH-Message-1.per ; then \
 	for f in sample-*-[1-9].per; do \
-	pdu=`echo $$f | sed -E -e "s/sample-([A-Za-z-]+)-[0-9].*/\1/"`; \
+	pdu=`echo $$f | sed -E -e "s/sample-([A-Za-z-]+)-[0-9].*//"`; \
 	for b in 1 17 33 980 8192; do \
 	echo "Recoding $$f into DER into XER and back ($$b)..."; \
 	./${TARGET} -b $$b -p $$pdu -iper -oder $$f > ./.tmp.1.$$$$ || exit 3; \

--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -203,7 +203,8 @@ asn1c_lang_C_type_common_INTEGER(arg_t *arg) {
 			OUT("\t/* This list is extensible */\n");
 		OUT("};\n");
 
-		OUT("static const asn_INTEGER_specifics_t asn_SPC_%s_specs_%d = {\n",
+		if(!(expr->_type_referenced)) OUT("static ");
+		OUT("const asn_INTEGER_specifics_t asn_SPC_%s_specs_%d = {\n",
 			MKID(expr), expr->_type_unique_index);
 		INDENT(+1);
 		OUT("asn_MAP_%s_value2enum_%d,\t"
@@ -235,7 +236,8 @@ asn1c_lang_C_type_common_INTEGER(arg_t *arg) {
 	if(expr->expr_type == ASN_BASIC_INTEGER
 	&& asn1c_type_fits_long(arg, expr) == FL_FITS_UNSIGN) {
 		REDIR(OT_STAT_DEFS);
-		OUT("static const asn_INTEGER_specifics_t asn_SPC_%s_specs_%d = {\n",
+		if(!(expr->_type_referenced)) OUT("static ");
+		OUT("const asn_INTEGER_specifics_t asn_SPC_%s_specs_%d = {\n",
 			MKID(expr), expr->_type_unique_index);
 		INDENT(+1);
 		OUT("0,\t");
@@ -376,7 +378,7 @@ asn1c_lang_C_type_SEQUENCE_def(arg_t *arg) {
 
 	GEN_INCLUDE_STD("constr_SEQUENCE");
 	if(!arg->embed)
-		GEN_DECLARE(expr);	/* asn_DEF_xxx */
+		GEN_DECLARE("SEQUENCE", expr);	/* asn_DEF_xxx */
 
 	REDIR(OT_STAT_DEFS);
 
@@ -386,7 +388,8 @@ asn1c_lang_C_type_SEQUENCE_def(arg_t *arg) {
 	if(expr_elements_count(arg, expr)) {
 		int comp_mode = 0;	/* {root,ext=1,root,root,...} */
 
-		OUT("static asn_TYPE_member_t asn_MBR_%s_%d[] = {\n",
+		if(!(expr->_type_referenced)) OUT("static ");
+		OUT("asn_TYPE_member_t asn_MBR_%s_%d[] = {\n",
 			MKID(expr), expr->_type_unique_index);
 
 		elements = 0;
@@ -468,7 +471,8 @@ asn1c_lang_C_type_SEQUENCE_def(arg_t *arg) {
 	 */
 	emit_tag2member_map(arg, tag2el, tag2el_count, 0);
 
-	OUT("static asn_SEQUENCE_specifics_t asn_SPC_%s_specs_%d = {\n",
+	if(!(expr->_type_referenced)) OUT("static ");
+	OUT("asn_SEQUENCE_specifics_t asn_SPC_%s_specs_%d = {\n",
 		MKID(expr), expr->_type_unique_index);
 	INDENT(+1);
 	OUT("sizeof(struct ");
@@ -635,7 +639,7 @@ asn1c_lang_C_type_SET_def(arg_t *arg) {
 
 	GEN_INCLUDE_STD("constr_SET");
 	if(!arg->embed)
-		GEN_DECLARE(expr);	/* asn_DEF_xxx */
+		GEN_DECLARE("SET", expr);	/* asn_DEF_xxx */
 
 	REDIR(OT_STAT_DEFS);
 
@@ -645,7 +649,8 @@ asn1c_lang_C_type_SET_def(arg_t *arg) {
 	if(expr_elements_count(arg, expr)) {
 		int comp_mode = 0;	/* {root,ext=1,root,root,...} */
 
-		OUT("static asn_TYPE_member_t asn_MBR_%s_%d[] = {\n",
+		if(!(expr->_type_referenced)) OUT("static ");
+		OUT("asn_TYPE_member_t asn_MBR_%s_%d[] = {\n",
 			MKID(expr), expr->_type_unique_index);
 
 		elements = 0;
@@ -705,7 +710,8 @@ asn1c_lang_C_type_SET_def(arg_t *arg) {
 	OUT("\n");
 	OUT("};\n");
 
-	OUT("static asn_SET_specifics_t asn_SPC_%s_specs_%d = {\n",
+	if(!(expr->_type_referenced)) OUT("static \n");
+	OUT("asn_SET_specifics_t asn_SPC_%s_specs_%d = {\n",
 		MKID(expr), expr->_type_unique_index);
 	INDENTED(
 		OUT("sizeof(struct ");
@@ -860,14 +866,15 @@ asn1c_lang_C_type_SEx_OF_def(arg_t *arg, int seq_of) {
 		GEN_INCLUDE_STD("constr_SET_OF");
 	}
 	if(!arg->embed)
-		GEN_DECLARE(expr);	/* asn_DEF_xxx */
+		GEN_DECLARE("SET_OF", expr);	/* asn_DEF_xxx */
 
 	REDIR(OT_STAT_DEFS);
 
 	/*
 	 * Print out the table according to which parsing is performed.
 	 */
-	OUT("static asn_TYPE_member_t asn_MBR_%s_%d[] = {\n",
+	if(!(expr->_type_referenced)) OUT("static ");
+	OUT("asn_TYPE_member_t asn_MBR_%s_%d[] = {\n",
 		MKID(expr), expr->_type_unique_index);
 	INDENT(+1);
 		v = TQ_FIRST(&(expr->members));
@@ -889,7 +896,8 @@ asn1c_lang_C_type_SEx_OF_def(arg_t *arg, int seq_of) {
 	 */
 	tv_mode = emit_tags_vectors(arg, expr, &tags_count, &all_tags_count);
 
-	OUT("static asn_SET_OF_specifics_t asn_SPC_%s_specs_%d = {\n",
+	if(!(expr->_type_referenced)) OUT("static ");
+	OUT("asn_SET_OF_specifics_t asn_SPC_%s_specs_%d = {\n",
 		MKID(expr), expr->_type_unique_index);
 	INDENTED(
 		OUT("sizeof(struct ");
@@ -1028,7 +1036,7 @@ asn1c_lang_C_type_CHOICE_def(arg_t *arg) {
 
 	GEN_INCLUDE_STD("constr_CHOICE");
 	if(!arg->embed)
-		GEN_DECLARE(expr);	/* asn_DEF_xxx */
+		GEN_DECLARE("CHOICE", expr);	/* asn_DEF_xxx */
 
 	REDIR(OT_STAT_DEFS);
 
@@ -1037,7 +1045,8 @@ asn1c_lang_C_type_CHOICE_def(arg_t *arg) {
 	 */
 	if(expr_elements_count(arg, expr)) {
 
-		OUT("static asn_TYPE_member_t asn_MBR_%s_%d[] = {\n",
+		if(!(expr->_type_referenced)) OUT("static ");
+		OUT("asn_TYPE_member_t asn_MBR_%s_%d[] = {\n",
 			MKID(expr), expr->_type_unique_index);
 
 		elements = 0;
@@ -1085,7 +1094,8 @@ asn1c_lang_C_type_CHOICE_def(arg_t *arg) {
 	 */
 	emit_tag2member_map(arg, tag2el, tag2el_count, 0);
 
-	OUT("static asn_CHOICE_specifics_t asn_SPC_%s_specs_%d = {\n",
+	if(!(expr->_type_referenced)) OUT("static ");
+	OUT("asn_CHOICE_specifics_t asn_SPC_%s_specs_%d = {\n",
 		MKID(expr), expr->_type_unique_index);
 	INDENTED(
 		OUT("sizeof(struct ");
@@ -1272,7 +1282,7 @@ asn1c_lang_C_type_SIMPLE_TYPE(arg_t *arg) {
 	/*
 	 * Constraint checking.
 	 */
-	if(!(arg->flags & A1C_NO_CONSTRAINTS)) {
+	if(!(arg->flags & A1C_NO_CONSTRAINTS) && expr->combined_constraints) {
 		p = MKID(expr);
 		if(HIDE_INNER_DEFS) OUT("static ");
 		OUT("int\n");
@@ -1324,6 +1334,8 @@ asn1c_lang_C_type_SIMPLE_TYPE(arg_t *arg) {
 		asn1c_type_name(arg, expr, TNF_SAFE));
 	OUT(" * so here we adjust the DEF accordingly.\n");
 	OUT(" */\n");
+
+#if 0 /* remove unnecessary functions */
 	OUT("static void\n");
 	OUT("%s_%d_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {\n",
 		MKID(expr), expr->_type_unique_index);
@@ -1493,7 +1505,7 @@ asn1c_lang_C_type_SIMPLE_TYPE(arg_t *arg) {
 	OUT("}\n");
 	OUT("\n");
   }
-
+#endif
 	REDIR(OT_FUNC_DECLS);
 
 	p = MKID(expr);
@@ -1503,6 +1515,20 @@ asn1c_lang_C_type_SIMPLE_TYPE(arg_t *arg) {
 			p, expr->_type_unique_index);
 	} else {
 		OUT("extern asn_TYPE_descriptor_t asn_DEF_%s;\n", p);
+		if (etd_spec == ETD_HAS_SPECIFICS) {
+			if((expr->expr_type == ASN_BASIC_ENUMERATED) ||
+				(expr->expr_type == ASN_BASIC_INTEGER)) {
+				if(expr->_type_referenced) {
+					OUT("extern asn_INTEGER_specifics_t "
+						"asn_SPC_%s_specs_%d;\n", p, expr->_type_unique_index);
+				}
+			} else {
+				asn1p_expr_t *terminal = asn1f_find_terminal_type_ex(arg->asn, expr);
+
+				OUT("extern asn_%s_specifics_t ", asn1c_type_name(arg, terminal, TNF_SAFE));
+				OUT("asn_SPC_%s_specs_%d;\n", MKID(expr), expr->_type_unique_index);
+			}
+		}
 		OUT("asn_struct_free_f %s_free;\n", p);
 		OUT("asn_struct_print_f %s_print;\n", p);
 		OUT("asn_constr_check_f %s_constraint;\n", p);
@@ -2044,9 +2070,18 @@ emit_member_PER_constraints(arg_t *arg, asn1p_expr_t *expr, const char *pfx) {
 		return 0;
 	}
 
+	if(expr->_type_referenced) {
+		REDIR(OT_FUNC_DECLS);
+
+		OUT("extern asn_per_constraints_t "
+			"asn_PER_%s_%s_constr_%d;\n",
+			pfx, MKID(expr), expr->_type_unique_index);
+	}
+
 	REDIR(OT_CTDEFS);
 
-	OUT("static asn_per_constraints_t "
+	if(!(expr->_type_referenced)) OUT("static ");
+	OUT("asn_per_constraints_t "
 		"asn_PER_%s_%s_constr_%d GCC_NOTUSED = {\n",
 		pfx, MKID(expr), expr->_type_unique_index);
 
@@ -2506,6 +2541,7 @@ emit_type_DEF(arg_t *arg, asn1p_expr_t *expr, enum tvm_compat tv_mode, int tags_
 	asn1p_expr_t *terminal;
 	int using_type_name = 0;
 	char *p = MKID(expr);
+	char *p2 = (char *)0;
 
 	terminal = asn1f_find_terminal_type_ex(arg->asn, expr);
 
@@ -2534,8 +2570,15 @@ emit_type_DEF(arg_t *arg, asn1p_expr_t *expr, enum tvm_compat tv_mode, int tags_
 			using_type_name = 1;
 			p = asn1c_type_name(arg, arg->expr, TNF_SAFE);
 		} else {
+			if (expr->expr_type == A1TC_REFERENCE) {
+				p2 = strdup(asn1c_type_name(arg, terminal, TNF_SAFE));
+			} else {
+				p2 = strdup(asn1c_type_name(arg, expr, TNF_SAFE));
+			}
 			p = MKID(expr);
 		}
+		if (!p2)
+			p2 = strdup(p);
 
 #define FUNCREF(foo)	do {				\
 	OUT("%s", p);					\
@@ -2544,20 +2587,30 @@ emit_type_DEF(arg_t *arg, asn1p_expr_t *expr, enum tvm_compat tv_mode, int tags_
 	OUT("_" #foo ",\n");				\
 } while(0)
 
-		FUNCREF(free);
-		FUNCREF(print);
-		FUNCREF(constraint);
-		FUNCREF(decode_ber);
-		FUNCREF(encode_der);
-		FUNCREF(decode_xer);
-		FUNCREF(encode_xer);
+#define FUNCREF2(foo)		\
+do {				\
+	OUT("%s", p2);		\
+	OUT("_" #foo ",\n");	\
+} while(0)
+
+		FUNCREF2(free);
+		FUNCREF2(print);
+		if (!expr->combined_constraints)
+			FUNCREF2(constraint);
+		else
+			FUNCREF(constraint);
+		FUNCREF2(decode_ber);
+		FUNCREF2(encode_der);
+		FUNCREF2(decode_xer);
+		FUNCREF2(encode_xer);
 		if(arg->flags & A1C_GEN_PER) {
-			FUNCREF(decode_uper);
-			FUNCREF(encode_uper);
+			FUNCREF2(decode_uper);
+			FUNCREF2(encode_uper);
 		} else {
 			OUT("0, 0,\t/* No PER support, "
 				"use \"-gen-PER\" to enable */\n");
 		}
+		if (p2) free(p2);
 
 		if(!terminal || terminal->expr_type == ASN_CONSTR_CHOICE) {
 		//if(expr->expr_type == ASN_CONSTR_CHOICE) {
@@ -2615,16 +2668,35 @@ emit_type_DEF(arg_t *arg, asn1p_expr_t *expr, enum tvm_compat tv_mode, int tags_
 			OUT("0,\t/* No PER visible constraints */\n");
 		}
 
-		if(elements_count) {
-			OUT("asn_MBR_%s_%d,\n", p, expr->_type_unique_index);
-			if(expr->expr_type == ASN_CONSTR_SEQUENCE_OF
-			|| expr->expr_type == ASN_CONSTR_SET_OF) {
-				OUT("%d,\t/* Single element */\n",
-					elements_count);
-				assert(elements_count == 1);
+		if(elements_count ||
+			((expr->expr_type == A1TC_REFERENCE) &&
+				(terminal->expr_type & ASN_CONSTR_MASK) &&
+				expr_elements_count(arg, terminal))) {
+
+			if (expr->expr_type == A1TC_REFERENCE) {
+				OUT("asn_MBR_%s_%d,\n", MKID(terminal), terminal->_type_unique_index);
+
+				if(terminal->expr_type == ASN_CONSTR_SEQUENCE_OF
+				|| terminal->expr_type == ASN_CONSTR_SET_OF) {
+					OUT("%d,\t/* Single element */\n",
+						expr_elements_count(arg, terminal));
+					assert(expr_elements_count(arg, terminal) == 1);
+				} else {
+					OUT("%d,\t/* Elements count */\n",
+						expr_elements_count(arg, terminal));
+				}
 			} else {
-				OUT("%d,\t/* Elements count */\n",
-					elements_count);
+				OUT("asn_MBR_%s_%d,\n", p, expr->_type_unique_index);
+
+				if(expr->expr_type == ASN_CONSTR_SEQUENCE_OF
+				|| expr->expr_type == ASN_CONSTR_SET_OF) {
+					OUT("%d,\t/* Single element */\n",
+						elements_count);
+					assert(elements_count == 1);
+				} else {
+					OUT("%d,\t/* Elements count */\n",
+						elements_count);
+				}
 			}
 		} else {
 			if(expr_elements_count(arg, expr))
@@ -2635,7 +2707,28 @@ emit_type_DEF(arg_t *arg, asn1p_expr_t *expr, enum tvm_compat tv_mode, int tags_
 
 		switch(spec) {
 		case ETD_NO_SPECIFICS:
-			OUT("0\t/* No specifics */\n");
+			if ((expr->expr_type == A1TC_REFERENCE) &&
+				((terminal->expr_type & ASN_CONSTR_MASK) ||
+				(terminal->expr_type == ASN_BASIC_ENUMERATED) ||
+				((terminal->expr_type == ASN_BASIC_INTEGER) &&
+				(asn1c_type_fits_long(arg, terminal) == FL_FITS_UNSIGN)))) {
+				OUT("&asn_SPC_%s_specs_%d\t/* Additional specs */\n", MKID(terminal), terminal->_type_unique_index);
+			} else if ((expr->expr_type == ASN_TYPE_ANY) ||
+					(expr->expr_type == ASN_BASIC_BIT_STRING) ||
+					(expr->expr_type == ASN_STRING_BMPString) ||
+					(expr->expr_type == ASN_BASIC_OCTET_STRING) ||
+					(expr->expr_type == ASN_STRING_UniversalString)) {
+				OUT("&asn_SPC_%s_specs\t/* Additional specs */\n", asn1c_type_name(arg, expr, TNF_SAFE));
+			} else if ((expr->expr_type == A1TC_REFERENCE) &&
+					((terminal->expr_type == ASN_TYPE_ANY) ||
+					(terminal->expr_type == ASN_BASIC_BIT_STRING) ||
+					(terminal->expr_type == ASN_STRING_BMPString) ||
+					(terminal->expr_type == ASN_BASIC_OCTET_STRING) ||
+					(terminal->expr_type == ASN_STRING_UniversalString))) {
+				OUT("&asn_SPC_%s_specs\t/* Additional specs */\n", asn1c_type_name(arg, terminal, TNF_SAFE));
+			} else {
+				OUT("0\t/* No specifics */\n");
+			}
 			break;
 		case ETD_HAS_SPECIFICS:
 			OUT("&asn_SPC_%s_specs_%d\t/* Additional specs */\n",
@@ -2815,7 +2908,7 @@ asn1c_recurse(arg_t *arg, asn1p_expr_t *expr, int (*callback)(arg_t *arg, void *
 	int maxret = 0;
 	int ret;
 
-	if(expr->_mark) return 0;
+	if(expr->_mark & TM_RECURSION) return 0;
 	expr->_mark |= TM_RECURSION;
 
 	/* Invoke callback for every type going into recursion */

--- a/libasn1compiler/asn1c_out.h
+++ b/libasn1compiler/asn1c_out.h
@@ -104,12 +104,22 @@ int asn1c_compiled_output(arg_t *arg, const char *fmt, ...);
 } while(0)
 
 /* Generate ASN.1 type declaration */
-#define	GEN_DECLARE(expr)	do {				\
-	int saved_target = arg->target->target;			\
-	REDIR(OT_FUNC_DECLS);					\
-	OUT_NOINDENT("extern asn_TYPE_descriptor_t "		\
-			"asn_DEF_%s;\n", MKID(expr));		\
-	REDIR(saved_target);					\
+#define	GEN_DECLARE(type_name, expr)	do {				\
+	int saved_target = arg->target->target;				\
+	REDIR(OT_FUNC_DECLS);						\
+	OUT_NOINDENT("extern asn_TYPE_descriptor_t "			\
+			"asn_DEF_%s;\n", MKID(expr));			\
+	if (expr->_type_referenced) {					\
+		OUT_NOINDENT("extern asn_%s_specifics_t "		\
+				"asn_SPC_%s_specs_%d;\n", type_name,	\
+				MKID(expr), expr->_type_unique_index);	\
+		if(expr_elements_count(arg, expr))			\
+			OUT_NOINDENT("extern asn_TYPE_member_t "	\
+				"asn_MBR_%s_%d[%d];\n",			\
+				MKID(expr), expr->_type_unique_index, 	\
+				expr_elements_count(arg, expr));	\
+	} 								\
+	REDIR(saved_target);						\
 } while(0)
 
 /*

--- a/libasn1fix/asn1fix_export.c
+++ b/libasn1fix/asn1fix_export.c
@@ -57,6 +57,21 @@ asn1f_find_terminal_type_ex(asn1p_t *asn, asn1p_expr_t *expr) {
 	return asn1f_find_terminal_type(&arg, expr);
 }
 
+asn1p_expr_t *
+asn1f_find_ancestor_type_with_PER_constraint_ex(asn1p_t *asn, asn1p_expr_t *expr) {
+	arg_t arg;
+
+	memset(&arg, 0, sizeof(arg));
+
+	arg.asn = asn;
+	arg.mod = expr->module;
+	arg.expr = expr;
+	arg.eh = a1f_replace_me_with_proper_interface_arg.eh;
+	arg.debug = a1f_replace_me_with_proper_interface_arg.debug;
+
+	return asn1f_find_ancestor_type_with_PER_constraint(&arg, expr);
+}
+
 int
 asn1f_fix_dereference_values_ex(asn1p_t *asn, asn1p_module_t *mod,
         asn1p_expr_t *expr) {

--- a/libasn1fix/asn1fix_export.h
+++ b/libasn1fix/asn1fix_export.h
@@ -38,4 +38,10 @@ asn1p_expr_t *asn1f_find_terminal_type_ex(asn1p_t *asn, asn1p_expr_t *tc);
 int asn1f_fix_dereference_values_ex(asn1p_t *asn, asn1p_module_t *mod,
 	asn1p_expr_t *expr);
 
+/*
+ * Exportable version of asn1f_find_ancestor_type_with_PER_constraint().
+ */
+asn1p_expr_t *asn1f_find_ancestor_type_with_PER_constraint_ex(asn1p_t *asn,
+	asn1p_expr_t *expr);
+
 #endif	/* ASN1FIX_EXPORT_H */

--- a/libasn1fix/asn1fix_retrieve.c
+++ b/libasn1fix/asn1fix_retrieve.c
@@ -3,6 +3,7 @@
 enum ftt_what {
 	FTT_TYPE,	/* Find the type of the given expression */
 	FTT_VALUE,	/* Find the value of the given expression */
+	FTT_CONSTR_TYPE /* Find the type of the given expression having constraint */ 
 };
 
 static asn1p_expr_t *asn1f_find_terminal_thing(arg_t *arg, asn1p_expr_t *expr, enum ftt_what);
@@ -380,6 +381,11 @@ asn1f_find_terminal_value(arg_t *arg, asn1p_expr_t *expr) {
 	return asn1f_find_terminal_thing(arg, expr, FTT_VALUE);
 }
 
+asn1p_expr_t *
+asn1f_find_ancestor_type_with_PER_constraint(arg_t *arg, asn1p_expr_t *expr) {
+	return asn1f_find_terminal_thing(arg, expr, FTT_CONSTR_TYPE);
+}
+
 static asn1p_expr_t *
 asn1f_find_terminal_thing(arg_t *arg, asn1p_expr_t *expr, enum ftt_what what) {
 	asn1p_ref_t *ref = 0;
@@ -387,6 +393,7 @@ asn1f_find_terminal_thing(arg_t *arg, asn1p_expr_t *expr, enum ftt_what what) {
 
 	switch(what) {
 	case FTT_TYPE:
+	case FTT_CONSTR_TYPE:
 		/* Expression may be a terminal type itself */
 		if(expr->expr_type != A1TC_REFERENCE)
 			return expr;
@@ -447,6 +454,10 @@ asn1f_find_terminal_thing(arg_t *arg, asn1p_expr_t *expr, enum ftt_what what) {
 	}
 
 	tc->_type_referenced = 1;
+
+	if((what == FTT_CONSTR_TYPE) && (tc->constraints))
+		return tc;
+
 	tc->_mark |= TM_RECURSION;
 	WITH_MODULE(tc->module,
 		expr = asn1f_find_terminal_thing(arg, tc, what));
@@ -454,6 +465,7 @@ asn1f_find_terminal_thing(arg_t *arg, asn1p_expr_t *expr, enum ftt_what what) {
 
 	return expr;
 }
+
 
 /*
  * Make sure that the specified name is present or otherwise does

--- a/libasn1fix/asn1fix_retrieve.h
+++ b/libasn1fix/asn1fix_retrieve.h
@@ -68,4 +68,11 @@ asn1p_expr_t *asn1f_find_terminal_type(arg_t *arg, asn1p_expr_t *tc);
  */
 asn1p_expr_t *asn1f_find_terminal_value(arg_t *arg, asn1p_expr_t *tc);
 
+/*
+ * Recursively find the original type with constraint for the given
+ * expression.
+ */
+asn1p_expr_t *asn1f_find_ancestor_type_with_PER_constraint(arg_t *arg, asn1p_expr_t *tc);
+
+
 #endif	/* ASN1FIX_RETRIEVE_H */

--- a/skeletons/ANY.c
+++ b/skeletons/ANY.c
@@ -6,7 +6,7 @@
 #include <ANY.h>
 #include <errno.h>
 
-static asn_OCTET_STRING_specifics_t asn_SPC_ANY_specs = {
+asn_OCTET_STRING_specifics_t asn_SPC_ANY_specs = {
 	sizeof(ANY_t),
 	offsetof(ANY_t, _asn_ctx),
 	ASN_OSUBV_ANY

--- a/skeletons/ANY.h
+++ b/skeletons/ANY.h
@@ -19,12 +19,20 @@ typedef struct ANY {
 } ANY_t;
 
 extern asn_TYPE_descriptor_t asn_DEF_ANY;
+extern asn_OCTET_STRING_specifics_t asn_SPC_ANY_specs;
 
 asn_struct_free_f ANY_free;
 asn_struct_print_f ANY_print;
 ber_type_decoder_f ANY_decode_ber;
 der_type_encoder_f ANY_encode_der;
 xer_type_encoder_f ANY_encode_xer;
+
+#define ANY_free         OCTET_STRING_free
+#define ANY_print        OCTET_STRING_print
+#define ANY_constraint   asn_generic_no_constraint
+#define ANY_decode_ber   OCTET_STRING_decode_ber
+#define ANY_encode_der   OCTET_STRING_encode_der
+#define ANY_decode_xer   OCTET_STRING_decode_xer_hex
 
 /******************************
  * Handy conversion routines. *

--- a/skeletons/BIT_STRING.c
+++ b/skeletons/BIT_STRING.c
@@ -12,7 +12,7 @@
 static const ber_tlv_tag_t asn_DEF_BIT_STRING_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (3 << 2))
 };
-static asn_OCTET_STRING_specifics_t asn_SPC_BIT_STRING_specs = {
+asn_OCTET_STRING_specifics_t asn_SPC_BIT_STRING_specs = {
 	sizeof(BIT_STRING_t),
 	offsetof(BIT_STRING_t, _asn_ctx),
 	ASN_OSUBV_BIT

--- a/skeletons/BIT_STRING.h
+++ b/skeletons/BIT_STRING.h
@@ -21,10 +21,18 @@ typedef struct BIT_STRING_s {
 } BIT_STRING_t;
 
 extern asn_TYPE_descriptor_t asn_DEF_BIT_STRING;
+extern asn_OCTET_STRING_specifics_t asn_SPC_BIT_STRING_specs;
 
 asn_struct_print_f BIT_STRING_print;	/* Human-readable output */
 asn_constr_check_f BIT_STRING_constraint;
 xer_type_encoder_f BIT_STRING_encode_xer;
+
+#define BIT_STRING_free              OCTET_STRING_free
+#define BIT_STRING_decode_ber        OCTET_STRING_decode_ber
+#define BIT_STRING_encode_der        OCTET_STRING_encode_der
+#define BIT_STRING_decode_xer        OCTET_STRING_decode_xer_binary
+#define BIT_STRING_decode_uper       OCTET_STRING_decode_uper
+#define BIT_STRING_encode_uper       OCTET_STRING_encode_uper
 
 #ifdef __cplusplus
 }

--- a/skeletons/BMPString.c
+++ b/skeletons/BMPString.c
@@ -13,7 +13,7 @@ static const ber_tlv_tag_t asn_DEF_BMPString_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (30 << 2)),	/* [UNIVERSAL 30] IMPLICIT ...*/
 	(ASN_TAG_CLASS_UNIVERSAL | (4 << 2))	/* ... OCTET STRING */
 };
-static asn_OCTET_STRING_specifics_t asn_SPC_BMPString_specs = {
+asn_OCTET_STRING_specifics_t asn_SPC_BMPString_specs = {
 	sizeof(BMPString_t),
 	offsetof(BMPString_t, _asn_ctx),
 	ASN_OSUBV_U16	/* 16-bits character */

--- a/skeletons/BMPString.h
+++ b/skeletons/BMPString.h
@@ -14,10 +14,19 @@ extern "C" {
 typedef OCTET_STRING_t BMPString_t;  /* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_BMPString;
+extern asn_OCTET_STRING_specifics_t asn_SPC_BMPString_specs;
 
 asn_struct_print_f BMPString_print;	/* Human-readable output */
 xer_type_decoder_f BMPString_decode_xer;
 xer_type_encoder_f BMPString_encode_xer;
+
+#define BMPString_free        OCTET_STRING_free
+#define BMPString_print       BMPString_print
+#define BMPString_constraint  asn_generic_no_constraint
+#define BMPString_decode_ber  OCTET_STRING_decode_ber
+#define BMPString_encode_der  OCTET_STRING_encode_der
+#define BMPString_decode_uper OCTET_STRING_decode_uper
+#define BMPString_encode_uper OCTET_STRING_encode_uper
 
 #ifdef __cplusplus
 }

--- a/skeletons/BOOLEAN.h
+++ b/skeletons/BOOLEAN.h
@@ -29,6 +29,8 @@ xer_type_encoder_f BOOLEAN_encode_xer;
 per_type_decoder_f BOOLEAN_decode_uper;
 per_type_encoder_f BOOLEAN_encode_uper;
 
+#define BOOLEAN_constraint     asn_generic_no_constraint
+
 #ifdef __cplusplus
 }
 #endif

--- a/skeletons/ENUMERATED.h
+++ b/skeletons/ENUMERATED.h
@@ -18,6 +18,14 @@ extern asn_TYPE_descriptor_t asn_DEF_ENUMERATED;
 per_type_decoder_f ENUMERATED_decode_uper;
 per_type_encoder_f ENUMERATED_encode_uper;
 
+#define ENUMERATED_free       ASN__PRIMITIVE_TYPE_free
+#define ENUMERATED_print      INTEGER_print
+#define ENUMERATED_constraint asn_generic_no_constraint
+#define ENUMERATED_decode_ber ber_decode_primitive
+#define ENUMERATED_encode_der INTEGER_encode_der
+#define ENUMERATED_decode_xer INTEGER_decode_xer
+#define ENUMERATED_encode_xer INTEGER_encode_xer
+
 #ifdef __cplusplus
 }
 #endif

--- a/skeletons/GeneralString.h
+++ b/skeletons/GeneralString.h
@@ -15,6 +15,16 @@ typedef OCTET_STRING_t GeneralString_t;	/* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_GeneralString;
 
+#define GeneralString_free         OCTET_STRING_free
+#define GeneralString_print        OCTET_STRING_print
+#define GeneralString_constraint   asn_generic_unknown_constraint
+#define GeneralString_decode_ber   OCTET_STRING_decode_ber
+#define GeneralString_encode_der   OCTET_STRING_encode_der
+#define GeneralString_decode_xer   OCTET_STRING_decode_xer_hex
+#define GeneralString_encode_xer   OCTET_STRING_encode_xer
+#define GeneralString_decode_uper  OCTET_STRING_decode_uper
+#define GeneralString_encode_uper  OCTET_STRING_encode_uper
+
 #ifdef __cplusplus
 }
 #endif

--- a/skeletons/GeneralizedTime.h
+++ b/skeletons/GeneralizedTime.h
@@ -20,6 +20,12 @@ asn_constr_check_f GeneralizedTime_constraint;
 der_type_encoder_f GeneralizedTime_encode_der;
 xer_type_encoder_f GeneralizedTime_encode_xer;
 
+#define GeneralizedTime_free           OCTET_STRING_free
+#define GeneralizedTime_decode_ber     OCTET_STRING_decode_ber
+#define GeneralizedTime_decode_xer     OCTET_STRING_decode_xer_utf8
+#define GeneralizedTime_decode_uper    OCTET_STRING_decode_uper
+#define GeneralizedTime_encode_uper    OCTET_STRING_encode_uper
+
 /***********************
  * Some handy helpers. *
  ***********************/

--- a/skeletons/GraphicString.h
+++ b/skeletons/GraphicString.h
@@ -15,6 +15,16 @@ typedef OCTET_STRING_t GraphicString_t;	/* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_GraphicString;
 
+#define GraphicString_free         OCTET_STRING_free
+#define GraphicString_print        OCTET_STRING_print
+#define GraphicString_constraint   asn_generic_unknown_constraint
+#define GraphicString_decode_ber   OCTET_STRING_decode_ber
+#define GraphicString_encode_der   OCTET_STRING_encode_der
+#define GraphicString_decode_xer   OCTET_STRING_decode_xer_hex
+#define GraphicString_encode_xer   OCTET_STRING_encode_xer
+#define GraphicString_decode_uper  OCTET_STRING_decode_uper
+#define GraphicString_encode_uper  OCTET_STRING_encode_uper
+
 #ifdef __cplusplus
 }
 #endif

--- a/skeletons/IA5String.h
+++ b/skeletons/IA5String.h
@@ -20,6 +20,15 @@ extern asn_TYPE_descriptor_t asn_DEF_IA5String;
 
 asn_constr_check_f IA5String_constraint;
 
+#define IA5String_free           OCTET_STRING_free
+#define IA5String_print          OCTET_STRING_print_utf8
+#define IA5String_decode_ber     OCTET_STRING_decode_ber
+#define IA5String_encode_der     OCTET_STRING_encode_der
+#define IA5String_decode_xer     OCTET_STRING_decode_xer_utf8
+#define IA5String_encode_xer     OCTET_STRING_encode_xer_utf8
+#define IA5String_decode_uper    OCTET_STRING_decode_uper
+#define IA5String_encode_uper    OCTET_STRING_encode_uper
+
 #ifdef __cplusplus
 }
 #endif

--- a/skeletons/ISO646String.h
+++ b/skeletons/ISO646String.h
@@ -16,6 +16,16 @@ typedef VisibleString_t ISO646String_t;	/* Implemented using VisibleString */
 
 extern asn_TYPE_descriptor_t asn_DEF_ISO646String;
 
+#define ISO646String_free         OCTET_STRING_free
+#define ISO646String_print        OCTET_STRING_print_utf8
+#define ISO646String_constraint   VisibleString_constraint
+#define ISO646String_decode_ber   OCTET_STRING_decode_ber
+#define ISO646String_encode_der   OCTET_STRING_encode_der
+#define ISO646String_decode_xer   OCTET_STRING_decode_xer_utf8
+#define ISO646String_encode_xer   OCTET_STRING_encode_xer_utf8
+#define ISO646String_decode_uper  OCTET_STRING_decode_uper
+#define ISO646String_encode_uper  OCTET_STRING_encode_uper
+
 #ifdef __cplusplus
 }
 #endif

--- a/skeletons/NULL.h
+++ b/skeletons/NULL.h
@@ -6,6 +6,7 @@
 #define	ASN_TYPE_NULL_H
 
 #include <asn_application.h>
+#include <BOOLEAN.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,6 +26,10 @@ xer_type_decoder_f NULL_decode_xer;
 xer_type_encoder_f NULL_encode_xer;
 per_type_decoder_f NULL_decode_uper;
 per_type_encoder_f NULL_encode_uper;
+
+#define NULL_free		BOOLEAN_free
+#define NULL_decode_ber	BOOLEAN_decode_ber
+#define NULL_constraint	asn_generic_no_constraint
 
 #ifdef __cplusplus
 }

--- a/skeletons/NativeEnumerated.h
+++ b/skeletons/NativeEnumerated.h
@@ -25,6 +25,13 @@ xer_type_encoder_f NativeEnumerated_encode_xer;
 per_type_decoder_f NativeEnumerated_decode_uper;
 per_type_encoder_f NativeEnumerated_encode_uper;
 
+#define NativeEnumerated_free       NativeInteger_free
+#define NativeEnumerated_print      NativeInteger_print
+#define NativeEnumerated_constraint asn_generic_no_constraint
+#define NativeEnumerated_decode_ber NativeInteger_decode_ber
+#define NativeEnumerated_encode_der NativeInteger_encode_der
+#define NativeEnumerated_decode_xer NativeInteger_decode_xer
+
 #ifdef __cplusplus
 }
 #endif

--- a/skeletons/NativeInteger.h
+++ b/skeletons/NativeInteger.h
@@ -30,6 +30,8 @@ xer_type_encoder_f NativeInteger_encode_xer;
 per_type_decoder_f NativeInteger_decode_uper;
 per_type_encoder_f NativeInteger_encode_uper;
 
+#define NativeInteger_constraint  asn_generic_no_constraint
+
 #ifdef __cplusplus
 }
 #endif

--- a/skeletons/NativeReal.h
+++ b/skeletons/NativeReal.h
@@ -28,6 +28,8 @@ xer_type_encoder_f NativeReal_encode_xer;
 per_type_decoder_f NativeReal_decode_uper;
 per_type_encoder_f NativeReal_encode_uper;
 
+#define NativeReal_constraint  asn_generic_no_constraint
+
 #ifdef __cplusplus
 }
 #endif

--- a/skeletons/NumericString.h
+++ b/skeletons/NumericString.h
@@ -17,6 +17,15 @@ extern asn_TYPE_descriptor_t asn_DEF_NumericString;
 
 asn_constr_check_f NumericString_constraint;
 
+#define NumericString_free           OCTET_STRING_free
+#define NumericString_print          OCTET_STRING_print_utf8
+#define NumericString_decode_ber     OCTET_STRING_decode_ber
+#define NumericString_encode_der     OCTET_STRING_encode_der
+#define NumericString_decode_xer     OCTET_STRING_decode_xer_utf8
+#define NumericString_encode_xer     OCTET_STRING_encode_xer_utf8
+#define NumericString_decode_uper    OCTET_STRING_decode_uper
+#define NumericString_encode_uper    OCTET_STRING_encode_uper
+
 #ifdef __cplusplus
 }
 #endif

--- a/skeletons/OBJECT_IDENTIFIER.h
+++ b/skeletons/OBJECT_IDENTIFIER.h
@@ -23,6 +23,12 @@ der_type_encoder_f OBJECT_IDENTIFIER_encode_der;
 xer_type_decoder_f OBJECT_IDENTIFIER_decode_xer;
 xer_type_encoder_f OBJECT_IDENTIFIER_encode_xer;
 
+#define OBJECT_IDENTIFIER_free           ASN__PRIMITIVE_TYPE_free
+#define OBJECT_IDENTIFIER_decode_ber     ber_decode_primitive
+#define OBJECT_IDENTIFIER_encode_der     der_encode_primitive
+#define OBJECT_IDENTIFIER_decode_uper    OCTET_STRING_decode_uper
+#define OBJECT_IDENTIFIER_encode_uper    OCTET_STRING_encode_uper
+
 /**********************************
  * Some handy conversion routines *
  **********************************/

--- a/skeletons/OCTET_STRING.c
+++ b/skeletons/OCTET_STRING.c
@@ -14,7 +14,7 @@
 static const ber_tlv_tag_t asn_DEF_OCTET_STRING_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (4 << 2))
 };
-static asn_OCTET_STRING_specifics_t asn_SPC_OCTET_STRING_specs = {
+asn_OCTET_STRING_specifics_t asn_SPC_OCTET_STRING_specs = {
 	sizeof(OCTET_STRING_t),
 	offsetof(OCTET_STRING_t, _asn_ctx),
 	ASN_OSUBV_STR

--- a/skeletons/OCTET_STRING.h
+++ b/skeletons/OCTET_STRING.h
@@ -33,6 +33,9 @@ xer_type_encoder_f OCTET_STRING_encode_xer_utf8;
 per_type_decoder_f OCTET_STRING_decode_uper;
 per_type_encoder_f OCTET_STRING_encode_uper;
 
+#define OCTET_STRING_constraint  asn_generic_no_constraint
+#define OCTET_STRING_decode_xer  OCTET_STRING_decode_xer_hex
+
 /******************************
  * Handy conversion routines. *
  ******************************/
@@ -78,6 +81,8 @@ typedef const struct asn_OCTET_STRING_specifics_s {
 		ASN_OSUBV_U32	/* 32-bit character (UniversalString) */
 	} subvariant;
 } asn_OCTET_STRING_specifics_t;
+
+extern asn_OCTET_STRING_specifics_t asn_SPC_OCTET_STRING_specs;
 
 #ifdef __cplusplus
 }

--- a/skeletons/ObjectDescriptor.h
+++ b/skeletons/ObjectDescriptor.h
@@ -15,6 +15,16 @@ typedef GraphicString_t ObjectDescriptor_t;  /* Implemented via GraphicString */
 
 extern asn_TYPE_descriptor_t asn_DEF_ObjectDescriptor;
 
+#define ObjectDescriptor_free         OCTET_STRING_free
+#define ObjectDescriptor_print        OCTET_STRING_print_utf8
+#define ObjectDescriptor_constraint   asn_generic_unknown_constraint
+#define ObjectDescriptor_decode_ber   OCTET_STRING_decode_ber
+#define ObjectDescriptor_encode_der   OCTET_STRING_encode_der
+#define ObjectDescriptor_decode_xer   OCTET_STRING_decode_xer_utf8
+#define ObjectDescriptor_encode_xer   OCTET_STRING_encode_xer_utf8
+#define ObjectDescriptor_decode_uper  OCTET_STRING_decode_uper
+#define ObjectDescriptor_encode_uper  OCTET_STRING_encode_uper
+
 #ifdef __cplusplus
 }
 #endif

--- a/skeletons/PrintableString.h
+++ b/skeletons/PrintableString.h
@@ -17,6 +17,15 @@ extern asn_TYPE_descriptor_t asn_DEF_PrintableString;
 
 asn_constr_check_f PrintableString_constraint;
 
+#define PrintableString_free           OCTET_STRING_free
+#define PrintableString_print          OCTET_STRING_print_utf8
+#define PrintableString_decode_ber     OCTET_STRING_decode_ber
+#define PrintableString_encode_der     OCTET_STRING_encode_der
+#define PrintableString_decode_xer     OCTET_STRING_decode_xer_utf8
+#define PrintableString_encode_xer     OCTET_STRING_encode_xer_utf8
+#define PrintableString_decode_uper    OCTET_STRING_decode_uper
+#define PrintableString_encode_uper    OCTET_STRING_encode_uper
+
 #ifdef __cplusplus
 }
 #endif

--- a/skeletons/REAL.h
+++ b/skeletons/REAL.h
@@ -22,6 +22,11 @@ xer_type_encoder_f REAL_encode_xer;
 per_type_decoder_f REAL_decode_uper;
 per_type_encoder_f REAL_encode_uper;
 
+#define REAL_free          ASN__PRIMITIVE_TYPE_free,
+#define REAL_constraint    asn_generic_no_constraint
+#define REAL_decode_ber    ber_decode_primitive
+#define REAL_encode_der    der_encode_primitive
+
 /***********************************
  * Some handy conversion routines. *
  ***********************************/

--- a/skeletons/RELATIVE-OID.h
+++ b/skeletons/RELATIVE-OID.h
@@ -20,6 +20,13 @@ asn_struct_print_f RELATIVE_OID_print;
 xer_type_decoder_f RELATIVE_OID_decode_xer;
 xer_type_encoder_f RELATIVE_OID_encode_xer;
 
+#define RELATIVE_OID_free         ASN__PRIMITIVE_TYPE_free
+#define RELATIVE_OID_constraint   asn_generic_no_constraint
+#define RELATIVE_OID_decode_ber   ber_decode_primitive
+#define RELATIVE_OID_encode_der   der_encode_primitive
+#define RELATIVE_OID_decode_uper  OCTET_STRING_decode_uper
+#define RELATIVE_OID_encode_uper  OCTET_STRING_encode_uper
+
 /**********************************
  * Some handy conversion routines *
  **********************************/

--- a/skeletons/T61String.h
+++ b/skeletons/T61String.h
@@ -15,6 +15,16 @@ typedef OCTET_STRING_t T61String_t;	/* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_T61String;
 
+#define T61String_free         OCTET_STRING_free
+#define T61String_print        OCTET_STRING_print
+#define T61String_constraint   asn_generic_unknown_constraint
+#define T61String_decode_ber   OCTET_STRING_decode_ber
+#define T61String_encode_der   OCTET_STRING_encode_der
+#define T61String_decode_xer   OCTET_STRING_decode_xer_hex
+#define T61String_encode_xer   OCTET_STRING_encode_xer
+#define T61String_decode_uper  OCTET_STRING_decode_uper
+#define T61String_encode_uper  OCTET_STRING_encode_uper
+
 #ifdef __cplusplus
 }
 #endif

--- a/skeletons/TeletexString.h
+++ b/skeletons/TeletexString.h
@@ -15,6 +15,16 @@ typedef OCTET_STRING_t TeletexString_t;	/* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_TeletexString;
 
+#define TeletexString_free           OCTET_STRING_free
+#define TeletexString_print          OCTET_STRING_print
+#define TeletexString_constraint     asn_generic_unknown_constraint
+#define TeletexString_decode_ber     OCTET_STRING_decode_ber
+#define TeletexString_encode_der     OCTET_STRING_encode_der
+#define TeletexString_decode_xer     OCTET_STRING_decode_xer_hex
+#define TeletexString_encode_xer     OCTET_STRING_encode_xer
+#define TeletexString_decode_uper    OCTET_STRING_decode_uper
+#define TeletexString_encode_uper    OCTET_STRING_encode_uper
+
 #ifdef __cplusplus
 }
 #endif

--- a/skeletons/UTCTime.h
+++ b/skeletons/UTCTime.h
@@ -19,6 +19,13 @@ asn_struct_print_f UTCTime_print;
 asn_constr_check_f UTCTime_constraint;
 xer_type_encoder_f UTCTime_encode_xer;
 
+#define UTCTime_free         OCTET_STRING_free
+#define UTCTime_decode_ber   OCTET_STRING_decode_ber
+#define UTCTime_encode_der   OCTET_STRING_encode_der
+#define UTCTime_decode_xer   OCTET_STRING_decode_xer_utf8
+#define UTCTime_decode_uper  OCTET_STRING_decode_uper
+#define UTCTime_encode_uper  OCTET_STRING_encode_uper
+
 /***********************
  * Some handy helpers. *
  ***********************/

--- a/skeletons/UTF8String.h
+++ b/skeletons/UTF8String.h
@@ -18,6 +18,15 @@ extern asn_TYPE_descriptor_t asn_DEF_UTF8String;
 asn_struct_print_f UTF8String_print;
 asn_constr_check_f UTF8String_constraint;
 
+#define UTF8String_free         OCTET_STRING_free
+#define UTF8String_constraint   UTF8String_constraint
+#define UTF8String_decode_ber   OCTET_STRING_decode_ber
+#define UTF8String_encode_der   OCTET_STRING_encode_der
+#define UTF8String_decode_xer   OCTET_STRING_decode_xer_utf8
+#define UTF8String_encode_xer   OCTET_STRING_encode_xer_utf8
+#define UTF8String_decode_uper  OCTET_STRING_decode_uper
+#define UTF8String_encode_uper  OCTET_STRING_encode_uper
+
 /*
  * Returns length of the given UTF-8 string in characters,
  * or a negative error code:

--- a/skeletons/UniversalString.c
+++ b/skeletons/UniversalString.c
@@ -13,7 +13,7 @@ static const ber_tlv_tag_t asn_DEF_UniversalString_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (28 << 2)),	/* [UNIVERSAL 28] IMPLICIT ...*/
 	(ASN_TAG_CLASS_UNIVERSAL | (4 << 2))	/* ... OCTET STRING */
 };
-static asn_OCTET_STRING_specifics_t asn_SPC_UniversalString_specs = {
+asn_OCTET_STRING_specifics_t asn_SPC_UniversalString_specs = {
 	sizeof(UniversalString_t),
 	offsetof(UniversalString_t, _asn_ctx),
 	ASN_OSUBV_U32	/* 32-bits character */

--- a/skeletons/UniversalString.h
+++ b/skeletons/UniversalString.h
@@ -14,6 +14,7 @@ extern "C" {
 typedef OCTET_STRING_t UniversalString_t;  /* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_UniversalString;
+extern asn_OCTET_STRING_specifics_t asn_SPC_UniversalString_specs;
 
 asn_struct_print_f UniversalString_print;	/* Human-readable output */
 xer_type_decoder_f UniversalString_decode_xer;

--- a/skeletons/VideotexString.h
+++ b/skeletons/VideotexString.h
@@ -15,6 +15,16 @@ typedef OCTET_STRING_t VideotexString_t;  /* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_VideotexString;
 
+#define VideotexString_free         OCTET_STRING_free
+#define VideotexString_print        OCTET_STRING_print
+#define VideotexString_constraint   asn_generic_unknown_constraint
+#define VideotexString_decode_ber   OCTET_STRING_decode_ber
+#define VideotexString_encode_der   OCTET_STRING_encode_der
+#define VideotexString_decode_xer   OCTET_STRING_decode_xer_hex
+#define VideotexString_encode_xer   OCTET_STRING_encode_xer
+#define VideotexString_decode_uper  OCTET_STRING_decode_uper
+#define VideotexString_encode_uper  OCTET_STRING_encode_uper
+
 #ifdef __cplusplus
 }
 #endif

--- a/skeletons/VisibleString.h
+++ b/skeletons/VisibleString.h
@@ -17,6 +17,16 @@ extern asn_TYPE_descriptor_t asn_DEF_VisibleString;
 
 asn_constr_check_f VisibleString_constraint;
 
+#define VisibleString_free         OCTET_STRING_free
+#define VisibleString_print        OCTET_STRING_print
+#define VisibleString_constraint   VisibleString_constraint
+#define VisibleString_decode_ber   OCTET_STRING_decode_ber
+#define VisibleString_encode_der   OCTET_STRING_encode_der
+#define VisibleString_decode_xer   OCTET_STRING_decode_xer_hex
+#define VisibleString_encode_xer   OCTET_STRING_encode_xer
+#define VisibleString_decode_uper  OCTET_STRING_decode_uper
+#define VisibleString_encode_uper  OCTET_STRING_encode_uper
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/03-enum-OK.asn1.-Pfwide-types
+++ b/tests/03-enum-OK.asn1.-Pfwide-types
@@ -32,80 +32,10 @@ xer_type_encoder_f Enum1_encode_xer;
 
 /*** <<< CODE [Enum1] >>> ***/
 
-int
-Enum1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using ENUMERATED,
  * so here we adjust the DEF accordingly.
  */
-static void
-Enum1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_ENUMERATED.free_struct;
-	td->print_struct   = asn_DEF_ENUMERATED.print_struct;
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	td->ber_decoder    = asn_DEF_ENUMERATED.ber_decoder;
-	td->der_encoder    = asn_DEF_ENUMERATED.der_encoder;
-	td->xer_decoder    = asn_DEF_ENUMERATED.xer_decoder;
-	td->xer_encoder    = asn_DEF_ENUMERATED.xer_encoder;
-	td->uper_decoder   = asn_DEF_ENUMERATED.uper_decoder;
-	td->uper_encoder   = asn_DEF_ENUMERATED.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_ENUMERATED.per_constraints;
-	td->elements       = asn_DEF_ENUMERATED.elements;
-	td->elements_count = asn_DEF_ENUMERATED.elements_count;
-     /* td->specifics      = asn_DEF_ENUMERATED.specifics;	// Defined explicitly */
-}
-
-void
-Enum1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Enum1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Enum1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Enum1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Enum1] >>> ***/
 
@@ -138,13 +68,13 @@ static const ber_tlv_tag_t asn_DEF_Enum1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Enum1 = {
 	"Enum1",
 	"Enum1",
-	Enum1_free,
-	Enum1_print,
-	Enum1_constraint,
-	Enum1_decode_ber,
-	Enum1_encode_der,
-	Enum1_decode_xer,
-	Enum1_encode_xer,
+	ENUMERATED_free,
+	ENUMERATED_print,
+	ENUMERATED_constraint,
+	ENUMERATED_decode_ber,
+	ENUMERATED_encode_der,
+	ENUMERATED_decode_xer,
+	ENUMERATED_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Enum1_tags_1,
@@ -195,80 +125,10 @@ xer_type_encoder_f Enum2_encode_xer;
 
 /*** <<< CODE [Enum2] >>> ***/
 
-int
-Enum2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using ENUMERATED,
  * so here we adjust the DEF accordingly.
  */
-static void
-Enum2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_ENUMERATED.free_struct;
-	td->print_struct   = asn_DEF_ENUMERATED.print_struct;
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	td->ber_decoder    = asn_DEF_ENUMERATED.ber_decoder;
-	td->der_encoder    = asn_DEF_ENUMERATED.der_encoder;
-	td->xer_decoder    = asn_DEF_ENUMERATED.xer_decoder;
-	td->xer_encoder    = asn_DEF_ENUMERATED.xer_encoder;
-	td->uper_decoder   = asn_DEF_ENUMERATED.uper_decoder;
-	td->uper_encoder   = asn_DEF_ENUMERATED.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_ENUMERATED.per_constraints;
-	td->elements       = asn_DEF_ENUMERATED.elements;
-	td->elements_count = asn_DEF_ENUMERATED.elements_count;
-     /* td->specifics      = asn_DEF_ENUMERATED.specifics;	// Defined explicitly */
-}
-
-void
-Enum2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Enum2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Enum2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Enum2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Enum2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Enum2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Enum2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Enum2] >>> ***/
 
@@ -307,13 +167,13 @@ static const ber_tlv_tag_t asn_DEF_Enum2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Enum2 = {
 	"Enum2",
 	"Enum2",
-	Enum2_free,
-	Enum2_print,
-	Enum2_constraint,
-	Enum2_decode_ber,
-	Enum2_encode_der,
-	Enum2_decode_xer,
-	Enum2_encode_xer,
+	ENUMERATED_free,
+	ENUMERATED_print,
+	ENUMERATED_constraint,
+	ENUMERATED_decode_ber,
+	ENUMERATED_encode_der,
+	ENUMERATED_decode_xer,
+	ENUMERATED_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Enum2_tags_1,
@@ -360,80 +220,10 @@ xer_type_encoder_f Enum3_encode_xer;
 
 /*** <<< CODE [Enum3] >>> ***/
 
-int
-Enum3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using ENUMERATED,
  * so here we adjust the DEF accordingly.
  */
-static void
-Enum3_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_ENUMERATED.free_struct;
-	td->print_struct   = asn_DEF_ENUMERATED.print_struct;
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	td->ber_decoder    = asn_DEF_ENUMERATED.ber_decoder;
-	td->der_encoder    = asn_DEF_ENUMERATED.der_encoder;
-	td->xer_decoder    = asn_DEF_ENUMERATED.xer_decoder;
-	td->xer_encoder    = asn_DEF_ENUMERATED.xer_encoder;
-	td->uper_decoder   = asn_DEF_ENUMERATED.uper_decoder;
-	td->uper_encoder   = asn_DEF_ENUMERATED.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_ENUMERATED.per_constraints;
-	td->elements       = asn_DEF_ENUMERATED.elements;
-	td->elements_count = asn_DEF_ENUMERATED.elements_count;
-     /* td->specifics      = asn_DEF_ENUMERATED.specifics;	// Defined explicitly */
-}
-
-void
-Enum3_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Enum3_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Enum3_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum3_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum3_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Enum3_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Enum3_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum3_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum3_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Enum3_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Enum3_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum3_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Enum3] >>> ***/
 
@@ -464,13 +254,13 @@ static const ber_tlv_tag_t asn_DEF_Enum3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Enum3 = {
 	"Enum3",
 	"Enum3",
-	Enum3_free,
-	Enum3_print,
-	Enum3_constraint,
-	Enum3_decode_ber,
-	Enum3_encode_der,
-	Enum3_decode_xer,
-	Enum3_encode_xer,
+	ENUMERATED_free,
+	ENUMERATED_print,
+	ENUMERATED_constraint,
+	ENUMERATED_decode_ber,
+	ENUMERATED_encode_der,
+	ENUMERATED_decode_xer,
+	ENUMERATED_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Enum3_tags_1,
@@ -518,80 +308,10 @@ xer_type_encoder_f Enum4_encode_xer;
 
 /*** <<< CODE [Enum4] >>> ***/
 
-int
-Enum4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using ENUMERATED,
  * so here we adjust the DEF accordingly.
  */
-static void
-Enum4_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_ENUMERATED.free_struct;
-	td->print_struct   = asn_DEF_ENUMERATED.print_struct;
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	td->ber_decoder    = asn_DEF_ENUMERATED.ber_decoder;
-	td->der_encoder    = asn_DEF_ENUMERATED.der_encoder;
-	td->xer_decoder    = asn_DEF_ENUMERATED.xer_decoder;
-	td->xer_encoder    = asn_DEF_ENUMERATED.xer_encoder;
-	td->uper_decoder   = asn_DEF_ENUMERATED.uper_decoder;
-	td->uper_encoder   = asn_DEF_ENUMERATED.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_ENUMERATED.per_constraints;
-	td->elements       = asn_DEF_ENUMERATED.elements;
-	td->elements_count = asn_DEF_ENUMERATED.elements_count;
-     /* td->specifics      = asn_DEF_ENUMERATED.specifics;	// Defined explicitly */
-}
-
-void
-Enum4_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Enum4_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Enum4_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum4_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum4_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Enum4_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Enum4_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum4_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum4_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Enum4_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Enum4_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum4_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Enum4] >>> ***/
 
@@ -624,13 +344,13 @@ static const ber_tlv_tag_t asn_DEF_Enum4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Enum4 = {
 	"Enum4",
 	"Enum4",
-	Enum4_free,
-	Enum4_print,
-	Enum4_constraint,
-	Enum4_decode_ber,
-	Enum4_encode_der,
-	Enum4_decode_xer,
-	Enum4_encode_xer,
+	ENUMERATED_free,
+	ENUMERATED_print,
+	ENUMERATED_constraint,
+	ENUMERATED_decode_ber,
+	ENUMERATED_encode_der,
+	ENUMERATED_decode_xer,
+	ENUMERATED_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Enum4_tags_1,
@@ -677,80 +397,10 @@ xer_type_encoder_f Enum5_encode_xer;
 
 /*** <<< CODE [Enum5] >>> ***/
 
-int
-Enum5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using ENUMERATED,
  * so here we adjust the DEF accordingly.
  */
-static void
-Enum5_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_ENUMERATED.free_struct;
-	td->print_struct   = asn_DEF_ENUMERATED.print_struct;
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	td->ber_decoder    = asn_DEF_ENUMERATED.ber_decoder;
-	td->der_encoder    = asn_DEF_ENUMERATED.der_encoder;
-	td->xer_decoder    = asn_DEF_ENUMERATED.xer_decoder;
-	td->xer_encoder    = asn_DEF_ENUMERATED.xer_encoder;
-	td->uper_decoder   = asn_DEF_ENUMERATED.uper_decoder;
-	td->uper_encoder   = asn_DEF_ENUMERATED.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_ENUMERATED.per_constraints;
-	td->elements       = asn_DEF_ENUMERATED.elements;
-	td->elements_count = asn_DEF_ENUMERATED.elements_count;
-     /* td->specifics      = asn_DEF_ENUMERATED.specifics;	// Defined explicitly */
-}
-
-void
-Enum5_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Enum5_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Enum5_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum5_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum5_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Enum5_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Enum5_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum5_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum5_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Enum5_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Enum5_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum5_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Enum5] >>> ***/
 
@@ -781,13 +431,13 @@ static const ber_tlv_tag_t asn_DEF_Enum5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Enum5 = {
 	"Enum5",
 	"Enum5",
-	Enum5_free,
-	Enum5_print,
-	Enum5_constraint,
-	Enum5_decode_ber,
-	Enum5_encode_der,
-	Enum5_decode_xer,
-	Enum5_encode_xer,
+	ENUMERATED_free,
+	ENUMERATED_print,
+	ENUMERATED_constraint,
+	ENUMERATED_decode_ber,
+	ENUMERATED_encode_der,
+	ENUMERATED_decode_xer,
+	ENUMERATED_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Enum5_tags_1,

--- a/tests/104-param-1-OK.asn1.-Pfwide-types
+++ b/tests/104-param-1-OK.asn1.-Pfwide-types
@@ -24,11 +24,15 @@ typedef struct Collection_16P1 {
 /*** <<< FUNC-DECLS [Collection] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Collection_16P0;
+extern asn_SET_OF_specifics_t asn_SPC_Collection_16P0_specs_1;
+extern asn_TYPE_member_t asn_MBR_Collection_16P0_1[1];
 extern asn_TYPE_descriptor_t asn_DEF_Collection_16P1;
+extern asn_SET_OF_specifics_t asn_SPC_Collection_16P1_specs_3;
+extern asn_TYPE_member_t asn_MBR_Collection_16P1_3[1];
 
 /*** <<< STAT-DEFS [Collection] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Collection_16P0_1[] = {
+asn_TYPE_member_t asn_MBR_Collection_16P0_1[] = {
 	{ ATF_POINTER, 0, 0,
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (9 << 2)),
 		.tag_mode = 0,
@@ -42,7 +46,7 @@ static asn_TYPE_member_t asn_MBR_Collection_16P0_1[] = {
 static const ber_tlv_tag_t asn_DEF_Collection_16P0_tags_1[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (17 << 2))
 };
-static asn_SET_OF_specifics_t asn_SPC_Collection_16P0_specs_1 = {
+asn_SET_OF_specifics_t asn_SPC_Collection_16P0_specs_1 = {
 	sizeof(struct Collection_16P0),
 	offsetof(struct Collection_16P0, _asn_ctx),
 	0,	/* XER encoding is XMLDelimitedItemList */
@@ -71,7 +75,7 @@ asn_TYPE_descriptor_t asn_DEF_Collection_16P0 = {
 	&asn_SPC_Collection_16P0_specs_1	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_Collection_16P1_3[] = {
+asn_TYPE_member_t asn_MBR_Collection_16P1_3[] = {
 	{ ATF_POINTER, 0, 0,
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (22 << 2)),
 		.tag_mode = 0,
@@ -85,7 +89,7 @@ static asn_TYPE_member_t asn_MBR_Collection_16P1_3[] = {
 static const ber_tlv_tag_t asn_DEF_Collection_16P1_tags_3[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (17 << 2))
 };
-static asn_SET_OF_specifics_t asn_SPC_Collection_16P1_specs_3 = {
+asn_SET_OF_specifics_t asn_SPC_Collection_16P1_specs_3 = {
 	sizeof(struct Collection_16P1),
 	offsetof(struct Collection_16P1, _asn_ctx),
 	0,	/* XER encoding is XMLDelimitedItemList */

--- a/tests/105-param-2-OK.asn1.-Pfwide-types
+++ b/tests/105-param-2-OK.asn1.-Pfwide-types
@@ -43,11 +43,15 @@ typedef struct SIGNED_16P1 {
 /*** <<< FUNC-DECLS [SIGNED] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_SIGNED_16P0;
+extern asn_SEQUENCE_specifics_t asn_SPC_SIGNED_16P0_specs_1;
+extern asn_TYPE_member_t asn_MBR_SIGNED_16P0_1[1];
 extern asn_TYPE_descriptor_t asn_DEF_SIGNED_16P1;
+extern asn_SEQUENCE_specifics_t asn_SPC_SIGNED_16P1_specs_3;
+extern asn_TYPE_member_t asn_MBR_SIGNED_16P1_3[1];
 
 /*** <<< STAT-DEFS [SIGNED] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_SIGNED_16P0_1[] = {
+asn_TYPE_member_t asn_MBR_SIGNED_16P0_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct SIGNED_16P0, Signed),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (9 << 2)),
 		.tag_mode = 0,
@@ -64,7 +68,7 @@ static const ber_tlv_tag_t asn_DEF_SIGNED_16P0_tags_1[] = {
 static const asn_TYPE_tag2member_t asn_MAP_SIGNED_16P0_tag2el_1[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (9 << 2)), 0, 0, 0 } /* signed */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_SIGNED_16P0_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_SIGNED_16P0_specs_1 = {
 	sizeof(struct SIGNED_16P0),
 	offsetof(struct SIGNED_16P0, _asn_ctx),
 	asn_MAP_SIGNED_16P0_tag2el_1,
@@ -117,7 +121,8 @@ static const asn_TYPE_tag2member_t asn_MAP_signed_tag2el_4[] = {
 static const uint8_t asn_MAP_signed_mmap_4[(1 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	(1 << 7)
 };
-static asn_SET_specifics_t asn_SPC_signed_specs_4 = {
+static 
+asn_SET_specifics_t asn_SPC_signed_specs_4 = {
 	sizeof(struct Signed),
 	offsetof(struct Signed, _asn_ctx),
 	offsetof(struct Signed, _presence_map),
@@ -153,7 +158,7 @@ asn_TYPE_descriptor_t asn_DEF_signed_4 = {
 	&asn_SPC_signed_specs_4	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_SIGNED_16P1_3[] = {
+asn_TYPE_member_t asn_MBR_SIGNED_16P1_3[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct SIGNED_16P1, Signed),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (17 << 2)),
 		.tag_mode = 0,
@@ -170,7 +175,7 @@ static const ber_tlv_tag_t asn_DEF_SIGNED_16P1_tags_3[] = {
 static const asn_TYPE_tag2member_t asn_MAP_SIGNED_16P1_tag2el_3[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (17 << 2)), 0, 0, 0 } /* signed */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_SIGNED_16P1_specs_3 = {
+asn_SEQUENCE_specifics_t asn_SPC_SIGNED_16P1_specs_3 = {
 	sizeof(struct SIGNED_16P1),
 	offsetof(struct SIGNED_16P1, _asn_ctx),
 	asn_MAP_SIGNED_16P1_tag2el_3,
@@ -225,80 +230,10 @@ xer_type_encoder_f SignedREAL_encode_xer;
 
 /*** <<< CODE [SignedREAL] >>> ***/
 
-int
-SignedREAL_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_SIGNED_16P0.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using SIGNED_16P0,
  * so here we adjust the DEF accordingly.
  */
-static void
-SignedREAL_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_SIGNED_16P0.free_struct;
-	td->print_struct   = asn_DEF_SIGNED_16P0.print_struct;
-	td->check_constraints = asn_DEF_SIGNED_16P0.check_constraints;
-	td->ber_decoder    = asn_DEF_SIGNED_16P0.ber_decoder;
-	td->der_encoder    = asn_DEF_SIGNED_16P0.der_encoder;
-	td->xer_decoder    = asn_DEF_SIGNED_16P0.xer_decoder;
-	td->xer_encoder    = asn_DEF_SIGNED_16P0.xer_encoder;
-	td->uper_decoder   = asn_DEF_SIGNED_16P0.uper_decoder;
-	td->uper_encoder   = asn_DEF_SIGNED_16P0.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_SIGNED_16P0.per_constraints;
-	td->elements       = asn_DEF_SIGNED_16P0.elements;
-	td->elements_count = asn_DEF_SIGNED_16P0.elements_count;
-	td->specifics      = asn_DEF_SIGNED_16P0.specifics;
-}
-
-void
-SignedREAL_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	SignedREAL_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-SignedREAL_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	SignedREAL_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-SignedREAL_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	SignedREAL_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-SignedREAL_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	SignedREAL_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-SignedREAL_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	SignedREAL_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-SignedREAL_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	SignedREAL_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [SignedREAL] >>> ***/
 
@@ -308,13 +243,13 @@ static const ber_tlv_tag_t asn_DEF_SignedREAL_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_SignedREAL = {
 	"SignedREAL",
 	"SignedREAL",
-	SignedREAL_free,
-	SignedREAL_print,
-	SignedREAL_constraint,
-	SignedREAL_decode_ber,
-	SignedREAL_encode_der,
-	SignedREAL_decode_xer,
-	SignedREAL_encode_xer,
+	SEQUENCE_free,
+	SEQUENCE_print,
+	SEQUENCE_constraint,
+	SEQUENCE_decode_ber,
+	SEQUENCE_encode_der,
+	SEQUENCE_decode_xer,
+	SEQUENCE_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SignedREAL_tags_1,
@@ -324,8 +259,9 @@ asn_TYPE_descriptor_t asn_DEF_SignedREAL = {
 	sizeof(asn_DEF_SignedREAL_tags_1)
 		/sizeof(asn_DEF_SignedREAL_tags_1[0]), /* 1 */
 	0,	/* No PER visible constraints */
-	0, 0,	/* Defined elsewhere */
-	0	/* No specifics */
+	asn_MBR_SIGNED_16P0_1,
+	1,	/* Elements count */
+	&asn_SPC_SIGNED_16P0_specs_1	/* Additional specs */
 };
 
 
@@ -350,80 +286,10 @@ xer_type_encoder_f SignedSET_encode_xer;
 
 /*** <<< CODE [SignedSET] >>> ***/
 
-int
-SignedSET_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_SIGNED_16P1.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using SIGNED_16P1,
  * so here we adjust the DEF accordingly.
  */
-static void
-SignedSET_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_SIGNED_16P1.free_struct;
-	td->print_struct   = asn_DEF_SIGNED_16P1.print_struct;
-	td->check_constraints = asn_DEF_SIGNED_16P1.check_constraints;
-	td->ber_decoder    = asn_DEF_SIGNED_16P1.ber_decoder;
-	td->der_encoder    = asn_DEF_SIGNED_16P1.der_encoder;
-	td->xer_decoder    = asn_DEF_SIGNED_16P1.xer_decoder;
-	td->xer_encoder    = asn_DEF_SIGNED_16P1.xer_encoder;
-	td->uper_decoder   = asn_DEF_SIGNED_16P1.uper_decoder;
-	td->uper_encoder   = asn_DEF_SIGNED_16P1.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_SIGNED_16P1.per_constraints;
-	td->elements       = asn_DEF_SIGNED_16P1.elements;
-	td->elements_count = asn_DEF_SIGNED_16P1.elements_count;
-	td->specifics      = asn_DEF_SIGNED_16P1.specifics;
-}
-
-void
-SignedSET_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	SignedSET_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-SignedSET_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	SignedSET_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-SignedSET_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	SignedSET_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-SignedSET_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	SignedSET_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-SignedSET_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	SignedSET_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-SignedSET_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	SignedSET_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [SignedSET] >>> ***/
 
@@ -433,13 +299,13 @@ static const ber_tlv_tag_t asn_DEF_SignedSET_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_SignedSET = {
 	"SignedSET",
 	"SignedSET",
-	SignedSET_free,
-	SignedSET_print,
-	SignedSET_constraint,
-	SignedSET_decode_ber,
-	SignedSET_encode_der,
-	SignedSET_decode_xer,
-	SignedSET_encode_xer,
+	SEQUENCE_free,
+	SEQUENCE_print,
+	SEQUENCE_constraint,
+	SEQUENCE_decode_ber,
+	SEQUENCE_encode_der,
+	SEQUENCE_decode_xer,
+	SEQUENCE_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SignedSET_tags_1,
@@ -449,7 +315,8 @@ asn_TYPE_descriptor_t asn_DEF_SignedSET = {
 	sizeof(asn_DEF_SignedSET_tags_1)
 		/sizeof(asn_DEF_SignedSET_tags_1[0]), /* 1 */
 	0,	/* No PER visible constraints */
-	0, 0,	/* Defined elsewhere */
-	0	/* No specifics */
+	asn_MBR_SIGNED_16P1_3,
+	1,	/* Elements count */
+	&asn_SPC_SIGNED_16P1_specs_3	/* Additional specs */
 };
 

--- a/tests/106-param-constr-OK.asn1.-P
+++ b/tests/106-param-constr-OK.asn1.-P
@@ -18,6 +18,8 @@ typedef struct Narrow_15P0 {
 /*** <<< FUNC-DECLS [Narrow] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Narrow_15P0;
+extern asn_SEQUENCE_specifics_t asn_SPC_Narrow_15P0_specs_1;
+extern asn_TYPE_member_t asn_MBR_Narrow_15P0_1[3];
 
 /*** <<< CODE [Narrow] >>> ***/
 
@@ -117,7 +119,7 @@ static int asn_DFL_2_set_3(int set_value, void **sptr) {
 		return (*st == 3);
 	}
 }
-static asn_TYPE_member_t asn_MBR_Narrow_15P0_1[] = {
+asn_TYPE_member_t asn_MBR_Narrow_15P0_1[] = {
 	{ ATF_POINTER, 1, offsetof(struct Narrow_15P0, narrow1),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
 		.tag_mode = 0,
@@ -154,7 +156,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Narrow_15P0_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 1, 0, 0 }, /* narrow2 */
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 2, 0, 0 } /* narrow3 */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Narrow_15P0_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Narrow_15P0_specs_1 = {
 	sizeof(struct Narrow_15P0),
 	offsetof(struct Narrow_15P0, _asn_ctx),
 	asn_MAP_Narrow_15P0_tag2el_1,
@@ -209,80 +211,10 @@ xer_type_encoder_f NarrowInteger_encode_xer;
 
 /*** <<< CODE [NarrowInteger] >>> ***/
 
-int
-NarrowInteger_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_Narrow_15P0.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using Narrow_15P0,
  * so here we adjust the DEF accordingly.
  */
-static void
-NarrowInteger_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Narrow_15P0.free_struct;
-	td->print_struct   = asn_DEF_Narrow_15P0.print_struct;
-	td->check_constraints = asn_DEF_Narrow_15P0.check_constraints;
-	td->ber_decoder    = asn_DEF_Narrow_15P0.ber_decoder;
-	td->der_encoder    = asn_DEF_Narrow_15P0.der_encoder;
-	td->xer_decoder    = asn_DEF_Narrow_15P0.xer_decoder;
-	td->xer_encoder    = asn_DEF_Narrow_15P0.xer_encoder;
-	td->uper_decoder   = asn_DEF_Narrow_15P0.uper_decoder;
-	td->uper_encoder   = asn_DEF_Narrow_15P0.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Narrow_15P0.per_constraints;
-	td->elements       = asn_DEF_Narrow_15P0.elements;
-	td->elements_count = asn_DEF_Narrow_15P0.elements_count;
-	td->specifics      = asn_DEF_Narrow_15P0.specifics;
-}
-
-void
-NarrowInteger_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NarrowInteger_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NarrowInteger_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NarrowInteger_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NarrowInteger_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NarrowInteger_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NarrowInteger_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NarrowInteger_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NarrowInteger_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NarrowInteger_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NarrowInteger_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NarrowInteger_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NarrowInteger] >>> ***/
 
@@ -292,13 +224,13 @@ static const ber_tlv_tag_t asn_DEF_NarrowInteger_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NarrowInteger = {
 	"NarrowInteger",
 	"NarrowInteger",
-	NarrowInteger_free,
-	NarrowInteger_print,
-	NarrowInteger_constraint,
-	NarrowInteger_decode_ber,
-	NarrowInteger_encode_der,
-	NarrowInteger_decode_xer,
-	NarrowInteger_encode_xer,
+	SEQUENCE_free,
+	SEQUENCE_print,
+	SEQUENCE_constraint,
+	SEQUENCE_decode_ber,
+	SEQUENCE_encode_der,
+	SEQUENCE_decode_xer,
+	SEQUENCE_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NarrowInteger_tags_1,
@@ -308,7 +240,8 @@ asn_TYPE_descriptor_t asn_DEF_NarrowInteger = {
 	sizeof(asn_DEF_NarrowInteger_tags_1)
 		/sizeof(asn_DEF_NarrowInteger_tags_1[0]), /* 1 */
 	0,	/* No PER visible constraints */
-	0, 0,	/* Defined elsewhere */
-	0	/* No specifics */
+	asn_MBR_Narrow_15P0_1,
+	3,	/* Elements count */
+	&asn_SPC_Narrow_15P0_specs_1	/* Additional specs */
 };
 

--- a/tests/108-param-constr-3-OK.asn1.-Pfwide-types
+++ b/tests/108-param-constr-3-OK.asn1.-Pfwide-types
@@ -55,68 +55,6 @@ MinMax_16P0_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-MinMax_16P0_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-MinMax_16P0_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	MinMax_16P0_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-MinMax_16P0_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	MinMax_16P0_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-MinMax_16P0_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	MinMax_16P0_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-MinMax_16P0_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	MinMax_16P0_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-MinMax_16P0_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	MinMax_16P0_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-MinMax_16P0_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	MinMax_16P0_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [MinMax] >>> ***/
 
@@ -126,13 +64,13 @@ static const ber_tlv_tag_t asn_DEF_MinMax_16P0_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_MinMax_16P0 = {
 	"MinMax",
 	"MinMax",
-	MinMax_16P0_free,
-	MinMax_16P0_print,
+	INTEGER_free,
+	INTEGER_print,
 	MinMax_16P0_constraint,
-	MinMax_16P0_decode_ber,
-	MinMax_16P0_encode_der,
-	MinMax_16P0_decode_xer,
-	MinMax_16P0_encode_xer,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_MinMax_16P0_tags_1,
@@ -203,68 +141,6 @@ ThreePlus_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using MinMax_16P0,
  * so here we adjust the DEF accordingly.
  */
-static void
-ThreePlus_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_MinMax_16P0.free_struct;
-	td->print_struct   = asn_DEF_MinMax_16P0.print_struct;
-	td->check_constraints = asn_DEF_MinMax_16P0.check_constraints;
-	td->ber_decoder    = asn_DEF_MinMax_16P0.ber_decoder;
-	td->der_encoder    = asn_DEF_MinMax_16P0.der_encoder;
-	td->xer_decoder    = asn_DEF_MinMax_16P0.xer_decoder;
-	td->xer_encoder    = asn_DEF_MinMax_16P0.xer_encoder;
-	td->uper_decoder   = asn_DEF_MinMax_16P0.uper_decoder;
-	td->uper_encoder   = asn_DEF_MinMax_16P0.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_MinMax_16P0.per_constraints;
-	td->elements       = asn_DEF_MinMax_16P0.elements;
-	td->elements_count = asn_DEF_MinMax_16P0.elements_count;
-	td->specifics      = asn_DEF_MinMax_16P0.specifics;
-}
-
-void
-ThreePlus_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	ThreePlus_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-ThreePlus_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	ThreePlus_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-ThreePlus_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	ThreePlus_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-ThreePlus_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	ThreePlus_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-ThreePlus_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	ThreePlus_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-ThreePlus_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	ThreePlus_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [ThreePlus] >>> ***/
 
@@ -274,13 +150,13 @@ static const ber_tlv_tag_t asn_DEF_ThreePlus_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_ThreePlus = {
 	"ThreePlus",
 	"ThreePlus",
-	ThreePlus_free,
-	ThreePlus_print,
+	INTEGER_free,
+	INTEGER_print,
 	ThreePlus_constraint,
-	ThreePlus_decode_ber,
-	ThreePlus_encode_der,
-	ThreePlus_decode_xer,
-	ThreePlus_encode_xer,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_ThreePlus_tags_1,

--- a/tests/110-param-3-OK.asn1.-Pfwide-types
+++ b/tests/110-param-3-OK.asn1.-Pfwide-types
@@ -36,85 +36,19 @@ typedef struct Flag_16P1 {
 /*** <<< FUNC-DECLS [Flag] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Flag_16P0;
+extern asn_SEQUENCE_specifics_t asn_SPC_Flag_16P0_specs_1;
+extern asn_TYPE_member_t asn_MBR_Flag_16P0_1[1];
 /* extern asn_TYPE_descriptor_t asn_DEF_field_7;	// (Use -fall-defs-global to expose) */
 extern asn_TYPE_descriptor_t asn_DEF_Flag_16P1;
+extern asn_SEQUENCE_specifics_t asn_SPC_Flag_16P1_specs_6;
+extern asn_TYPE_member_t asn_MBR_Flag_16P1_6[1];
 
 /*** <<< CODE [Flag] >>> ***/
-
-static int
-field_7_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
 
 /*
  * This type is implemented using ENUMERATED,
  * so here we adjust the DEF accordingly.
  */
-static void
-field_7_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_ENUMERATED.free_struct;
-	td->print_struct   = asn_DEF_ENUMERATED.print_struct;
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	td->ber_decoder    = asn_DEF_ENUMERATED.ber_decoder;
-	td->der_encoder    = asn_DEF_ENUMERATED.der_encoder;
-	td->xer_decoder    = asn_DEF_ENUMERATED.xer_decoder;
-	td->xer_encoder    = asn_DEF_ENUMERATED.xer_encoder;
-	td->uper_decoder   = asn_DEF_ENUMERATED.uper_decoder;
-	td->uper_encoder   = asn_DEF_ENUMERATED.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_ENUMERATED.per_constraints;
-	td->elements       = asn_DEF_ENUMERATED.elements;
-	td->elements_count = asn_DEF_ENUMERATED.elements_count;
-     /* td->specifics      = asn_DEF_ENUMERATED.specifics;	// Defined explicitly */
-}
-
-static void
-field_7_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	field_7_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-static int
-field_7_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	field_7_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-static asn_dec_rval_t
-field_7_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	field_7_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-static asn_enc_rval_t
-field_7_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	field_7_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-static asn_dec_rval_t
-field_7_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	field_7_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-static asn_enc_rval_t
-field_7_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	field_7_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Flag] >>> ***/
 
@@ -138,7 +72,7 @@ static int asn_DFL_2_set_5(int set_value, void **sptr) {
 		return (value == 5);
 	}
 }
-static asn_TYPE_member_t asn_MBR_Flag_16P0_1[] = {
+asn_TYPE_member_t asn_MBR_Flag_16P0_1[] = {
 	{ ATF_POINTER, 1, offsetof(struct Flag_16P0, field),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
 		.tag_mode = 0,
@@ -155,7 +89,7 @@ static const ber_tlv_tag_t asn_DEF_Flag_16P0_tags_1[] = {
 static const asn_TYPE_tag2member_t asn_MAP_Flag_16P0_tag2el_1[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)), 0, 0, 0 } /* field */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Flag_16P0_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Flag_16P0_specs_1 = {
 	sizeof(struct Flag_16P0),
 	offsetof(struct Flag_16P0, _asn_ctx),
 	asn_MAP_Flag_16P0_tag2el_1,
@@ -234,13 +168,13 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_field_7 = {
 	"field",
 	"field",
-	field_7_free,
-	field_7_print,
-	field_7_constraint,
-	field_7_decode_ber,
-	field_7_encode_der,
-	field_7_decode_xer,
-	field_7_encode_xer,
+	ENUMERATED_free,
+	ENUMERATED_print,
+	ENUMERATED_constraint,
+	ENUMERATED_decode_ber,
+	ENUMERATED_encode_der,
+	ENUMERATED_decode_xer,
+	ENUMERATED_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_field_tags_7,
@@ -254,7 +188,7 @@ asn_TYPE_descriptor_t asn_DEF_field_7 = {
 	&asn_SPC_field_specs_7	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_Flag_16P1_6[] = {
+asn_TYPE_member_t asn_MBR_Flag_16P1_6[] = {
 	{ ATF_POINTER, 1, offsetof(struct Flag_16P1, field),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (10 << 2)),
 		.tag_mode = 0,
@@ -271,7 +205,7 @@ static const ber_tlv_tag_t asn_DEF_Flag_16P1_tags_6[] = {
 static const asn_TYPE_tag2member_t asn_MAP_Flag_16P1_tag2el_6[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (10 << 2)), 0, 0, 0 } /* field */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Flag_16P1_specs_6 = {
+asn_SEQUENCE_specifics_t asn_SPC_Flag_16P1_specs_6 = {
 	sizeof(struct Flag_16P1),
 	offsetof(struct Flag_16P1, _asn_ctx),
 	asn_MAP_Flag_16P1_tag2el_6,
@@ -326,80 +260,10 @@ xer_type_encoder_f IntegerColorFlag_encode_xer;
 
 /*** <<< CODE [IntegerColorFlag] >>> ***/
 
-int
-IntegerColorFlag_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_Flag_16P0.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using Flag_16P0,
  * so here we adjust the DEF accordingly.
  */
-static void
-IntegerColorFlag_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Flag_16P0.free_struct;
-	td->print_struct   = asn_DEF_Flag_16P0.print_struct;
-	td->check_constraints = asn_DEF_Flag_16P0.check_constraints;
-	td->ber_decoder    = asn_DEF_Flag_16P0.ber_decoder;
-	td->der_encoder    = asn_DEF_Flag_16P0.der_encoder;
-	td->xer_decoder    = asn_DEF_Flag_16P0.xer_decoder;
-	td->xer_encoder    = asn_DEF_Flag_16P0.xer_encoder;
-	td->uper_decoder   = asn_DEF_Flag_16P0.uper_decoder;
-	td->uper_encoder   = asn_DEF_Flag_16P0.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Flag_16P0.per_constraints;
-	td->elements       = asn_DEF_Flag_16P0.elements;
-	td->elements_count = asn_DEF_Flag_16P0.elements_count;
-	td->specifics      = asn_DEF_Flag_16P0.specifics;
-}
-
-void
-IntegerColorFlag_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	IntegerColorFlag_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-IntegerColorFlag_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	IntegerColorFlag_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-IntegerColorFlag_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	IntegerColorFlag_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-IntegerColorFlag_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	IntegerColorFlag_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-IntegerColorFlag_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	IntegerColorFlag_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-IntegerColorFlag_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	IntegerColorFlag_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [IntegerColorFlag] >>> ***/
 
@@ -409,13 +273,13 @@ static const ber_tlv_tag_t asn_DEF_IntegerColorFlag_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_IntegerColorFlag = {
 	"IntegerColorFlag",
 	"IntegerColorFlag",
-	IntegerColorFlag_free,
-	IntegerColorFlag_print,
-	IntegerColorFlag_constraint,
-	IntegerColorFlag_decode_ber,
-	IntegerColorFlag_encode_der,
-	IntegerColorFlag_decode_xer,
-	IntegerColorFlag_encode_xer,
+	SEQUENCE_free,
+	SEQUENCE_print,
+	SEQUENCE_constraint,
+	SEQUENCE_decode_ber,
+	SEQUENCE_encode_der,
+	SEQUENCE_decode_xer,
+	SEQUENCE_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_IntegerColorFlag_tags_1,
@@ -425,8 +289,9 @@ asn_TYPE_descriptor_t asn_DEF_IntegerColorFlag = {
 	sizeof(asn_DEF_IntegerColorFlag_tags_1)
 		/sizeof(asn_DEF_IntegerColorFlag_tags_1[0]), /* 1 */
 	0,	/* No PER visible constraints */
-	0, 0,	/* Defined elsewhere */
-	0	/* No specifics */
+	asn_MBR_Flag_16P0_1,
+	1,	/* Elements count */
+	&asn_SPC_Flag_16P0_specs_1	/* Additional specs */
 };
 
 
@@ -451,80 +316,10 @@ xer_type_encoder_f EnumeratedColorFlag_encode_xer;
 
 /*** <<< CODE [EnumeratedColorFlag] >>> ***/
 
-int
-EnumeratedColorFlag_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_Flag_16P1.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using Flag_16P1,
  * so here we adjust the DEF accordingly.
  */
-static void
-EnumeratedColorFlag_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Flag_16P1.free_struct;
-	td->print_struct   = asn_DEF_Flag_16P1.print_struct;
-	td->check_constraints = asn_DEF_Flag_16P1.check_constraints;
-	td->ber_decoder    = asn_DEF_Flag_16P1.ber_decoder;
-	td->der_encoder    = asn_DEF_Flag_16P1.der_encoder;
-	td->xer_decoder    = asn_DEF_Flag_16P1.xer_decoder;
-	td->xer_encoder    = asn_DEF_Flag_16P1.xer_encoder;
-	td->uper_decoder   = asn_DEF_Flag_16P1.uper_decoder;
-	td->uper_encoder   = asn_DEF_Flag_16P1.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Flag_16P1.per_constraints;
-	td->elements       = asn_DEF_Flag_16P1.elements;
-	td->elements_count = asn_DEF_Flag_16P1.elements_count;
-	td->specifics      = asn_DEF_Flag_16P1.specifics;
-}
-
-void
-EnumeratedColorFlag_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	EnumeratedColorFlag_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-EnumeratedColorFlag_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	EnumeratedColorFlag_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-EnumeratedColorFlag_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	EnumeratedColorFlag_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-EnumeratedColorFlag_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	EnumeratedColorFlag_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-EnumeratedColorFlag_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	EnumeratedColorFlag_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-EnumeratedColorFlag_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	EnumeratedColorFlag_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [EnumeratedColorFlag] >>> ***/
 
@@ -534,13 +329,13 @@ static const ber_tlv_tag_t asn_DEF_EnumeratedColorFlag_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_EnumeratedColorFlag = {
 	"EnumeratedColorFlag",
 	"EnumeratedColorFlag",
-	EnumeratedColorFlag_free,
-	EnumeratedColorFlag_print,
-	EnumeratedColorFlag_constraint,
-	EnumeratedColorFlag_decode_ber,
-	EnumeratedColorFlag_encode_der,
-	EnumeratedColorFlag_decode_xer,
-	EnumeratedColorFlag_encode_xer,
+	SEQUENCE_free,
+	SEQUENCE_print,
+	SEQUENCE_constraint,
+	SEQUENCE_decode_ber,
+	SEQUENCE_encode_der,
+	SEQUENCE_decode_xer,
+	SEQUENCE_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_EnumeratedColorFlag_tags_1,
@@ -550,7 +345,8 @@ asn_TYPE_descriptor_t asn_DEF_EnumeratedColorFlag = {
 	sizeof(asn_DEF_EnumeratedColorFlag_tags_1)
 		/sizeof(asn_DEF_EnumeratedColorFlag_tags_1[0]), /* 1 */
 	0,	/* No PER visible constraints */
-	0, 0,	/* Defined elsewhere */
-	0	/* No specifics */
+	asn_MBR_Flag_16P1_6,
+	1,	/* Elements count */
+	&asn_SPC_Flag_16P1_specs_6	/* Additional specs */
 };
 

--- a/tests/119-per-strings-OK.asn1.-Pgen-PER
+++ b/tests/119-per-strings-OK.asn1.-Pgen-PER
@@ -65,6 +65,8 @@ typedef struct PDU {
 /*** <<< FUNC-DECLS [PDU] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_PDU;
+extern asn_SEQUENCE_specifics_t asn_SPC_PDU_specs_1;
+extern asn_TYPE_member_t asn_MBR_PDU_1[31];
 
 /*** <<< POST-INCLUDE [PDU] >>> ***/
 
@@ -1227,7 +1229,7 @@ asn_TYPE_descriptor_t asn_DEF_many_2 = {
 	&asn_SPC_many_specs_2	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_PDU_1[] = {
+asn_TYPE_member_t asn_MBR_PDU_1[] = {
 	{ ATF_POINTER, 31, offsetof(struct PDU, many),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = 0,
@@ -1545,7 +1547,7 @@ static const asn_TYPE_tag2member_t asn_MAP_PDU_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (29 << 2)), 29, 0, 0 }, /* real */
     { (ASN_TAG_CLASS_CONTEXT | (30 << 2)), 30, 0, 0 } /* oid */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_PDU_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_PDU_specs_1 = {
 	sizeof(struct PDU),
 	offsetof(struct PDU, _asn_ctx),
 	asn_MAP_PDU_tag2el_1,

--- a/tests/125-bitstring-constraint-OK.asn1.-P
+++ b/tests/125-bitstring-constraint-OK.asn1.-P
@@ -54,68 +54,6 @@ T_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using BIT_STRING,
  * so here we adjust the DEF accordingly.
  */
-static void
-T_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_BIT_STRING.free_struct;
-	td->print_struct   = asn_DEF_BIT_STRING.print_struct;
-	td->check_constraints = asn_DEF_BIT_STRING.check_constraints;
-	td->ber_decoder    = asn_DEF_BIT_STRING.ber_decoder;
-	td->der_encoder    = asn_DEF_BIT_STRING.der_encoder;
-	td->xer_decoder    = asn_DEF_BIT_STRING.xer_decoder;
-	td->xer_encoder    = asn_DEF_BIT_STRING.xer_encoder;
-	td->uper_decoder   = asn_DEF_BIT_STRING.uper_decoder;
-	td->uper_encoder   = asn_DEF_BIT_STRING.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_BIT_STRING.per_constraints;
-	td->elements       = asn_DEF_BIT_STRING.elements;
-	td->elements_count = asn_DEF_BIT_STRING.elements_count;
-	td->specifics      = asn_DEF_BIT_STRING.specifics;
-}
-
-void
-T_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	T_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-T_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-T_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-T_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-T_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-T_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [T] >>> ***/
 
@@ -125,13 +63,13 @@ static const ber_tlv_tag_t asn_DEF_T_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	T_free,
-	T_print,
+	BIT_STRING_free,
+	BIT_STRING_print,
 	T_constraint,
-	T_decode_ber,
-	T_encode_der,
-	T_decode_xer,
-	T_encode_xer,
+	BIT_STRING_decode_ber,
+	BIT_STRING_encode_der,
+	BIT_STRING_decode_xer,
+	BIT_STRING_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
@@ -142,6 +80,6 @@ asn_TYPE_descriptor_t asn_DEF_T = {
 		/sizeof(asn_DEF_T_tags_1[0]), /* 1 */
 	0,	/* No PER visible constraints */
 	0, 0,	/* Defined elsewhere */
-	0	/* No specifics */
+	&asn_SPC_BIT_STRING_specs	/* Additional specs */
 };
 

--- a/tests/126-per-extensions-OK.asn1.-Pgen-PER
+++ b/tests/126-per-extensions-OK.asn1.-Pgen-PER
@@ -137,6 +137,8 @@ typedef struct Singleton {
 /*** <<< FUNC-DECLS [Singleton] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Singleton;
+extern asn_SEQUENCE_specifics_t asn_SPC_Singleton_specs_1;
+extern asn_TYPE_member_t asn_MBR_Singleton_1[1];
 
 /*** <<< STAT-DEFS [Singleton] >>> ***/
 
@@ -166,7 +168,7 @@ static int asn_DFL_2_set(int set_value, void **sptr) {
 	}
 	
 }
-static asn_TYPE_member_t asn_MBR_Singleton_1[] = {
+asn_TYPE_member_t asn_MBR_Singleton_1[] = {
 	{ ATF_POINTER, 1, offsetof(struct Singleton, opt_z),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -184,7 +186,7 @@ static const ber_tlv_tag_t asn_DEF_Singleton_tags_1[] = {
 static const asn_TYPE_tag2member_t asn_MAP_Singleton_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 } /* opt-z */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Singleton_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Singleton_specs_1 = {
 	sizeof(struct Singleton),
 	offsetof(struct Singleton, _asn_ctx),
 	asn_MAP_Singleton_tag2el_1,
@@ -256,10 +258,13 @@ typedef struct PDU_2 {
 /*** <<< FUNC-DECLS [PDU-2] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_PDU_2;
+extern asn_CHOICE_specifics_t asn_SPC_PDU_2_specs_1;
+extern asn_TYPE_member_t asn_MBR_PDU_2_1[3];
+extern asn_per_constraints_t asn_PER_type_PDU_2_constr_1;
 
 /*** <<< CTDEFS [PDU-2] >>> ***/
 
-static asn_per_constraints_t asn_PER_type_PDU_2_constr_1 GCC_NOTUSED = {
+asn_per_constraints_t asn_PER_type_PDU_2_constr_1 GCC_NOTUSED = {
 	{ APC_CONSTRAINED | APC_EXTENSIBLE,  0,  0,  0,  0 }	/* (0..0,...) */,
 	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
 	0, 0	/* No PER value map */
@@ -267,7 +272,7 @@ static asn_per_constraints_t asn_PER_type_PDU_2_constr_1 GCC_NOTUSED = {
 
 /*** <<< STAT-DEFS [PDU-2] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_PDU_2_1[] = {
+asn_TYPE_member_t asn_MBR_PDU_2_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct PDU_2, choice.main),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (3 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -302,7 +307,7 @@ static const asn_TYPE_tag2member_t asn_MAP_PDU_2_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 }, /* ext1 */
     { (ASN_TAG_CLASS_CONTEXT | (3 << 2)), 0, 0, 0 } /* main */
 };
-static asn_CHOICE_specifics_t asn_SPC_PDU_2_specs_1 = {
+asn_CHOICE_specifics_t asn_SPC_PDU_2_specs_1 = {
 	sizeof(struct PDU_2),
 	offsetof(struct PDU_2, _asn_ctx),
 	offsetof(struct PDU_2, present),

--- a/tests/127-per-long-OK.asn1.-Pgen-PER
+++ b/tests/127-per-long-OK.asn1.-Pgen-PER
@@ -44,83 +44,6 @@ unsigned32_4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-unsigned32_4_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-     /* td->specifics      = asn_DEF_NativeInteger.specifics;	// Defined explicitly */
-}
-
-static void
-unsigned32_4_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	unsigned32_4_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-static int
-unsigned32_4_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	unsigned32_4_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-static asn_dec_rval_t
-unsigned32_4_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	unsigned32_4_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-static asn_enc_rval_t
-unsigned32_4_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	unsigned32_4_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-static asn_dec_rval_t
-unsigned32_4_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	unsigned32_4_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-static asn_enc_rval_t
-unsigned32_4_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	unsigned32_4_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-static asn_dec_rval_t
-unsigned32_4_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	unsigned32_4_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-static asn_enc_rval_t
-unsigned32_4_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	unsigned32_4_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 static int
 unsplit32_5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
@@ -150,83 +73,6 @@ unsplit32_5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-unsplit32_5_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-     /* td->specifics      = asn_DEF_NativeInteger.specifics;	// Defined explicitly */
-}
-
-static void
-unsplit32_5_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	unsplit32_5_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-static int
-unsplit32_5_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	unsplit32_5_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-static asn_dec_rval_t
-unsplit32_5_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	unsplit32_5_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-static asn_enc_rval_t
-unsplit32_5_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	unsplit32_5_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-static asn_dec_rval_t
-unsplit32_5_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	unsplit32_5_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-static asn_enc_rval_t
-unsplit32_5_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	unsplit32_5_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-static asn_dec_rval_t
-unsplit32_5_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	unsplit32_5_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-static asn_enc_rval_t
-unsplit32_5_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	unsplit32_5_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 static int
 memb_small32range_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
@@ -367,15 +213,15 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_unsigned32_4 = {
 	"unsigned32",
 	"unsigned32",
-	unsigned32_4_free,
-	unsigned32_4_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	unsigned32_4_constraint,
-	unsigned32_4_decode_ber,
-	unsigned32_4_encode_der,
-	unsigned32_4_decode_xer,
-	unsigned32_4_encode_xer,
-	unsigned32_4_decode_uper,
-	unsigned32_4_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_unsigned32_tags_4,
 	sizeof(asn_DEF_unsigned32_tags_4)
@@ -401,15 +247,15 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_unsplit32_5 = {
 	"unsplit32",
 	"unsplit32",
-	unsplit32_5_free,
-	unsplit32_5_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	unsplit32_5_constraint,
-	unsplit32_5_decode_ber,
-	unsplit32_5_encode_der,
-	unsplit32_5_decode_xer,
-	unsplit32_5_encode_xer,
-	unsplit32_5_decode_uper,
-	unsplit32_5_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_unsplit32_tags_5,
 	sizeof(asn_DEF_unsplit32_tags_5)

--- a/tests/19-param-OK.asn1.-Pfwide-types
+++ b/tests/19-param-OK.asn1.-Pfwide-types
@@ -28,6 +28,8 @@ typedef struct SIGNED_15P0 {
 /*** <<< FUNC-DECLS [SIGNED] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_SIGNED_15P0;
+extern asn_SEQUENCE_specifics_t asn_SPC_SIGNED_15P0_specs_1;
+extern asn_TYPE_member_t asn_MBR_SIGNED_15P0_1[3];
 
 /*** <<< CODE [SIGNED] >>> ***/
 
@@ -136,7 +138,7 @@ asn_TYPE_descriptor_t asn_DEF_toBeSigned_2 = {
 	&asn_SPC_toBeSigned_specs_2	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_SIGNED_15P0_1[] = {
+asn_TYPE_member_t asn_MBR_SIGNED_15P0_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct SIGNED_15P0, toBeSigned),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
@@ -173,7 +175,7 @@ static const asn_TYPE_tag2member_t asn_MAP_SIGNED_15P0_tag2el_1[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (6 << 2)), 1, 0, 0 }, /* algorithm */
     { (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)), 0, 0, 0 } /* toBeSigned */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_SIGNED_15P0_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_SIGNED_15P0_specs_1 = {
 	sizeof(struct SIGNED_15P0),
 	offsetof(struct SIGNED_15P0, _asn_ctx),
 	asn_MAP_SIGNED_15P0_tag2el_1,
@@ -228,80 +230,10 @@ xer_type_encoder_f Certificate_encode_xer;
 
 /*** <<< CODE [Certificate] >>> ***/
 
-int
-Certificate_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_SIGNED_15P0.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using SIGNED_15P0,
  * so here we adjust the DEF accordingly.
  */
-static void
-Certificate_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_SIGNED_15P0.free_struct;
-	td->print_struct   = asn_DEF_SIGNED_15P0.print_struct;
-	td->check_constraints = asn_DEF_SIGNED_15P0.check_constraints;
-	td->ber_decoder    = asn_DEF_SIGNED_15P0.ber_decoder;
-	td->der_encoder    = asn_DEF_SIGNED_15P0.der_encoder;
-	td->xer_decoder    = asn_DEF_SIGNED_15P0.xer_decoder;
-	td->xer_encoder    = asn_DEF_SIGNED_15P0.xer_encoder;
-	td->uper_decoder   = asn_DEF_SIGNED_15P0.uper_decoder;
-	td->uper_encoder   = asn_DEF_SIGNED_15P0.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_SIGNED_15P0.per_constraints;
-	td->elements       = asn_DEF_SIGNED_15P0.elements;
-	td->elements_count = asn_DEF_SIGNED_15P0.elements_count;
-	td->specifics      = asn_DEF_SIGNED_15P0.specifics;
-}
-
-void
-Certificate_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Certificate_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Certificate_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Certificate_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Certificate_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Certificate_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Certificate_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Certificate_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Certificate_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Certificate_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Certificate_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Certificate_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Certificate] >>> ***/
 
@@ -311,13 +243,13 @@ static const ber_tlv_tag_t asn_DEF_Certificate_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Certificate = {
 	"Certificate",
 	"Certificate",
-	Certificate_free,
-	Certificate_print,
-	Certificate_constraint,
-	Certificate_decode_ber,
-	Certificate_encode_der,
-	Certificate_decode_xer,
-	Certificate_encode_xer,
+	SEQUENCE_free,
+	SEQUENCE_print,
+	SEQUENCE_constraint,
+	SEQUENCE_decode_ber,
+	SEQUENCE_encode_der,
+	SEQUENCE_decode_xer,
+	SEQUENCE_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Certificate_tags_1,
@@ -327,8 +259,9 @@ asn_TYPE_descriptor_t asn_DEF_Certificate = {
 	sizeof(asn_DEF_Certificate_tags_1)
 		/sizeof(asn_DEF_Certificate_tags_1[0]), /* 1 */
 	0,	/* No PER visible constraints */
-	0, 0,	/* Defined elsewhere */
-	0	/* No specifics */
+	asn_MBR_SIGNED_15P0_1,
+	3,	/* Elements count */
+	&asn_SPC_SIGNED_15P0_specs_1	/* Additional specs */
 };
 
 
@@ -353,6 +286,8 @@ typedef struct Name {
 /*** <<< FUNC-DECLS [Name] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Name;
+extern asn_SET_OF_specifics_t asn_SPC_Name_specs_1;
+extern asn_TYPE_member_t asn_MBR_Name_1[1];
 
 /*** <<< POST-INCLUDE [Name] >>> ***/
 
@@ -360,7 +295,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Name;
 
 /*** <<< STAT-DEFS [Name] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Name_1[] = {
+asn_TYPE_member_t asn_MBR_Name_1[] = {
 	{ ATF_POINTER, 0, 0,
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (17 << 2)),
 		.tag_mode = 0,
@@ -374,7 +309,7 @@ static asn_TYPE_member_t asn_MBR_Name_1[] = {
 static const ber_tlv_tag_t asn_DEF_Name_tags_1[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
 };
-static asn_SET_OF_specifics_t asn_SPC_Name_specs_1 = {
+asn_SET_OF_specifics_t asn_SPC_Name_specs_1 = {
 	sizeof(struct Name),
 	offsetof(struct Name, _asn_ctx),
 	0,	/* XER encoding is XMLDelimitedItemList */
@@ -422,6 +357,8 @@ typedef struct RelativeDistinguishedName {
 /*** <<< FUNC-DECLS [RelativeDistinguishedName] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_RelativeDistinguishedName;
+extern asn_SET_OF_specifics_t asn_SPC_RelativeDistinguishedName_specs_1;
+extern asn_TYPE_member_t asn_MBR_RelativeDistinguishedName_1[1];
 
 /*** <<< CTABLES [RelativeDistinguishedName] >>> ***/
 
@@ -480,7 +417,7 @@ memb_IA5String_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 
 /*** <<< STAT-DEFS [RelativeDistinguishedName] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_RelativeDistinguishedName_1[] = {
+asn_TYPE_member_t asn_MBR_RelativeDistinguishedName_1[] = {
 	{ ATF_POINTER, 0, 0,
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (22 << 2)),
 		.tag_mode = 0,
@@ -494,7 +431,7 @@ static asn_TYPE_member_t asn_MBR_RelativeDistinguishedName_1[] = {
 static const ber_tlv_tag_t asn_DEF_RelativeDistinguishedName_tags_1[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (17 << 2))
 };
-static asn_SET_OF_specifics_t asn_SPC_RelativeDistinguishedName_specs_1 = {
+asn_SET_OF_specifics_t asn_SPC_RelativeDistinguishedName_specs_1 = {
 	sizeof(struct RelativeDistinguishedName),
 	offsetof(struct RelativeDistinguishedName, _asn_ctx),
 	0,	/* XER encoding is XMLDelimitedItemList */

--- a/tests/30-set-OK.asn1.-Pfwide-types
+++ b/tests/30-set-OK.asn1.-Pfwide-types
@@ -83,7 +83,8 @@ static const asn_TYPE_tag2member_t asn_MAP_T_tag2el_1[] = {
 static const uint8_t asn_MAP_T_mmap_1[(3 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	(1 << 7) | (1 << 6) | (0 << 5)
 };
-static asn_SET_specifics_t asn_SPC_T_specs_1 = {
+static 
+asn_SET_specifics_t asn_SPC_T_specs_1 = {
 	sizeof(struct T),
 	offsetof(struct T, _asn_ctx),
 	offsetof(struct T, _presence_map),

--- a/tests/31-set-of-OK.asn1.-Pfwide-types
+++ b/tests/31-set-of-OK.asn1.-Pfwide-types
@@ -20,6 +20,8 @@ typedef struct Forest {
 /*** <<< FUNC-DECLS [Forest] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Forest;
+extern asn_SET_OF_specifics_t asn_SPC_Forest_specs_1;
+extern asn_TYPE_member_t asn_MBR_Forest_1[1];
 
 /*** <<< POST-INCLUDE [Forest] >>> ***/
 
@@ -27,7 +29,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Forest;
 
 /*** <<< STAT-DEFS [Forest] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Forest_1[] = {
+asn_TYPE_member_t asn_MBR_Forest_1[] = {
 	{ ATF_POINTER, 0, 0,
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
@@ -41,7 +43,7 @@ static asn_TYPE_member_t asn_MBR_Forest_1[] = {
 static const ber_tlv_tag_t asn_DEF_Forest_tags_1[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (17 << 2))
 };
-static asn_SET_OF_specifics_t asn_SPC_Forest_specs_1 = {
+asn_SET_OF_specifics_t asn_SPC_Forest_specs_1 = {
 	sizeof(struct Forest),
 	offsetof(struct Forest, _asn_ctx),
 	0,	/* XER encoding is XMLDelimitedItemList */
@@ -89,10 +91,12 @@ typedef struct Tree {
 /*** <<< FUNC-DECLS [Tree] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Tree;
+extern asn_SEQUENCE_specifics_t asn_SPC_Tree_specs_1;
+extern asn_TYPE_member_t asn_MBR_Tree_1[2];
 
 /*** <<< STAT-DEFS [Tree] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Tree_1[] = {
+asn_TYPE_member_t asn_MBR_Tree_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Tree, height),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
 		.tag_mode = 0,
@@ -119,7 +123,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Tree_tag2el_1[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)), 0, 0, 1 }, /* height */
     { (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)), 1, -1, 0 } /* width */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Tree_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Tree_specs_1 = {
 	sizeof(struct Tree),
 	offsetof(struct Tree, _asn_ctx),
 	asn_MAP_Tree_tag2el_1,
@@ -489,7 +493,8 @@ static const asn_TYPE_tag2member_t asn_MAP_Stuff_tag2el_cxer_1[] = {
 static const uint8_t asn_MAP_Stuff_mmap_1[(3 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	(0 << 7) | (0 << 6) | (0 << 5)
 };
-static asn_SET_specifics_t asn_SPC_Stuff_specs_1 = {
+static 
+asn_SET_specifics_t asn_SPC_Stuff_specs_1 = {
 	sizeof(struct Stuff),
 	offsetof(struct Stuff, _asn_ctx),
 	offsetof(struct Stuff, _presence_map),

--- a/tests/32-sequence-of-OK.asn1.-P
+++ b/tests/32-sequence-of-OK.asn1.-P
@@ -92,6 +92,8 @@ typedef struct Fault {
 /*** <<< FUNC-DECLS [Fault] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Fault;
+extern asn_SET_OF_specifics_t asn_SPC_Fault_specs_1;
+extern asn_TYPE_member_t asn_MBR_Fault_1[1];
 
 /*** <<< POST-INCLUDE [Fault] >>> ***/
 
@@ -99,7 +101,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Fault;
 
 /*** <<< STAT-DEFS [Fault] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Fault_1[] = {
+asn_TYPE_member_t asn_MBR_Fault_1[] = {
 	{ ATF_POINTER, 0, 0,
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
@@ -113,7 +115,7 @@ static asn_TYPE_member_t asn_MBR_Fault_1[] = {
 static const ber_tlv_tag_t asn_DEF_Fault_tags_1[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (17 << 2))
 };
-static asn_SET_OF_specifics_t asn_SPC_Fault_specs_1 = {
+asn_SET_OF_specifics_t asn_SPC_Fault_specs_1 = {
 	sizeof(struct Fault),
 	offsetof(struct Fault, _asn_ctx),
 	0,	/* XER encoding is XMLDelimitedItemList */
@@ -162,13 +164,14 @@ typedef struct Error {
 /*** <<< FUNC-DECLS [Error] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Error;
+extern asn_SEQUENCE_specifics_t asn_SPC_Error_specs_1;
 
 /*** <<< STAT-DEFS [Error] >>> ***/
 
 static const ber_tlv_tag_t asn_DEF_Error_tags_1[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Error_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Error_specs_1 = {
 	sizeof(struct Error),
 	offsetof(struct Error, _asn_ctx),
 	0,	/* No top level tags */

--- a/tests/37-indirect-choice-OK.asn1.-Pfwide-types
+++ b/tests/37-indirect-choice-OK.asn1.-Pfwide-types
@@ -145,10 +145,12 @@ typedef struct Choice1 {
 /*** <<< FUNC-DECLS [Choice1] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Choice1;
+extern asn_CHOICE_specifics_t asn_SPC_Choice1_specs_1;
+extern asn_TYPE_member_t asn_MBR_Choice1_1[2];
 
 /*** <<< STAT-DEFS [Choice1] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Choice1_1[] = {
+asn_TYPE_member_t asn_MBR_Choice1_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Choice1, choice.c_a),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (4 << 2)),
 		.tag_mode = 0,
@@ -172,7 +174,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Choice1_tag2el_1[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)), 1, 0, 0 }, /* c-b */
     { (ASN_TAG_CLASS_UNIVERSAL | (4 << 2)), 0, 0, 0 } /* c-a */
 };
-static asn_CHOICE_specifics_t asn_SPC_Choice1_specs_1 = {
+asn_CHOICE_specifics_t asn_SPC_Choice1_specs_1 = {
 	sizeof(struct Choice1),
 	offsetof(struct Choice1, _asn_ctx),
 	offsetof(struct Choice1, present),
@@ -240,10 +242,12 @@ typedef struct Choice2 {
 /*** <<< FUNC-DECLS [Choice2] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Choice2;
+extern asn_CHOICE_specifics_t asn_SPC_Choice2_specs_1;
+extern asn_TYPE_member_t asn_MBR_Choice2_1[4];
 
 /*** <<< STAT-DEFS [Choice2] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Choice2_1[] = {
+asn_TYPE_member_t asn_MBR_Choice2_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Choice2, choice.c_a),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (4 << 2)),
 		.tag_mode = 0,
@@ -290,7 +294,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Choice2_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (3 << 2)), 2, 0, 0 }, /* c-d */
     { (ASN_TAG_CLASS_CONTEXT | (4 << 2)), 3, 0, 0 } /* c-e */
 };
-static asn_CHOICE_specifics_t asn_SPC_Choice2_specs_1 = {
+asn_CHOICE_specifics_t asn_SPC_Choice2_specs_1 = {
 	sizeof(struct Choice2),
 	offsetof(struct Choice2, _asn_ctx),
 	offsetof(struct Choice2, present),
@@ -346,80 +350,10 @@ xer_type_encoder_f Choice3_encode_xer;
 
 /*** <<< CODE [Choice3] >>> ***/
 
-int
-Choice3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_Choice2.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using Choice2,
  * so here we adjust the DEF accordingly.
  */
-static void
-Choice3_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Choice2.free_struct;
-	td->print_struct   = asn_DEF_Choice2.print_struct;
-	td->check_constraints = asn_DEF_Choice2.check_constraints;
-	td->ber_decoder    = asn_DEF_Choice2.ber_decoder;
-	td->der_encoder    = asn_DEF_Choice2.der_encoder;
-	td->xer_decoder    = asn_DEF_Choice2.xer_decoder;
-	td->xer_encoder    = asn_DEF_Choice2.xer_encoder;
-	td->uper_decoder   = asn_DEF_Choice2.uper_decoder;
-	td->uper_encoder   = asn_DEF_Choice2.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Choice2.per_constraints;
-	td->elements       = asn_DEF_Choice2.elements;
-	td->elements_count = asn_DEF_Choice2.elements_count;
-	td->specifics      = asn_DEF_Choice2.specifics;
-}
-
-void
-Choice3_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Choice3_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Choice3_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Choice3_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Choice3_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Choice3_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Choice3_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Choice3_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Choice3_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Choice3_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Choice3_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Choice3_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Choice3] >>> ***/
 
@@ -430,13 +364,13 @@ static const ber_tlv_tag_t asn_DEF_Choice3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Choice3 = {
 	"Choice3",
 	"Choice3",
-	Choice3_free,
-	Choice3_print,
-	Choice3_constraint,
-	Choice3_decode_ber,
-	Choice3_encode_der,
-	Choice3_decode_xer,
-	Choice3_encode_xer,
+	CHOICE_free,
+	CHOICE_print,
+	CHOICE_constraint,
+	CHOICE_decode_ber,
+	CHOICE_encode_der,
+	CHOICE_decode_xer,
+	CHOICE_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	CHOICE_outmost_tag,
 	asn_DEF_Choice3_tags_1,
@@ -446,8 +380,9 @@ asn_TYPE_descriptor_t asn_DEF_Choice3 = {
 	sizeof(asn_DEF_Choice3_tags_1)
 		/sizeof(asn_DEF_Choice3_tags_1[0]), /* 2 */
 	0,	/* No PER visible constraints */
-	0, 0,	/* Defined elsewhere */
-	0	/* No specifics */
+	asn_MBR_Choice2_1,
+	4,	/* Elements count */
+	&asn_SPC_Choice2_specs_1	/* Additional specs */
 };
 
 
@@ -472,80 +407,10 @@ xer_type_encoder_f Choice4_encode_xer;
 
 /*** <<< CODE [Choice4] >>> ***/
 
-int
-Choice4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_Choice2.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using Choice2,
  * so here we adjust the DEF accordingly.
  */
-static void
-Choice4_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Choice2.free_struct;
-	td->print_struct   = asn_DEF_Choice2.print_struct;
-	td->check_constraints = asn_DEF_Choice2.check_constraints;
-	td->ber_decoder    = asn_DEF_Choice2.ber_decoder;
-	td->der_encoder    = asn_DEF_Choice2.der_encoder;
-	td->xer_decoder    = asn_DEF_Choice2.xer_decoder;
-	td->xer_encoder    = asn_DEF_Choice2.xer_encoder;
-	td->uper_decoder   = asn_DEF_Choice2.uper_decoder;
-	td->uper_encoder   = asn_DEF_Choice2.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Choice2.per_constraints;
-	td->elements       = asn_DEF_Choice2.elements;
-	td->elements_count = asn_DEF_Choice2.elements_count;
-	td->specifics      = asn_DEF_Choice2.specifics;
-}
-
-void
-Choice4_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Choice4_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Choice4_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Choice4_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Choice4_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Choice4_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Choice4_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Choice4_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Choice4_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Choice4_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Choice4_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Choice4_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Choice4] >>> ***/
 
@@ -556,13 +421,13 @@ static const ber_tlv_tag_t asn_DEF_Choice4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Choice4 = {
 	"Choice4",
 	"Choice4",
-	Choice4_free,
-	Choice4_print,
-	Choice4_constraint,
-	Choice4_decode_ber,
-	Choice4_encode_der,
-	Choice4_decode_xer,
-	Choice4_encode_xer,
+	CHOICE_free,
+	CHOICE_print,
+	CHOICE_constraint,
+	CHOICE_decode_ber,
+	CHOICE_encode_der,
+	CHOICE_decode_xer,
+	CHOICE_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	CHOICE_outmost_tag,
 	asn_DEF_Choice4_tags_1,
@@ -572,8 +437,9 @@ asn_TYPE_descriptor_t asn_DEF_Choice4 = {
 	sizeof(asn_DEF_Choice4_tags_1)
 		/sizeof(asn_DEF_Choice4_tags_1[0]), /* 2 */
 	0,	/* No PER visible constraints */
-	0, 0,	/* Defined elsewhere */
-	0	/* No specifics */
+	asn_MBR_Choice2_1,
+	4,	/* Elements count */
+	&asn_SPC_Choice2_specs_1	/* Additional specs */
 };
 
 
@@ -598,80 +464,10 @@ xer_type_encoder_f Choice5_encode_xer;
 
 /*** <<< CODE [Choice5] >>> ***/
 
-int
-Choice5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_Choice2.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using Choice2,
  * so here we adjust the DEF accordingly.
  */
-static void
-Choice5_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Choice2.free_struct;
-	td->print_struct   = asn_DEF_Choice2.print_struct;
-	td->check_constraints = asn_DEF_Choice2.check_constraints;
-	td->ber_decoder    = asn_DEF_Choice2.ber_decoder;
-	td->der_encoder    = asn_DEF_Choice2.der_encoder;
-	td->xer_decoder    = asn_DEF_Choice2.xer_decoder;
-	td->xer_encoder    = asn_DEF_Choice2.xer_encoder;
-	td->uper_decoder   = asn_DEF_Choice2.uper_decoder;
-	td->uper_encoder   = asn_DEF_Choice2.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Choice2.per_constraints;
-	td->elements       = asn_DEF_Choice2.elements;
-	td->elements_count = asn_DEF_Choice2.elements_count;
-	td->specifics      = asn_DEF_Choice2.specifics;
-}
-
-void
-Choice5_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Choice5_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Choice5_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Choice5_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Choice5_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Choice5_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Choice5_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Choice5_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Choice5_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Choice5_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Choice5_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Choice5_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Choice5] >>> ***/
 
@@ -681,13 +477,13 @@ static const ber_tlv_tag_t asn_DEF_Choice5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Choice5 = {
 	"Choice5",
 	"Choice5",
-	Choice5_free,
-	Choice5_print,
-	Choice5_constraint,
-	Choice5_decode_ber,
-	Choice5_encode_der,
-	Choice5_decode_xer,
-	Choice5_encode_xer,
+	CHOICE_free,
+	CHOICE_print,
+	CHOICE_constraint,
+	CHOICE_decode_ber,
+	CHOICE_encode_der,
+	CHOICE_decode_xer,
+	CHOICE_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	CHOICE_outmost_tag,
 	asn_DEF_Choice5_tags_1,
@@ -697,8 +493,9 @@ asn_TYPE_descriptor_t asn_DEF_Choice5 = {
 	sizeof(asn_DEF_Choice5_tags_1)
 		/sizeof(asn_DEF_Choice5_tags_1[0]), /* 1 */
 	0,	/* No PER visible constraints */
-	0, 0,	/* Defined elsewhere */
-	0	/* No specifics */
+	asn_MBR_Choice2_1,
+	4,	/* Elements count */
+	&asn_SPC_Choice2_specs_1	/* Additional specs */
 };
 
 
@@ -723,93 +520,23 @@ xer_type_encoder_f Choice6_encode_xer;
 
 /*** <<< CODE [Choice6] >>> ***/
 
-int
-Choice6_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_Choice1.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using Choice1,
  * so here we adjust the DEF accordingly.
  */
-static void
-Choice6_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Choice1.free_struct;
-	td->print_struct   = asn_DEF_Choice1.print_struct;
-	td->check_constraints = asn_DEF_Choice1.check_constraints;
-	td->ber_decoder    = asn_DEF_Choice1.ber_decoder;
-	td->der_encoder    = asn_DEF_Choice1.der_encoder;
-	td->xer_decoder    = asn_DEF_Choice1.xer_decoder;
-	td->xer_encoder    = asn_DEF_Choice1.xer_encoder;
-	td->uper_decoder   = asn_DEF_Choice1.uper_decoder;
-	td->uper_encoder   = asn_DEF_Choice1.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Choice1.per_constraints;
-	td->elements       = asn_DEF_Choice1.elements;
-	td->elements_count = asn_DEF_Choice1.elements_count;
-	td->specifics      = asn_DEF_Choice1.specifics;
-}
-
-void
-Choice6_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Choice6_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Choice6_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Choice6_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Choice6_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Choice6_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Choice6_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Choice6_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Choice6_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Choice6_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Choice6_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Choice6_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Choice6] >>> ***/
 
 asn_TYPE_descriptor_t asn_DEF_Choice6 = {
 	"Choice6",
 	"Choice6",
-	Choice6_free,
-	Choice6_print,
-	Choice6_constraint,
-	Choice6_decode_ber,
-	Choice6_encode_der,
-	Choice6_decode_xer,
-	Choice6_encode_xer,
+	CHOICE_free,
+	CHOICE_print,
+	CHOICE_constraint,
+	CHOICE_decode_ber,
+	CHOICE_encode_der,
+	CHOICE_decode_xer,
+	CHOICE_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
@@ -817,7 +544,8 @@ asn_TYPE_descriptor_t asn_DEF_Choice6 = {
 	0,	/* No tags (pointer) */
 	0,	/* No tags (count) */
 	0,	/* No PER visible constraints */
-	0, 0,	/* Defined elsewhere */
-	0	/* No specifics */
+	asn_MBR_Choice1_1,
+	2,	/* Elements count */
+	&asn_SPC_Choice1_specs_1	/* Additional specs */
 };
 

--- a/tests/39-sequence-of-OK.asn1.-Pfwide-types
+++ b/tests/39-sequence-of-OK.asn1.-Pfwide-types
@@ -159,10 +159,12 @@ typedef struct T2 {
 /*** <<< FUNC-DECLS [T2] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_T2;
+extern asn_SEQUENCE_specifics_t asn_SPC_T2_specs_1;
+extern asn_TYPE_member_t asn_MBR_T2_1[2];
 
 /*** <<< STAT-DEFS [T2] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_T2_1[] = {
+asn_TYPE_member_t asn_MBR_T2_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct T2, flag),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (1 << 2)),
 		.tag_mode = 0,
@@ -189,7 +191,7 @@ static const asn_TYPE_tag2member_t asn_MAP_T2_tag2el_1[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (1 << 2)), 0, 0, 0 }, /* flag */
     { (ASN_TAG_CLASS_UNIVERSAL | (12 << 2)), 1, 0, 0 } /* str */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_T2_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_T2_specs_1 = {
 	sizeof(struct T2),
 	offsetof(struct T2, _asn_ctx),
 	asn_MAP_T2_tag2el_1,

--- a/tests/42-real-life-OK.asn1.-PR
+++ b/tests/42-real-life-OK.asn1.-PR
@@ -206,6 +206,8 @@ typedef struct VariablePartSet {
 /*** <<< FUNC-DECLS [VariablePartSet] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_VariablePartSet;
+extern asn_SEQUENCE_specifics_t asn_SPC_VariablePartSet_specs_1;
+extern asn_TYPE_member_t asn_MBR_VariablePartSet_1[2];
 
 /*** <<< POST-INCLUDE [VariablePartSet] >>> ***/
 
@@ -279,7 +281,7 @@ asn_TYPE_descriptor_t asn_DEF_vparts_2 = {
 	&asn_SPC_vparts_specs_2	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_VariablePartSet_1[] = {
+asn_TYPE_member_t asn_MBR_VariablePartSet_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct VariablePartSet, vparts),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
@@ -306,7 +308,7 @@ static const asn_TYPE_tag2member_t asn_MAP_VariablePartSet_tag2el_1[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)), 0, 0, 1 }, /* vparts */
     { (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)), 1, -1, 0 } /* resolution */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_VariablePartSet_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_VariablePartSet_specs_1 = {
 	sizeof(struct VariablePartSet),
 	offsetof(struct VariablePartSet, _asn_ctx),
 	asn_MAP_VariablePartSet_tag2el_1,
@@ -393,6 +395,8 @@ typedef struct VariablePart {
 /*** <<< FUNC-DECLS [VariablePart] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_VariablePart;
+extern asn_CHOICE_specifics_t asn_SPC_VariablePart_specs_1;
+extern asn_TYPE_member_t asn_MBR_VariablePart_1[2];
 
 /*** <<< CODE [VariablePart] >>> ***/
 
@@ -530,7 +534,7 @@ asn_TYPE_descriptor_t asn_DEF_vrange_4 = {
 	&asn_SPC_vrange_specs_4	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_VariablePart_1[] = {
+asn_TYPE_member_t asn_MBR_VariablePart_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct VariablePart, choice.vset),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (17 << 2)),
 		.tag_mode = 0,
@@ -554,7 +558,7 @@ static const asn_TYPE_tag2member_t asn_MAP_VariablePart_tag2el_1[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)), 1, 0, 0 }, /* vrange */
     { (ASN_TAG_CLASS_UNIVERSAL | (17 << 2)), 0, 0, 0 } /* vset */
 };
-static asn_CHOICE_specifics_t asn_SPC_VariablePart_specs_1 = {
+asn_CHOICE_specifics_t asn_SPC_VariablePart_specs_1 = {
 	sizeof(struct VariablePart),
 	offsetof(struct VariablePart, _asn_ctx),
 	offsetof(struct VariablePart, present),
@@ -640,83 +644,15 @@ typedef struct ActionItem {
 
 /* extern asn_TYPE_descriptor_t asn_DEF_accept_as_2;	// (Use -fall-defs-global to expose) */
 extern asn_TYPE_descriptor_t asn_DEF_ActionItem;
+extern asn_SEQUENCE_specifics_t asn_SPC_ActionItem_specs_1;
+extern asn_TYPE_member_t asn_MBR_ActionItem_1[2];
 
 /*** <<< CODE [ActionItem] >>> ***/
-
-static int
-accept_as_2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_NativeEnumerated.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
 
 /*
  * This type is implemented using NativeEnumerated,
  * so here we adjust the DEF accordingly.
  */
-static void
-accept_as_2_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeEnumerated.free_struct;
-	td->print_struct   = asn_DEF_NativeEnumerated.print_struct;
-	td->check_constraints = asn_DEF_NativeEnumerated.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeEnumerated.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeEnumerated.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeEnumerated.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeEnumerated.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeEnumerated.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeEnumerated.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeEnumerated.per_constraints;
-	td->elements       = asn_DEF_NativeEnumerated.elements;
-	td->elements_count = asn_DEF_NativeEnumerated.elements_count;
-     /* td->specifics      = asn_DEF_NativeEnumerated.specifics;	// Defined explicitly */
-}
-
-static void
-accept_as_2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	accept_as_2_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-static int
-accept_as_2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	accept_as_2_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-static asn_dec_rval_t
-accept_as_2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	accept_as_2_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-static asn_enc_rval_t
-accept_as_2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	accept_as_2_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-static asn_dec_rval_t
-accept_as_2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	accept_as_2_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-static asn_enc_rval_t
-accept_as_2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	accept_as_2_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [ActionItem] >>> ***/
 
@@ -748,13 +684,13 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_accept_as_2 = {
 	"accept-as",
 	"accept-as",
-	accept_as_2_free,
-	accept_as_2_print,
-	accept_as_2_constraint,
-	accept_as_2_decode_ber,
-	accept_as_2_encode_der,
-	accept_as_2_decode_xer,
-	accept_as_2_encode_xer,
+	NativeEnumerated_free,
+	NativeEnumerated_print,
+	NativeEnumerated_constraint,
+	NativeEnumerated_decode_ber,
+	NativeEnumerated_encode_der,
+	NativeEnumerated_decode_xer,
+	NativeEnumerated_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_accept_as_tags_2,
@@ -873,7 +809,7 @@ asn_TYPE_descriptor_t asn_DEF_notify_7 = {
 	&asn_SPC_notify_specs_7	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_ActionItem_1[] = {
+asn_TYPE_member_t asn_MBR_ActionItem_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct ActionItem, accept_as),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (10 << 2)),
 		.tag_mode = 0,
@@ -900,7 +836,7 @@ static const asn_TYPE_tag2member_t asn_MAP_ActionItem_tag2el_1[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (10 << 2)), 0, 0, 0 }, /* accept-as */
     { (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)), 1, 0, 0 } /* notify */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_ActionItem_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_ActionItem_specs_1 = {
 	sizeof(struct ActionItem),
 	offsetof(struct ActionItem, _asn_ctx),
 	asn_MAP_ActionItem_tag2el_1,

--- a/tests/43-recursion-OK.asn1.-Pfwide-types
+++ b/tests/43-recursion-OK.asn1.-Pfwide-types
@@ -37,6 +37,8 @@ typedef struct Test_structure_1 {
 /*** <<< FUNC-DECLS [Test-structure-1] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Test_structure_1;
+extern asn_SEQUENCE_specifics_t asn_SPC_Test_structure_1_specs_1;
+extern asn_TYPE_member_t asn_MBR_Test_structure_1_1[4];
 
 /*** <<< POST-INCLUDE [Test-structure-1] >>> ***/
 
@@ -132,7 +134,7 @@ asn_TYPE_descriptor_t asn_DEF_t_member2_4 = {
 	&asn_SPC_t_member2_specs_4	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_Test_structure_1_1[] = {
+asn_TYPE_member_t asn_MBR_Test_structure_1_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Test_structure_1, t_member1),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (17 << 2)),
 		.tag_mode = 0,
@@ -179,7 +181,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Test_structure_1_tag2el_1[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)), 2, -1, 0 }, /* t-member3 */
     { (ASN_TAG_CLASS_UNIVERSAL | (17 << 2)), 0, 0, 0 } /* t-member1 */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Test_structure_1_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Test_structure_1_specs_1 = {
 	sizeof(struct Test_structure_1),
 	offsetof(struct Test_structure_1, _asn_ctx),
 	asn_MAP_Test_structure_1_tag2el_1,
@@ -257,6 +259,8 @@ typedef struct Choice_1 {
 /*** <<< FUNC-DECLS [Choice-1] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Choice_1;
+extern asn_CHOICE_specifics_t asn_SPC_Choice_1_specs_1;
+extern asn_TYPE_member_t asn_MBR_Choice_1_1[4];
 
 /*** <<< POST-INCLUDE [Choice-1] >>> ***/
 
@@ -309,7 +313,7 @@ asn_TYPE_descriptor_t asn_DEF_or_3 = {
 	&asn_SPC_or_specs_3	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_Choice_1_1[] = {
+asn_TYPE_member_t asn_MBR_Choice_1_1[] = {
 	{ ATF_POINTER, 0, offsetof(struct Choice_1, choice.And),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (1 << 2)),
 		.tag_mode = +1,	/* EXPLICIT tag at current level */
@@ -353,7 +357,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Choice_1_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (3 << 2)), 2, 0, 0 }, /* not */
     { (ASN_TAG_CLASS_CONTEXT | (4 << 2)), 3, 0, 0 } /* other */
 };
-static asn_CHOICE_specifics_t asn_SPC_Choice_1_specs_1 = {
+asn_CHOICE_specifics_t asn_SPC_Choice_1_specs_1 = {
 	sizeof(struct Choice_1),
 	offsetof(struct Choice_1, _asn_ctx),
 	offsetof(struct Choice_1, present),
@@ -420,6 +424,8 @@ typedef struct Test_structure_2 {
 /*** <<< FUNC-DECLS [Test-structure-2] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Test_structure_2;
+extern asn_SET_specifics_t asn_SPC_Test_structure_2_specs_1;
+extern asn_TYPE_member_t asn_MBR_Test_structure_2_1[1];
 
 /*** <<< POST-INCLUDE [Test-structure-2] >>> ***/
 
@@ -427,7 +433,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Test_structure_2;
 
 /*** <<< STAT-DEFS [Test-structure-2] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Test_structure_2_1[] = {
+asn_TYPE_member_t asn_MBR_Test_structure_2_1[] = {
 	{ ATF_POINTER, 1, offsetof(struct Test_structure_2, m1),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (17 << 2)),
 		.tag_mode = 0,
@@ -447,7 +453,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Test_structure_2_tag2el_1[] = {
 static const uint8_t asn_MAP_Test_structure_2_mmap_1[(1 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	(0 << 7)
 };
-static asn_SET_specifics_t asn_SPC_Test_structure_2_specs_1 = {
+asn_SET_specifics_t asn_SPC_Test_structure_2_specs_1 = {
 	sizeof(struct Test_structure_2),
 	offsetof(struct Test_structure_2, _asn_ctx),
 	offsetof(struct Test_structure_2, _presence_map),
@@ -517,6 +523,8 @@ typedef struct Test_structure_3 {
 /*** <<< FUNC-DECLS [Test-structure-3] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Test_structure_3;
+extern asn_SET_specifics_t asn_SPC_Test_structure_3_specs_1;
+extern asn_TYPE_member_t asn_MBR_Test_structure_3_1[1];
 
 /*** <<< POST-INCLUDE [Test-structure-3] >>> ***/
 
@@ -524,7 +532,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Test_structure_3;
 
 /*** <<< STAT-DEFS [Test-structure-3] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Test_structure_3_1[] = {
+asn_TYPE_member_t asn_MBR_Test_structure_3_1[] = {
 	{ ATF_POINTER, 1, offsetof(struct Test_structure_3, m1),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (17 << 2)),
 		.tag_mode = 0,
@@ -544,7 +552,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Test_structure_3_tag2el_1[] = {
 static const uint8_t asn_MAP_Test_structure_3_mmap_1[(1 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	(0 << 7)
 };
-static asn_SET_specifics_t asn_SPC_Test_structure_3_specs_1 = {
+asn_SET_specifics_t asn_SPC_Test_structure_3_specs_1 = {
 	sizeof(struct Test_structure_3),
 	offsetof(struct Test_structure_3, _asn_ctx),
 	offsetof(struct Test_structure_3, _presence_map),

--- a/tests/46-redefine-OK.asn1.-PR
+++ b/tests/46-redefine-OK.asn1.-PR
@@ -20,80 +20,10 @@ xer_type_encoder_f PrimitiveType_encode_xer;
 
 /*** <<< CODE [PrimitiveType] >>> ***/
 
-int
-PrimitiveType_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_OCTET_STRING.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using OCTET_STRING,
  * so here we adjust the DEF accordingly.
  */
-static void
-PrimitiveType_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_OCTET_STRING.free_struct;
-	td->print_struct   = asn_DEF_OCTET_STRING.print_struct;
-	td->check_constraints = asn_DEF_OCTET_STRING.check_constraints;
-	td->ber_decoder    = asn_DEF_OCTET_STRING.ber_decoder;
-	td->der_encoder    = asn_DEF_OCTET_STRING.der_encoder;
-	td->xer_decoder    = asn_DEF_OCTET_STRING.xer_decoder;
-	td->xer_encoder    = asn_DEF_OCTET_STRING.xer_encoder;
-	td->uper_decoder   = asn_DEF_OCTET_STRING.uper_decoder;
-	td->uper_encoder   = asn_DEF_OCTET_STRING.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_OCTET_STRING.per_constraints;
-	td->elements       = asn_DEF_OCTET_STRING.elements;
-	td->elements_count = asn_DEF_OCTET_STRING.elements_count;
-	td->specifics      = asn_DEF_OCTET_STRING.specifics;
-}
-
-void
-PrimitiveType_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	PrimitiveType_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-PrimitiveType_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	PrimitiveType_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-PrimitiveType_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	PrimitiveType_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-PrimitiveType_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	PrimitiveType_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-PrimitiveType_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	PrimitiveType_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-PrimitiveType_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	PrimitiveType_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [PrimitiveType] >>> ***/
 
@@ -103,13 +33,13 @@ static const ber_tlv_tag_t asn_DEF_PrimitiveType_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_PrimitiveType = {
 	"PrimitiveType",
 	"PrimitiveType",
-	PrimitiveType_free,
-	PrimitiveType_print,
-	PrimitiveType_constraint,
-	PrimitiveType_decode_ber,
-	PrimitiveType_encode_der,
-	PrimitiveType_decode_xer,
-	PrimitiveType_encode_xer,
+	OCTET_STRING_free,
+	OCTET_STRING_print,
+	OCTET_STRING_constraint,
+	OCTET_STRING_decode_ber,
+	OCTET_STRING_encode_der,
+	OCTET_STRING_decode_xer,
+	OCTET_STRING_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_PrimitiveType_tags_1,
@@ -120,7 +50,7 @@ asn_TYPE_descriptor_t asn_DEF_PrimitiveType = {
 		/sizeof(asn_DEF_PrimitiveType_tags_1[0]), /* 1 */
 	0,	/* No PER visible constraints */
 	0, 0,	/* No members */
-	0	/* No specifics */
+	&asn_SPC_OCTET_STRING_specs	/* Additional specs */
 };
 
 
@@ -141,10 +71,12 @@ typedef struct ConstructedType {
 /*** <<< FUNC-DECLS [ConstructedType] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_ConstructedType;
+extern asn_SEQUENCE_specifics_t asn_SPC_ConstructedType_specs_1;
+extern asn_TYPE_member_t asn_MBR_ConstructedType_1[1];
 
 /*** <<< STAT-DEFS [ConstructedType] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_ConstructedType_1[] = {
+asn_TYPE_member_t asn_MBR_ConstructedType_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct ConstructedType, field),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (5 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -161,7 +93,7 @@ static const ber_tlv_tag_t asn_DEF_ConstructedType_tags_1[] = {
 static const asn_TYPE_tag2member_t asn_MAP_ConstructedType_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (5 << 2)), 0, 0, 0 } /* field */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_ConstructedType_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_ConstructedType_specs_1 = {
 	sizeof(struct ConstructedType),
 	offsetof(struct ConstructedType, _asn_ctx),
 	asn_MAP_ConstructedType_tag2el_1,
@@ -216,80 +148,10 @@ xer_type_encoder_f T_encode_xer;
 
 /*** <<< CODE [T] >>> ***/
 
-int
-T_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_ConstructedType.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using ConstructedType,
  * so here we adjust the DEF accordingly.
  */
-static void
-T_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_ConstructedType.free_struct;
-	td->print_struct   = asn_DEF_ConstructedType.print_struct;
-	td->check_constraints = asn_DEF_ConstructedType.check_constraints;
-	td->ber_decoder    = asn_DEF_ConstructedType.ber_decoder;
-	td->der_encoder    = asn_DEF_ConstructedType.der_encoder;
-	td->xer_decoder    = asn_DEF_ConstructedType.xer_decoder;
-	td->xer_encoder    = asn_DEF_ConstructedType.xer_encoder;
-	td->uper_decoder   = asn_DEF_ConstructedType.uper_decoder;
-	td->uper_encoder   = asn_DEF_ConstructedType.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_ConstructedType.per_constraints;
-	td->elements       = asn_DEF_ConstructedType.elements;
-	td->elements_count = asn_DEF_ConstructedType.elements_count;
-	td->specifics      = asn_DEF_ConstructedType.specifics;
-}
-
-void
-T_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	T_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-T_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-T_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-T_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-T_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-T_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [T] >>> ***/
 
@@ -300,13 +162,13 @@ static const ber_tlv_tag_t asn_DEF_T_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	T_free,
-	T_print,
-	T_constraint,
-	T_decode_ber,
-	T_encode_der,
-	T_decode_xer,
-	T_encode_xer,
+	SEQUENCE_free,
+	SEQUENCE_print,
+	SEQUENCE_constraint,
+	SEQUENCE_decode_ber,
+	SEQUENCE_encode_der,
+	SEQUENCE_decode_xer,
+	SEQUENCE_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
@@ -316,7 +178,8 @@ asn_TYPE_descriptor_t asn_DEF_T = {
 	sizeof(asn_DEF_T_tags_1)
 		/sizeof(asn_DEF_T_tags_1[0]), /* 2 */
 	0,	/* No PER visible constraints */
-	0, 0,	/* Defined elsewhere */
-	0	/* No specifics */
+	asn_MBR_ConstructedType_1,
+	1,	/* Elements count */
+	&asn_SPC_ConstructedType_specs_1	/* Additional specs */
 };
 

--- a/tests/47-set-ext-OK.asn1.-Pfwide-types
+++ b/tests/47-set-ext-OK.asn1.-Pfwide-types
@@ -57,7 +57,8 @@ static const asn_TYPE_tag2member_t asn_MAP_T1_tag2el_1[] = {
 static const uint8_t asn_MAP_T1_mmap_1[(1 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	(1 << 7)
 };
-static asn_SET_specifics_t asn_SPC_T1_specs_1 = {
+static 
+asn_SET_specifics_t asn_SPC_T1_specs_1 = {
 	sizeof(struct T1),
 	offsetof(struct T1, _asn_ctx),
 	offsetof(struct T1, _presence_map),
@@ -151,7 +152,8 @@ static const asn_TYPE_tag2member_t asn_MAP_T2_tag2el_1[] = {
 static const uint8_t asn_MAP_T2_mmap_1[(1 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	(1 << 7)
 };
-static asn_SET_specifics_t asn_SPC_T2_specs_1 = {
+static 
+asn_SET_specifics_t asn_SPC_T2_specs_1 = {
 	sizeof(struct T2),
 	offsetof(struct T2, _asn_ctx),
 	offsetof(struct T2, _presence_map),

--- a/tests/50-constraint-OK.asn1.-Pfwide-types
+++ b/tests/50-constraint-OK.asn1.-Pfwide-types
@@ -20,80 +20,10 @@ xer_type_encoder_f Int1_encode_xer;
 
 /*** <<< CODE [Int1] >>> ***/
 
-int
-Int1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-Int1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-Int1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Int1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Int1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Int1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Int1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Int1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Int1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Int1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Int1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Int1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Int1] >>> ***/
 
@@ -103,13 +33,13 @@ static const ber_tlv_tag_t asn_DEF_Int1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int1 = {
 	"Int1",
 	"Int1",
-	Int1_free,
-	Int1_print,
-	Int1_constraint,
-	Int1_decode_ber,
-	Int1_encode_der,
-	Int1_decode_xer,
-	Int1_encode_xer,
+	INTEGER_free,
+	INTEGER_print,
+	INTEGER_constraint,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int1_tags_1,
@@ -176,68 +106,6 @@ Int2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using Int1,
  * so here we adjust the DEF accordingly.
  */
-static void
-Int2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Int1.free_struct;
-	td->print_struct   = asn_DEF_Int1.print_struct;
-	td->check_constraints = asn_DEF_Int1.check_constraints;
-	td->ber_decoder    = asn_DEF_Int1.ber_decoder;
-	td->der_encoder    = asn_DEF_Int1.der_encoder;
-	td->xer_decoder    = asn_DEF_Int1.xer_decoder;
-	td->xer_encoder    = asn_DEF_Int1.xer_encoder;
-	td->uper_decoder   = asn_DEF_Int1.uper_decoder;
-	td->uper_encoder   = asn_DEF_Int1.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Int1.per_constraints;
-	td->elements       = asn_DEF_Int1.elements;
-	td->elements_count = asn_DEF_Int1.elements_count;
-	td->specifics      = asn_DEF_Int1.specifics;
-}
-
-void
-Int2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Int2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Int2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Int2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Int2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Int2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Int2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Int2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Int2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Int2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Int2] >>> ***/
 
@@ -247,13 +115,13 @@ static const ber_tlv_tag_t asn_DEF_Int2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int2 = {
 	"Int2",
 	"Int2",
-	Int2_free,
-	Int2_print,
+	INTEGER_free,
+	INTEGER_print,
 	Int2_constraint,
-	Int2_decode_ber,
-	Int2_encode_der,
-	Int2_decode_xer,
-	Int2_encode_xer,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int2_tags_1,
@@ -324,68 +192,6 @@ Int3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using Int2,
  * so here we adjust the DEF accordingly.
  */
-static void
-Int3_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Int2.free_struct;
-	td->print_struct   = asn_DEF_Int2.print_struct;
-	td->check_constraints = asn_DEF_Int2.check_constraints;
-	td->ber_decoder    = asn_DEF_Int2.ber_decoder;
-	td->der_encoder    = asn_DEF_Int2.der_encoder;
-	td->xer_decoder    = asn_DEF_Int2.xer_decoder;
-	td->xer_encoder    = asn_DEF_Int2.xer_encoder;
-	td->uper_decoder   = asn_DEF_Int2.uper_decoder;
-	td->uper_encoder   = asn_DEF_Int2.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Int2.per_constraints;
-	td->elements       = asn_DEF_Int2.elements;
-	td->elements_count = asn_DEF_Int2.elements_count;
-	td->specifics      = asn_DEF_Int2.specifics;
-}
-
-void
-Int3_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Int3_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Int3_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Int3_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Int3_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Int3_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Int3_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int3_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Int3_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Int3_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Int3_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int3_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Int3] >>> ***/
 
@@ -395,13 +201,13 @@ static const ber_tlv_tag_t asn_DEF_Int3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int3 = {
 	"Int3",
 	"Int3",
-	Int3_free,
-	Int3_print,
+	INTEGER_free,
+	INTEGER_print,
 	Int3_constraint,
-	Int3_decode_ber,
-	Int3_encode_der,
-	Int3_decode_xer,
-	Int3_encode_xer,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int3_tags_1,
@@ -472,68 +278,6 @@ Int4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using Int3,
  * so here we adjust the DEF accordingly.
  */
-static void
-Int4_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Int3.free_struct;
-	td->print_struct   = asn_DEF_Int3.print_struct;
-	td->check_constraints = asn_DEF_Int3.check_constraints;
-	td->ber_decoder    = asn_DEF_Int3.ber_decoder;
-	td->der_encoder    = asn_DEF_Int3.der_encoder;
-	td->xer_decoder    = asn_DEF_Int3.xer_decoder;
-	td->xer_encoder    = asn_DEF_Int3.xer_encoder;
-	td->uper_decoder   = asn_DEF_Int3.uper_decoder;
-	td->uper_encoder   = asn_DEF_Int3.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Int3.per_constraints;
-	td->elements       = asn_DEF_Int3.elements;
-	td->elements_count = asn_DEF_Int3.elements_count;
-	td->specifics      = asn_DEF_Int3.specifics;
-}
-
-void
-Int4_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Int4_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Int4_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Int4_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Int4_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Int4_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Int4_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int4_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Int4_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Int4_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Int4_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int4_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Int4] >>> ***/
 
@@ -543,13 +287,13 @@ static const ber_tlv_tag_t asn_DEF_Int4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int4 = {
 	"Int4",
 	"Int4",
-	Int4_free,
-	Int4_print,
+	INTEGER_free,
+	INTEGER_print,
 	Int4_constraint,
-	Int4_decode_ber,
-	Int4_encode_der,
-	Int4_decode_xer,
-	Int4_encode_xer,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int4_tags_1,
@@ -620,68 +364,6 @@ Int5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using Int4,
  * so here we adjust the DEF accordingly.
  */
-static void
-Int5_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Int4.free_struct;
-	td->print_struct   = asn_DEF_Int4.print_struct;
-	td->check_constraints = asn_DEF_Int4.check_constraints;
-	td->ber_decoder    = asn_DEF_Int4.ber_decoder;
-	td->der_encoder    = asn_DEF_Int4.der_encoder;
-	td->xer_decoder    = asn_DEF_Int4.xer_decoder;
-	td->xer_encoder    = asn_DEF_Int4.xer_encoder;
-	td->uper_decoder   = asn_DEF_Int4.uper_decoder;
-	td->uper_encoder   = asn_DEF_Int4.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Int4.per_constraints;
-	td->elements       = asn_DEF_Int4.elements;
-	td->elements_count = asn_DEF_Int4.elements_count;
-	td->specifics      = asn_DEF_Int4.specifics;
-}
-
-void
-Int5_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Int5_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Int5_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Int5_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Int5_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Int5_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Int5_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int5_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Int5_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Int5_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Int5_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int5_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Int5] >>> ***/
 
@@ -691,13 +373,13 @@ static const ber_tlv_tag_t asn_DEF_Int5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int5 = {
 	"Int5",
 	"Int5",
-	Int5_free,
-	Int5_print,
+	INTEGER_free,
+	INTEGER_print,
 	Int5_constraint,
-	Int5_decode_ber,
-	Int5_encode_der,
-	Int5_decode_xer,
-	Int5_encode_xer,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int5_tags_1,
@@ -768,68 +450,6 @@ ExtensibleExtensions_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-ExtensibleExtensions_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-ExtensibleExtensions_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	ExtensibleExtensions_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-ExtensibleExtensions_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	ExtensibleExtensions_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-ExtensibleExtensions_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	ExtensibleExtensions_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-ExtensibleExtensions_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	ExtensibleExtensions_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-ExtensibleExtensions_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	ExtensibleExtensions_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-ExtensibleExtensions_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	ExtensibleExtensions_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [ExtensibleExtensions] >>> ***/
 
@@ -839,13 +459,13 @@ static const ber_tlv_tag_t asn_DEF_ExtensibleExtensions_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_ExtensibleExtensions = {
 	"ExtensibleExtensions",
 	"ExtensibleExtensions",
-	ExtensibleExtensions_free,
-	ExtensibleExtensions_print,
+	INTEGER_free,
+	INTEGER_print,
 	ExtensibleExtensions_constraint,
-	ExtensibleExtensions_decode_ber,
-	ExtensibleExtensions_encode_der,
-	ExtensibleExtensions_decode_xer,
-	ExtensibleExtensions_encode_xer,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_ExtensibleExtensions_tags_1,
@@ -881,80 +501,10 @@ xer_type_encoder_f Str1_encode_xer;
 
 /*** <<< CODE [Str1] >>> ***/
 
-int
-Str1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_IA5String.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using IA5String,
  * so here we adjust the DEF accordingly.
  */
-static void
-Str1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_IA5String.free_struct;
-	td->print_struct   = asn_DEF_IA5String.print_struct;
-	td->check_constraints = asn_DEF_IA5String.check_constraints;
-	td->ber_decoder    = asn_DEF_IA5String.ber_decoder;
-	td->der_encoder    = asn_DEF_IA5String.der_encoder;
-	td->xer_decoder    = asn_DEF_IA5String.xer_decoder;
-	td->xer_encoder    = asn_DEF_IA5String.xer_encoder;
-	td->uper_decoder   = asn_DEF_IA5String.uper_decoder;
-	td->uper_encoder   = asn_DEF_IA5String.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_IA5String.per_constraints;
-	td->elements       = asn_DEF_IA5String.elements;
-	td->elements_count = asn_DEF_IA5String.elements_count;
-	td->specifics      = asn_DEF_IA5String.specifics;
-}
-
-void
-Str1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Str1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Str1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Str1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Str1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Str1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Str1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Str1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Str1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Str1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Str1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Str1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Str1] >>> ***/
 
@@ -964,13 +514,13 @@ static const ber_tlv_tag_t asn_DEF_Str1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Str1 = {
 	"Str1",
 	"Str1",
-	Str1_free,
-	Str1_print,
-	Str1_constraint,
-	Str1_decode_ber,
-	Str1_encode_der,
-	Str1_decode_xer,
-	Str1_encode_xer,
+	IA5String_free,
+	IA5String_print,
+	IA5String_constraint,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Str1_tags_1,
@@ -1053,68 +603,6 @@ Str2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using Str1,
  * so here we adjust the DEF accordingly.
  */
-static void
-Str2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Str1.free_struct;
-	td->print_struct   = asn_DEF_Str1.print_struct;
-	td->check_constraints = asn_DEF_Str1.check_constraints;
-	td->ber_decoder    = asn_DEF_Str1.ber_decoder;
-	td->der_encoder    = asn_DEF_Str1.der_encoder;
-	td->xer_decoder    = asn_DEF_Str1.xer_decoder;
-	td->xer_encoder    = asn_DEF_Str1.xer_encoder;
-	td->uper_decoder   = asn_DEF_Str1.uper_decoder;
-	td->uper_encoder   = asn_DEF_Str1.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Str1.per_constraints;
-	td->elements       = asn_DEF_Str1.elements;
-	td->elements_count = asn_DEF_Str1.elements_count;
-	td->specifics      = asn_DEF_Str1.specifics;
-}
-
-void
-Str2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Str2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Str2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Str2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Str2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Str2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Str2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Str2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Str2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Str2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Str2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Str2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Str2] >>> ***/
 
@@ -1124,13 +612,13 @@ static const ber_tlv_tag_t asn_DEF_Str2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Str2 = {
 	"Str2",
 	"Str2",
-	Str2_free,
-	Str2_print,
+	IA5String_free,
+	IA5String_print,
 	Str2_constraint,
-	Str2_decode_ber,
-	Str2_encode_der,
-	Str2_decode_xer,
-	Str2_encode_xer,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Str2_tags_1,
@@ -1224,68 +712,6 @@ Str3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using Str2,
  * so here we adjust the DEF accordingly.
  */
-static void
-Str3_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Str2.free_struct;
-	td->print_struct   = asn_DEF_Str2.print_struct;
-	td->check_constraints = asn_DEF_Str2.check_constraints;
-	td->ber_decoder    = asn_DEF_Str2.ber_decoder;
-	td->der_encoder    = asn_DEF_Str2.der_encoder;
-	td->xer_decoder    = asn_DEF_Str2.xer_decoder;
-	td->xer_encoder    = asn_DEF_Str2.xer_encoder;
-	td->uper_decoder   = asn_DEF_Str2.uper_decoder;
-	td->uper_encoder   = asn_DEF_Str2.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Str2.per_constraints;
-	td->elements       = asn_DEF_Str2.elements;
-	td->elements_count = asn_DEF_Str2.elements_count;
-	td->specifics      = asn_DEF_Str2.specifics;
-}
-
-void
-Str3_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Str3_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Str3_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Str3_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Str3_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Str3_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Str3_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Str3_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Str3_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Str3_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Str3_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Str3_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Str3] >>> ***/
 
@@ -1295,13 +721,13 @@ static const ber_tlv_tag_t asn_DEF_Str3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Str3 = {
 	"Str3",
 	"Str3",
-	Str3_free,
-	Str3_print,
+	IA5String_free,
+	IA5String_print,
 	Str3_constraint,
-	Str3_decode_ber,
-	Str3_encode_der,
-	Str3_decode_xer,
-	Str3_encode_xer,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Str3_tags_1,
@@ -1381,68 +807,6 @@ Str4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using IA5String,
  * so here we adjust the DEF accordingly.
  */
-static void
-Str4_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_IA5String.free_struct;
-	td->print_struct   = asn_DEF_IA5String.print_struct;
-	td->check_constraints = asn_DEF_IA5String.check_constraints;
-	td->ber_decoder    = asn_DEF_IA5String.ber_decoder;
-	td->der_encoder    = asn_DEF_IA5String.der_encoder;
-	td->xer_decoder    = asn_DEF_IA5String.xer_decoder;
-	td->xer_encoder    = asn_DEF_IA5String.xer_encoder;
-	td->uper_decoder   = asn_DEF_IA5String.uper_decoder;
-	td->uper_encoder   = asn_DEF_IA5String.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_IA5String.per_constraints;
-	td->elements       = asn_DEF_IA5String.elements;
-	td->elements_count = asn_DEF_IA5String.elements_count;
-	td->specifics      = asn_DEF_IA5String.specifics;
-}
-
-void
-Str4_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Str4_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Str4_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Str4_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Str4_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Str4_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Str4_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Str4_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Str4_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Str4_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Str4_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Str4_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Str4] >>> ***/
 
@@ -1452,13 +816,13 @@ static const ber_tlv_tag_t asn_DEF_Str4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Str4 = {
 	"Str4",
 	"Str4",
-	Str4_free,
-	Str4_print,
+	IA5String_free,
+	IA5String_print,
 	Str4_constraint,
-	Str4_decode_ber,
-	Str4_encode_der,
-	Str4_decode_xer,
-	Str4_encode_xer,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Str4_tags_1,
@@ -1538,68 +902,6 @@ PER_Visible_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using IA5String,
  * so here we adjust the DEF accordingly.
  */
-static void
-PER_Visible_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_IA5String.free_struct;
-	td->print_struct   = asn_DEF_IA5String.print_struct;
-	td->check_constraints = asn_DEF_IA5String.check_constraints;
-	td->ber_decoder    = asn_DEF_IA5String.ber_decoder;
-	td->der_encoder    = asn_DEF_IA5String.der_encoder;
-	td->xer_decoder    = asn_DEF_IA5String.xer_decoder;
-	td->xer_encoder    = asn_DEF_IA5String.xer_encoder;
-	td->uper_decoder   = asn_DEF_IA5String.uper_decoder;
-	td->uper_encoder   = asn_DEF_IA5String.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_IA5String.per_constraints;
-	td->elements       = asn_DEF_IA5String.elements;
-	td->elements_count = asn_DEF_IA5String.elements_count;
-	td->specifics      = asn_DEF_IA5String.specifics;
-}
-
-void
-PER_Visible_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	PER_Visible_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-PER_Visible_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	PER_Visible_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-PER_Visible_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	PER_Visible_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-PER_Visible_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	PER_Visible_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-PER_Visible_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	PER_Visible_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-PER_Visible_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	PER_Visible_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [PER-Visible] >>> ***/
 
@@ -1609,13 +911,13 @@ static const ber_tlv_tag_t asn_DEF_PER_Visible_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_PER_Visible = {
 	"PER-Visible",
 	"PER-Visible",
-	PER_Visible_free,
-	PER_Visible_print,
+	IA5String_free,
+	IA5String_print,
 	PER_Visible_constraint,
-	PER_Visible_decode_ber,
-	PER_Visible_encode_der,
-	PER_Visible_decode_xer,
-	PER_Visible_encode_xer,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_PER_Visible_tags_1,
@@ -1695,68 +997,6 @@ PER_Visible_2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using PER_Visible,
  * so here we adjust the DEF accordingly.
  */
-static void
-PER_Visible_2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_PER_Visible.free_struct;
-	td->print_struct   = asn_DEF_PER_Visible.print_struct;
-	td->check_constraints = asn_DEF_PER_Visible.check_constraints;
-	td->ber_decoder    = asn_DEF_PER_Visible.ber_decoder;
-	td->der_encoder    = asn_DEF_PER_Visible.der_encoder;
-	td->xer_decoder    = asn_DEF_PER_Visible.xer_decoder;
-	td->xer_encoder    = asn_DEF_PER_Visible.xer_encoder;
-	td->uper_decoder   = asn_DEF_PER_Visible.uper_decoder;
-	td->uper_encoder   = asn_DEF_PER_Visible.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_PER_Visible.per_constraints;
-	td->elements       = asn_DEF_PER_Visible.elements;
-	td->elements_count = asn_DEF_PER_Visible.elements_count;
-	td->specifics      = asn_DEF_PER_Visible.specifics;
-}
-
-void
-PER_Visible_2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-PER_Visible_2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-PER_Visible_2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-PER_Visible_2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-PER_Visible_2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-PER_Visible_2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [PER-Visible-2] >>> ***/
 
@@ -1766,13 +1006,13 @@ static const ber_tlv_tag_t asn_DEF_PER_Visible_2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_PER_Visible_2 = {
 	"PER-Visible-2",
 	"PER-Visible-2",
-	PER_Visible_2_free,
-	PER_Visible_2_print,
+	IA5String_free,
+	IA5String_print,
 	PER_Visible_2_constraint,
-	PER_Visible_2_decode_ber,
-	PER_Visible_2_encode_der,
-	PER_Visible_2_decode_xer,
-	PER_Visible_2_encode_xer,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_PER_Visible_2_tags_1,
@@ -1852,68 +1092,6 @@ Not_PER_Visible_1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using PER_Visible,
  * so here we adjust the DEF accordingly.
  */
-static void
-Not_PER_Visible_1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_PER_Visible.free_struct;
-	td->print_struct   = asn_DEF_PER_Visible.print_struct;
-	td->check_constraints = asn_DEF_PER_Visible.check_constraints;
-	td->ber_decoder    = asn_DEF_PER_Visible.ber_decoder;
-	td->der_encoder    = asn_DEF_PER_Visible.der_encoder;
-	td->xer_decoder    = asn_DEF_PER_Visible.xer_decoder;
-	td->xer_encoder    = asn_DEF_PER_Visible.xer_encoder;
-	td->uper_decoder   = asn_DEF_PER_Visible.uper_decoder;
-	td->uper_encoder   = asn_DEF_PER_Visible.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_PER_Visible.per_constraints;
-	td->elements       = asn_DEF_PER_Visible.elements;
-	td->elements_count = asn_DEF_PER_Visible.elements_count;
-	td->specifics      = asn_DEF_PER_Visible.specifics;
-}
-
-void
-Not_PER_Visible_1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Not_PER_Visible_1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Not_PER_Visible_1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Not_PER_Visible_1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Not_PER_Visible_1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Not_PER_Visible_1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Not_PER_Visible_1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Not_PER_Visible_1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Not_PER_Visible_1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Not_PER_Visible_1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Not_PER_Visible_1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Not_PER_Visible_1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Not-PER-Visible-1] >>> ***/
 
@@ -1923,13 +1101,13 @@ static const ber_tlv_tag_t asn_DEF_Not_PER_Visible_1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Not_PER_Visible_1 = {
 	"Not-PER-Visible-1",
 	"Not-PER-Visible-1",
-	Not_PER_Visible_1_free,
-	Not_PER_Visible_1_print,
+	IA5String_free,
+	IA5String_print,
 	Not_PER_Visible_1_constraint,
-	Not_PER_Visible_1_decode_ber,
-	Not_PER_Visible_1_encode_der,
-	Not_PER_Visible_1_decode_xer,
-	Not_PER_Visible_1_encode_xer,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Not_PER_Visible_1_tags_1,
@@ -2009,68 +1187,6 @@ Not_PER_Visible_2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using PER_Visible,
  * so here we adjust the DEF accordingly.
  */
-static void
-Not_PER_Visible_2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_PER_Visible.free_struct;
-	td->print_struct   = asn_DEF_PER_Visible.print_struct;
-	td->check_constraints = asn_DEF_PER_Visible.check_constraints;
-	td->ber_decoder    = asn_DEF_PER_Visible.ber_decoder;
-	td->der_encoder    = asn_DEF_PER_Visible.der_encoder;
-	td->xer_decoder    = asn_DEF_PER_Visible.xer_decoder;
-	td->xer_encoder    = asn_DEF_PER_Visible.xer_encoder;
-	td->uper_decoder   = asn_DEF_PER_Visible.uper_decoder;
-	td->uper_encoder   = asn_DEF_PER_Visible.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_PER_Visible.per_constraints;
-	td->elements       = asn_DEF_PER_Visible.elements;
-	td->elements_count = asn_DEF_PER_Visible.elements_count;
-	td->specifics      = asn_DEF_PER_Visible.specifics;
-}
-
-void
-Not_PER_Visible_2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Not_PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Not_PER_Visible_2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Not_PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Not_PER_Visible_2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Not_PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Not_PER_Visible_2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Not_PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Not_PER_Visible_2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Not_PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Not_PER_Visible_2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Not_PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Not-PER-Visible-2] >>> ***/
 
@@ -2080,13 +1196,13 @@ static const ber_tlv_tag_t asn_DEF_Not_PER_Visible_2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Not_PER_Visible_2 = {
 	"Not-PER-Visible-2",
 	"Not-PER-Visible-2",
-	Not_PER_Visible_2_free,
-	Not_PER_Visible_2_print,
+	IA5String_free,
+	IA5String_print,
 	Not_PER_Visible_2_constraint,
-	Not_PER_Visible_2_decode_ber,
-	Not_PER_Visible_2_encode_der,
-	Not_PER_Visible_2_decode_xer,
-	Not_PER_Visible_2_encode_xer,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Not_PER_Visible_2_tags_1,
@@ -2166,68 +1282,6 @@ Not_PER_Visible_3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using PER_Visible,
  * so here we adjust the DEF accordingly.
  */
-static void
-Not_PER_Visible_3_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_PER_Visible.free_struct;
-	td->print_struct   = asn_DEF_PER_Visible.print_struct;
-	td->check_constraints = asn_DEF_PER_Visible.check_constraints;
-	td->ber_decoder    = asn_DEF_PER_Visible.ber_decoder;
-	td->der_encoder    = asn_DEF_PER_Visible.der_encoder;
-	td->xer_decoder    = asn_DEF_PER_Visible.xer_decoder;
-	td->xer_encoder    = asn_DEF_PER_Visible.xer_encoder;
-	td->uper_decoder   = asn_DEF_PER_Visible.uper_decoder;
-	td->uper_encoder   = asn_DEF_PER_Visible.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_PER_Visible.per_constraints;
-	td->elements       = asn_DEF_PER_Visible.elements;
-	td->elements_count = asn_DEF_PER_Visible.elements_count;
-	td->specifics      = asn_DEF_PER_Visible.specifics;
-}
-
-void
-Not_PER_Visible_3_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Not_PER_Visible_3_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Not_PER_Visible_3_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Not_PER_Visible_3_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Not_PER_Visible_3_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Not_PER_Visible_3_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Not_PER_Visible_3_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Not_PER_Visible_3_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Not_PER_Visible_3_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Not_PER_Visible_3_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Not_PER_Visible_3_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Not_PER_Visible_3_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Not-PER-Visible-3] >>> ***/
 
@@ -2237,13 +1291,13 @@ static const ber_tlv_tag_t asn_DEF_Not_PER_Visible_3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Not_PER_Visible_3 = {
 	"Not-PER-Visible-3",
 	"Not-PER-Visible-3",
-	Not_PER_Visible_3_free,
-	Not_PER_Visible_3_print,
+	IA5String_free,
+	IA5String_print,
 	Not_PER_Visible_3_constraint,
-	Not_PER_Visible_3_decode_ber,
-	Not_PER_Visible_3_encode_der,
-	Not_PER_Visible_3_decode_xer,
-	Not_PER_Visible_3_encode_xer,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Not_PER_Visible_3_tags_1,
@@ -2326,68 +1380,6 @@ SIZE_but_not_FROM_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using PER_Visible,
  * so here we adjust the DEF accordingly.
  */
-static void
-SIZE_but_not_FROM_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_PER_Visible.free_struct;
-	td->print_struct   = asn_DEF_PER_Visible.print_struct;
-	td->check_constraints = asn_DEF_PER_Visible.check_constraints;
-	td->ber_decoder    = asn_DEF_PER_Visible.ber_decoder;
-	td->der_encoder    = asn_DEF_PER_Visible.der_encoder;
-	td->xer_decoder    = asn_DEF_PER_Visible.xer_decoder;
-	td->xer_encoder    = asn_DEF_PER_Visible.xer_encoder;
-	td->uper_decoder   = asn_DEF_PER_Visible.uper_decoder;
-	td->uper_encoder   = asn_DEF_PER_Visible.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_PER_Visible.per_constraints;
-	td->elements       = asn_DEF_PER_Visible.elements;
-	td->elements_count = asn_DEF_PER_Visible.elements_count;
-	td->specifics      = asn_DEF_PER_Visible.specifics;
-}
-
-void
-SIZE_but_not_FROM_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	SIZE_but_not_FROM_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-SIZE_but_not_FROM_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	SIZE_but_not_FROM_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-SIZE_but_not_FROM_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	SIZE_but_not_FROM_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-SIZE_but_not_FROM_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	SIZE_but_not_FROM_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-SIZE_but_not_FROM_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	SIZE_but_not_FROM_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-SIZE_but_not_FROM_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	SIZE_but_not_FROM_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [SIZE-but-not-FROM] >>> ***/
 
@@ -2397,13 +1389,13 @@ static const ber_tlv_tag_t asn_DEF_SIZE_but_not_FROM_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_SIZE_but_not_FROM = {
 	"SIZE-but-not-FROM",
 	"SIZE-but-not-FROM",
-	SIZE_but_not_FROM_free,
-	SIZE_but_not_FROM_print,
+	IA5String_free,
+	IA5String_print,
 	SIZE_but_not_FROM_constraint,
-	SIZE_but_not_FROM_decode_ber,
-	SIZE_but_not_FROM_encode_der,
-	SIZE_but_not_FROM_decode_xer,
-	SIZE_but_not_FROM_encode_xer,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SIZE_but_not_FROM_tags_1,
@@ -2486,68 +1478,6 @@ SIZE_and_FROM_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using PER_Visible,
  * so here we adjust the DEF accordingly.
  */
-static void
-SIZE_and_FROM_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_PER_Visible.free_struct;
-	td->print_struct   = asn_DEF_PER_Visible.print_struct;
-	td->check_constraints = asn_DEF_PER_Visible.check_constraints;
-	td->ber_decoder    = asn_DEF_PER_Visible.ber_decoder;
-	td->der_encoder    = asn_DEF_PER_Visible.der_encoder;
-	td->xer_decoder    = asn_DEF_PER_Visible.xer_decoder;
-	td->xer_encoder    = asn_DEF_PER_Visible.xer_encoder;
-	td->uper_decoder   = asn_DEF_PER_Visible.uper_decoder;
-	td->uper_encoder   = asn_DEF_PER_Visible.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_PER_Visible.per_constraints;
-	td->elements       = asn_DEF_PER_Visible.elements;
-	td->elements_count = asn_DEF_PER_Visible.elements_count;
-	td->specifics      = asn_DEF_PER_Visible.specifics;
-}
-
-void
-SIZE_and_FROM_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	SIZE_and_FROM_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-SIZE_and_FROM_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	SIZE_and_FROM_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-SIZE_and_FROM_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	SIZE_and_FROM_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-SIZE_and_FROM_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	SIZE_and_FROM_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-SIZE_and_FROM_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	SIZE_and_FROM_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-SIZE_and_FROM_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	SIZE_and_FROM_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [SIZE-and-FROM] >>> ***/
 
@@ -2557,13 +1487,13 @@ static const ber_tlv_tag_t asn_DEF_SIZE_and_FROM_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_SIZE_and_FROM = {
 	"SIZE-and-FROM",
 	"SIZE-and-FROM",
-	SIZE_and_FROM_free,
-	SIZE_and_FROM_print,
+	IA5String_free,
+	IA5String_print,
 	SIZE_and_FROM_constraint,
-	SIZE_and_FROM_decode_ber,
-	SIZE_and_FROM_encode_der,
-	SIZE_and_FROM_decode_xer,
-	SIZE_and_FROM_encode_xer,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SIZE_and_FROM_tags_1,
@@ -2643,68 +1573,6 @@ Neither_SIZE_nor_FROM_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using PER_Visible,
  * so here we adjust the DEF accordingly.
  */
-static void
-Neither_SIZE_nor_FROM_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_PER_Visible.free_struct;
-	td->print_struct   = asn_DEF_PER_Visible.print_struct;
-	td->check_constraints = asn_DEF_PER_Visible.check_constraints;
-	td->ber_decoder    = asn_DEF_PER_Visible.ber_decoder;
-	td->der_encoder    = asn_DEF_PER_Visible.der_encoder;
-	td->xer_decoder    = asn_DEF_PER_Visible.xer_decoder;
-	td->xer_encoder    = asn_DEF_PER_Visible.xer_encoder;
-	td->uper_decoder   = asn_DEF_PER_Visible.uper_decoder;
-	td->uper_encoder   = asn_DEF_PER_Visible.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_PER_Visible.per_constraints;
-	td->elements       = asn_DEF_PER_Visible.elements;
-	td->elements_count = asn_DEF_PER_Visible.elements_count;
-	td->specifics      = asn_DEF_PER_Visible.specifics;
-}
-
-void
-Neither_SIZE_nor_FROM_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Neither_SIZE_nor_FROM_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Neither_SIZE_nor_FROM_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Neither_SIZE_nor_FROM_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Neither_SIZE_nor_FROM_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Neither_SIZE_nor_FROM_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Neither_SIZE_nor_FROM_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Neither_SIZE_nor_FROM_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Neither_SIZE_nor_FROM_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Neither_SIZE_nor_FROM_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Neither_SIZE_nor_FROM_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Neither_SIZE_nor_FROM_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Neither-SIZE-nor-FROM] >>> ***/
 
@@ -2714,13 +1582,13 @@ static const ber_tlv_tag_t asn_DEF_Neither_SIZE_nor_FROM_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Neither_SIZE_nor_FROM = {
 	"Neither-SIZE-nor-FROM",
 	"Neither-SIZE-nor-FROM",
-	Neither_SIZE_nor_FROM_free,
-	Neither_SIZE_nor_FROM_print,
+	IA5String_free,
+	IA5String_print,
 	Neither_SIZE_nor_FROM_constraint,
-	Neither_SIZE_nor_FROM_decode_ber,
-	Neither_SIZE_nor_FROM_encode_der,
-	Neither_SIZE_nor_FROM_decode_xer,
-	Neither_SIZE_nor_FROM_encode_xer,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Neither_SIZE_nor_FROM_tags_1,
@@ -2794,68 +1662,6 @@ Utf8_4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using UTF8String,
  * so here we adjust the DEF accordingly.
  */
-static void
-Utf8_4_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_UTF8String.free_struct;
-	td->print_struct   = asn_DEF_UTF8String.print_struct;
-	td->check_constraints = asn_DEF_UTF8String.check_constraints;
-	td->ber_decoder    = asn_DEF_UTF8String.ber_decoder;
-	td->der_encoder    = asn_DEF_UTF8String.der_encoder;
-	td->xer_decoder    = asn_DEF_UTF8String.xer_decoder;
-	td->xer_encoder    = asn_DEF_UTF8String.xer_encoder;
-	td->uper_decoder   = asn_DEF_UTF8String.uper_decoder;
-	td->uper_encoder   = asn_DEF_UTF8String.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_UTF8String.per_constraints;
-	td->elements       = asn_DEF_UTF8String.elements;
-	td->elements_count = asn_DEF_UTF8String.elements_count;
-	td->specifics      = asn_DEF_UTF8String.specifics;
-}
-
-void
-Utf8_4_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Utf8_4_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Utf8_4_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_4_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_4_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Utf8_4_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Utf8_4_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_4_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_4_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Utf8_4_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Utf8_4_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_4_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Utf8-4] >>> ***/
 
@@ -2865,13 +1671,13 @@ static const ber_tlv_tag_t asn_DEF_Utf8_4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Utf8_4 = {
 	"Utf8-4",
 	"Utf8-4",
-	Utf8_4_free,
-	Utf8_4_print,
+	UTF8String_free,
+	UTF8String_print,
 	Utf8_4_constraint,
-	Utf8_4_decode_ber,
-	Utf8_4_encode_der,
-	Utf8_4_decode_xer,
-	Utf8_4_encode_xer,
+	UTF8String_decode_ber,
+	UTF8String_encode_der,
+	UTF8String_decode_xer,
+	UTF8String_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Utf8_4_tags_1,
@@ -2973,68 +1779,6 @@ Utf8_3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using Utf8_2,
  * so here we adjust the DEF accordingly.
  */
-static void
-Utf8_3_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Utf8_2.free_struct;
-	td->print_struct   = asn_DEF_Utf8_2.print_struct;
-	td->check_constraints = asn_DEF_Utf8_2.check_constraints;
-	td->ber_decoder    = asn_DEF_Utf8_2.ber_decoder;
-	td->der_encoder    = asn_DEF_Utf8_2.der_encoder;
-	td->xer_decoder    = asn_DEF_Utf8_2.xer_decoder;
-	td->xer_encoder    = asn_DEF_Utf8_2.xer_encoder;
-	td->uper_decoder   = asn_DEF_Utf8_2.uper_decoder;
-	td->uper_encoder   = asn_DEF_Utf8_2.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Utf8_2.per_constraints;
-	td->elements       = asn_DEF_Utf8_2.elements;
-	td->elements_count = asn_DEF_Utf8_2.elements_count;
-	td->specifics      = asn_DEF_Utf8_2.specifics;
-}
-
-void
-Utf8_3_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Utf8_3_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Utf8_3_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_3_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_3_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Utf8_3_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Utf8_3_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_3_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_3_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Utf8_3_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Utf8_3_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_3_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Utf8-3] >>> ***/
 
@@ -3044,13 +1788,13 @@ static const ber_tlv_tag_t asn_DEF_Utf8_3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Utf8_3 = {
 	"Utf8-3",
 	"Utf8-3",
-	Utf8_3_free,
-	Utf8_3_print,
+	UTF8String_free,
+	UTF8String_print,
 	Utf8_3_constraint,
-	Utf8_3_decode_ber,
-	Utf8_3_encode_der,
-	Utf8_3_decode_xer,
-	Utf8_3_encode_xer,
+	UTF8String_decode_ber,
+	UTF8String_encode_der,
+	UTF8String_decode_xer,
+	UTF8String_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Utf8_3_tags_1,
@@ -3122,68 +1866,6 @@ Utf8_2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using Utf8_1,
  * so here we adjust the DEF accordingly.
  */
-static void
-Utf8_2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Utf8_1.free_struct;
-	td->print_struct   = asn_DEF_Utf8_1.print_struct;
-	td->check_constraints = asn_DEF_Utf8_1.check_constraints;
-	td->ber_decoder    = asn_DEF_Utf8_1.ber_decoder;
-	td->der_encoder    = asn_DEF_Utf8_1.der_encoder;
-	td->xer_decoder    = asn_DEF_Utf8_1.xer_decoder;
-	td->xer_encoder    = asn_DEF_Utf8_1.xer_encoder;
-	td->uper_decoder   = asn_DEF_Utf8_1.uper_decoder;
-	td->uper_encoder   = asn_DEF_Utf8_1.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Utf8_1.per_constraints;
-	td->elements       = asn_DEF_Utf8_1.elements;
-	td->elements_count = asn_DEF_Utf8_1.elements_count;
-	td->specifics      = asn_DEF_Utf8_1.specifics;
-}
-
-void
-Utf8_2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Utf8_2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Utf8_2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Utf8_2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Utf8_2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Utf8_2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Utf8_2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Utf8-2] >>> ***/
 
@@ -3193,13 +1875,13 @@ static const ber_tlv_tag_t asn_DEF_Utf8_2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Utf8_2 = {
 	"Utf8-2",
 	"Utf8-2",
-	Utf8_2_free,
-	Utf8_2_print,
+	UTF8String_free,
+	UTF8String_print,
 	Utf8_2_constraint,
-	Utf8_2_decode_ber,
-	Utf8_2_encode_der,
-	Utf8_2_decode_xer,
-	Utf8_2_encode_xer,
+	UTF8String_decode_ber,
+	UTF8String_encode_der,
+	UTF8String_decode_xer,
+	UTF8String_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Utf8_2_tags_1,
@@ -3235,80 +1917,10 @@ xer_type_encoder_f Utf8_1_encode_xer;
 
 /*** <<< CODE [Utf8-1] >>> ***/
 
-int
-Utf8_1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_UTF8String.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using UTF8String,
  * so here we adjust the DEF accordingly.
  */
-static void
-Utf8_1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_UTF8String.free_struct;
-	td->print_struct   = asn_DEF_UTF8String.print_struct;
-	td->check_constraints = asn_DEF_UTF8String.check_constraints;
-	td->ber_decoder    = asn_DEF_UTF8String.ber_decoder;
-	td->der_encoder    = asn_DEF_UTF8String.der_encoder;
-	td->xer_decoder    = asn_DEF_UTF8String.xer_decoder;
-	td->xer_encoder    = asn_DEF_UTF8String.xer_encoder;
-	td->uper_decoder   = asn_DEF_UTF8String.uper_decoder;
-	td->uper_encoder   = asn_DEF_UTF8String.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_UTF8String.per_constraints;
-	td->elements       = asn_DEF_UTF8String.elements;
-	td->elements_count = asn_DEF_UTF8String.elements_count;
-	td->specifics      = asn_DEF_UTF8String.specifics;
-}
-
-void
-Utf8_1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Utf8_1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Utf8_1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Utf8_1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Utf8_1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Utf8_1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Utf8_1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Utf8-1] >>> ***/
 
@@ -3318,13 +1930,13 @@ static const ber_tlv_tag_t asn_DEF_Utf8_1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Utf8_1 = {
 	"Utf8-1",
 	"Utf8-1",
-	Utf8_1_free,
-	Utf8_1_print,
-	Utf8_1_constraint,
-	Utf8_1_decode_ber,
-	Utf8_1_encode_der,
-	Utf8_1_decode_xer,
-	Utf8_1_encode_xer,
+	UTF8String_free,
+	UTF8String_print,
+	UTF8String_constraint,
+	UTF8String_decode_ber,
+	UTF8String_encode_der,
+	UTF8String_decode_xer,
+	UTF8String_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Utf8_1_tags_1,
@@ -3419,68 +2031,6 @@ VisibleIdentifier_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using Identifier,
  * so here we adjust the DEF accordingly.
  */
-static void
-VisibleIdentifier_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Identifier.free_struct;
-	td->print_struct   = asn_DEF_Identifier.print_struct;
-	td->check_constraints = asn_DEF_Identifier.check_constraints;
-	td->ber_decoder    = asn_DEF_Identifier.ber_decoder;
-	td->der_encoder    = asn_DEF_Identifier.der_encoder;
-	td->xer_decoder    = asn_DEF_Identifier.xer_decoder;
-	td->xer_encoder    = asn_DEF_Identifier.xer_encoder;
-	td->uper_decoder   = asn_DEF_Identifier.uper_decoder;
-	td->uper_encoder   = asn_DEF_Identifier.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Identifier.per_constraints;
-	td->elements       = asn_DEF_Identifier.elements;
-	td->elements_count = asn_DEF_Identifier.elements_count;
-	td->specifics      = asn_DEF_Identifier.specifics;
-}
-
-void
-VisibleIdentifier_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	VisibleIdentifier_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-VisibleIdentifier_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	VisibleIdentifier_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-VisibleIdentifier_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	VisibleIdentifier_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-VisibleIdentifier_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	VisibleIdentifier_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-VisibleIdentifier_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	VisibleIdentifier_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-VisibleIdentifier_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	VisibleIdentifier_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [VisibleIdentifier] >>> ***/
 
@@ -3490,13 +2040,13 @@ static const ber_tlv_tag_t asn_DEF_VisibleIdentifier_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_VisibleIdentifier = {
 	"VisibleIdentifier",
 	"VisibleIdentifier",
-	VisibleIdentifier_free,
-	VisibleIdentifier_print,
+	VisibleString_free,
+	VisibleString_print,
 	VisibleIdentifier_constraint,
-	VisibleIdentifier_decode_ber,
-	VisibleIdentifier_encode_der,
-	VisibleIdentifier_decode_xer,
-	VisibleIdentifier_encode_xer,
+	VisibleString_decode_ber,
+	VisibleString_encode_der,
+	VisibleString_decode_xer,
+	VisibleString_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_VisibleIdentifier_tags_1,
@@ -3555,83 +2105,15 @@ typedef struct Sequence {
 
 /* extern asn_TYPE_descriptor_t asn_DEF_enum_c_6;	// (Use -fall-defs-global to expose) */
 extern asn_TYPE_descriptor_t asn_DEF_Sequence;
+extern asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1;
+extern asn_TYPE_member_t asn_MBR_Sequence_1[7];
 
 /*** <<< CODE [Sequence] >>> ***/
-
-static int
-enum_c_6_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
 
 /*
  * This type is implemented using ENUMERATED,
  * so here we adjust the DEF accordingly.
  */
-static void
-enum_c_6_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_ENUMERATED.free_struct;
-	td->print_struct   = asn_DEF_ENUMERATED.print_struct;
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	td->ber_decoder    = asn_DEF_ENUMERATED.ber_decoder;
-	td->der_encoder    = asn_DEF_ENUMERATED.der_encoder;
-	td->xer_decoder    = asn_DEF_ENUMERATED.xer_decoder;
-	td->xer_encoder    = asn_DEF_ENUMERATED.xer_encoder;
-	td->uper_decoder   = asn_DEF_ENUMERATED.uper_decoder;
-	td->uper_encoder   = asn_DEF_ENUMERATED.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_ENUMERATED.per_constraints;
-	td->elements       = asn_DEF_ENUMERATED.elements;
-	td->elements_count = asn_DEF_ENUMERATED.elements_count;
-     /* td->specifics      = asn_DEF_ENUMERATED.specifics;	// Defined explicitly */
-}
-
-static void
-enum_c_6_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	enum_c_6_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-static int
-enum_c_6_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	enum_c_6_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-static asn_dec_rval_t
-enum_c_6_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	enum_c_6_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-static asn_enc_rval_t
-enum_c_6_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	enum_c_6_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-static asn_dec_rval_t
-enum_c_6_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	enum_c_6_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-static asn_enc_rval_t
-enum_c_6_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	enum_c_6_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 static int
 memb_int1_c_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
@@ -3794,13 +2276,13 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_enum_c_6 = {
 	"enum-c",
 	"enum-c",
-	enum_c_6_free,
-	enum_c_6_print,
-	enum_c_6_constraint,
-	enum_c_6_decode_ber,
-	enum_c_6_encode_der,
-	enum_c_6_decode_xer,
-	enum_c_6_encode_xer,
+	ENUMERATED_free,
+	ENUMERATED_print,
+	ENUMERATED_constraint,
+	ENUMERATED_decode_ber,
+	ENUMERATED_encode_der,
+	ENUMERATED_decode_xer,
+	ENUMERATED_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_enum_c_tags_6,
@@ -3814,7 +2296,7 @@ asn_TYPE_descriptor_t asn_DEF_enum_c_6 = {
 	&asn_SPC_enum_c_specs_6	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_Sequence_1[] = {
+asn_TYPE_member_t asn_MBR_Sequence_1[] = {
 	{ ATF_POINTER, 1, offsetof(struct Sequence, int1_c),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
 		.tag_mode = 0,
@@ -3891,7 +2373,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Sequence_tag2el_1[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (10 << 2)), 4, 0, 0 }, /* enum-c */
     { (ASN_TAG_CLASS_CONTEXT | (2 << 2)), 1, 0, 0 } /* int4 */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1 = {
 	sizeof(struct Sequence),
 	offsetof(struct Sequence, _asn_ctx),
 	asn_MAP_Sequence_tag2el_1,
@@ -4025,80 +2507,10 @@ xer_type_encoder_f Enum0_encode_xer;
 
 /*** <<< CODE [Enum0] >>> ***/
 
-int
-Enum0_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using ENUMERATED,
  * so here we adjust the DEF accordingly.
  */
-static void
-Enum0_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_ENUMERATED.free_struct;
-	td->print_struct   = asn_DEF_ENUMERATED.print_struct;
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	td->ber_decoder    = asn_DEF_ENUMERATED.ber_decoder;
-	td->der_encoder    = asn_DEF_ENUMERATED.der_encoder;
-	td->xer_decoder    = asn_DEF_ENUMERATED.xer_decoder;
-	td->xer_encoder    = asn_DEF_ENUMERATED.xer_encoder;
-	td->uper_decoder   = asn_DEF_ENUMERATED.uper_decoder;
-	td->uper_encoder   = asn_DEF_ENUMERATED.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_ENUMERATED.per_constraints;
-	td->elements       = asn_DEF_ENUMERATED.elements;
-	td->elements_count = asn_DEF_ENUMERATED.elements_count;
-     /* td->specifics      = asn_DEF_ENUMERATED.specifics;	// Defined explicitly */
-}
-
-void
-Enum0_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Enum0_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Enum0_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum0_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum0_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Enum0_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Enum0_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum0_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum0_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Enum0_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Enum0_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum0_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Enum0] >>> ***/
 
@@ -4125,13 +2537,13 @@ static const ber_tlv_tag_t asn_DEF_Enum0_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Enum0 = {
 	"Enum0",
 	"Enum0",
-	Enum0_free,
-	Enum0_print,
-	Enum0_constraint,
-	Enum0_decode_ber,
-	Enum0_encode_der,
-	Enum0_decode_xer,
-	Enum0_encode_xer,
+	ENUMERATED_free,
+	ENUMERATED_print,
+	ENUMERATED_constraint,
+	ENUMERATED_decode_ber,
+	ENUMERATED_encode_der,
+	ENUMERATED_decode_xer,
+	ENUMERATED_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Enum0_tags_1,
@@ -4203,68 +2615,6 @@ Enum1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeEnumerated,
  * so here we adjust the DEF accordingly.
  */
-static void
-Enum1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeEnumerated.free_struct;
-	td->print_struct   = asn_DEF_NativeEnumerated.print_struct;
-	td->check_constraints = asn_DEF_NativeEnumerated.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeEnumerated.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeEnumerated.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeEnumerated.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeEnumerated.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeEnumerated.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeEnumerated.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeEnumerated.per_constraints;
-	td->elements       = asn_DEF_NativeEnumerated.elements;
-	td->elements_count = asn_DEF_NativeEnumerated.elements_count;
-     /* td->specifics      = asn_DEF_NativeEnumerated.specifics;	// Defined explicitly */
-}
-
-void
-Enum1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Enum1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Enum1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Enum1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Enum1] >>> ***/
 
@@ -4291,13 +2641,13 @@ static const ber_tlv_tag_t asn_DEF_Enum1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Enum1 = {
 	"Enum1",
 	"Enum1",
-	Enum1_free,
-	Enum1_print,
+	NativeEnumerated_free,
+	NativeEnumerated_print,
 	Enum1_constraint,
-	Enum1_decode_ber,
-	Enum1_encode_der,
-	Enum1_decode_xer,
-	Enum1_encode_xer,
+	NativeEnumerated_decode_ber,
+	NativeEnumerated_encode_der,
+	NativeEnumerated_decode_xer,
+	NativeEnumerated_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Enum1_tags_1,
@@ -4392,68 +2742,6 @@ Identifier_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using VisibleString,
  * so here we adjust the DEF accordingly.
  */
-static void
-Identifier_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_VisibleString.free_struct;
-	td->print_struct   = asn_DEF_VisibleString.print_struct;
-	td->check_constraints = asn_DEF_VisibleString.check_constraints;
-	td->ber_decoder    = asn_DEF_VisibleString.ber_decoder;
-	td->der_encoder    = asn_DEF_VisibleString.der_encoder;
-	td->xer_decoder    = asn_DEF_VisibleString.xer_decoder;
-	td->xer_encoder    = asn_DEF_VisibleString.xer_encoder;
-	td->uper_decoder   = asn_DEF_VisibleString.uper_decoder;
-	td->uper_encoder   = asn_DEF_VisibleString.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_VisibleString.per_constraints;
-	td->elements       = asn_DEF_VisibleString.elements;
-	td->elements_count = asn_DEF_VisibleString.elements_count;
-	td->specifics      = asn_DEF_VisibleString.specifics;
-}
-
-void
-Identifier_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Identifier_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Identifier_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Identifier_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Identifier_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Identifier_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Identifier_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Identifier_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Identifier_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Identifier_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Identifier_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Identifier_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [Identifier] >>> ***/
 
@@ -4463,13 +2751,13 @@ static const ber_tlv_tag_t asn_DEF_Identifier_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Identifier = {
 	"Identifier",
 	"Identifier",
-	Identifier_free,
-	Identifier_print,
+	VisibleString_free,
+	VisibleString_print,
 	Identifier_constraint,
-	Identifier_decode_ber,
-	Identifier_encode_der,
-	Identifier_decode_xer,
-	Identifier_encode_xer,
+	VisibleString_decode_ber,
+	VisibleString_encode_der,
+	VisibleString_decode_xer,
+	VisibleString_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Identifier_tags_1,

--- a/tests/50-constraint-OK.asn1.-Pgen-PER
+++ b/tests/50-constraint-OK.asn1.-Pgen-PER
@@ -22,95 +22,10 @@ per_type_encoder_f Int1_encode_uper;
 
 /*** <<< CODE [Int1] >>> ***/
 
-int
-Int1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-Int1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-Int1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Int1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Int1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Int1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Int1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Int1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Int1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Int1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Int1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Int1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Int1_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Int1_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Int1_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Int1_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< STAT-DEFS [Int1] >>> ***/
 
@@ -120,15 +35,15 @@ static const ber_tlv_tag_t asn_DEF_Int1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int1 = {
 	"Int1",
 	"Int1",
-	Int1_free,
-	Int1_print,
-	Int1_constraint,
-	Int1_decode_ber,
-	Int1_encode_der,
-	Int1_decode_xer,
-	Int1_encode_xer,
-	Int1_decode_uper,
-	Int1_encode_uper,
+	NativeInteger_free,
+	NativeInteger_print,
+	NativeInteger_constraint,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int1_tags_1,
 	sizeof(asn_DEF_Int1_tags_1)
@@ -152,6 +67,7 @@ typedef Int1_t	 Int2_t;
 
 /*** <<< FUNC-DECLS [Int2] >>> ***/
 
+extern asn_per_constraints_t asn_PER_type_Int2_constr_1;
 extern asn_TYPE_descriptor_t asn_DEF_Int2;
 asn_struct_free_f Int2_free;
 asn_struct_print_f Int2_print;
@@ -194,87 +110,10 @@ Int2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using Int1,
  * so here we adjust the DEF accordingly.
  */
-static void
-Int2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Int1.free_struct;
-	td->print_struct   = asn_DEF_Int1.print_struct;
-	td->check_constraints = asn_DEF_Int1.check_constraints;
-	td->ber_decoder    = asn_DEF_Int1.ber_decoder;
-	td->der_encoder    = asn_DEF_Int1.der_encoder;
-	td->xer_decoder    = asn_DEF_Int1.xer_decoder;
-	td->xer_encoder    = asn_DEF_Int1.xer_encoder;
-	td->uper_decoder   = asn_DEF_Int1.uper_decoder;
-	td->uper_encoder   = asn_DEF_Int1.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Int1.per_constraints;
-	td->elements       = asn_DEF_Int1.elements;
-	td->elements_count = asn_DEF_Int1.elements_count;
-	td->specifics      = asn_DEF_Int1.specifics;
-}
-
-void
-Int2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Int2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Int2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Int2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Int2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Int2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Int2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Int2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Int2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Int2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Int2_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Int2_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Int2_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Int2_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [Int2] >>> ***/
 
-static asn_per_constraints_t asn_PER_type_Int2_constr_1 GCC_NOTUSED = {
+asn_per_constraints_t asn_PER_type_Int2_constr_1 GCC_NOTUSED = {
 	{ APC_SEMI_CONSTRAINED,	-1, -1,  0,  0 }	/* (0..MAX) */,
 	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
 	0, 0	/* No PER value map */
@@ -288,15 +127,15 @@ static const ber_tlv_tag_t asn_DEF_Int2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int2 = {
 	"Int2",
 	"Int2",
-	Int2_free,
-	Int2_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	Int2_constraint,
-	Int2_decode_ber,
-	Int2_encode_der,
-	Int2_decode_xer,
-	Int2_encode_xer,
-	Int2_decode_uper,
-	Int2_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int2_tags_1,
 	sizeof(asn_DEF_Int2_tags_1)
@@ -320,6 +159,7 @@ typedef Int2_t	 Int3_t;
 
 /*** <<< FUNC-DECLS [Int3] >>> ***/
 
+extern asn_per_constraints_t asn_PER_type_Int3_constr_1;
 extern asn_TYPE_descriptor_t asn_DEF_Int3;
 asn_struct_free_f Int3_free;
 asn_struct_print_f Int3_print;
@@ -362,87 +202,10 @@ Int3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using Int2,
  * so here we adjust the DEF accordingly.
  */
-static void
-Int3_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Int2.free_struct;
-	td->print_struct   = asn_DEF_Int2.print_struct;
-	td->check_constraints = asn_DEF_Int2.check_constraints;
-	td->ber_decoder    = asn_DEF_Int2.ber_decoder;
-	td->der_encoder    = asn_DEF_Int2.der_encoder;
-	td->xer_decoder    = asn_DEF_Int2.xer_decoder;
-	td->xer_encoder    = asn_DEF_Int2.xer_encoder;
-	td->uper_decoder   = asn_DEF_Int2.uper_decoder;
-	td->uper_encoder   = asn_DEF_Int2.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Int2.per_constraints;
-	td->elements       = asn_DEF_Int2.elements;
-	td->elements_count = asn_DEF_Int2.elements_count;
-	td->specifics      = asn_DEF_Int2.specifics;
-}
-
-void
-Int3_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Int3_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Int3_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Int3_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Int3_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Int3_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Int3_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int3_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Int3_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Int3_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Int3_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int3_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Int3_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Int3_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Int3_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Int3_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [Int3] >>> ***/
 
-static asn_per_constraints_t asn_PER_type_Int3_constr_1 GCC_NOTUSED = {
+asn_per_constraints_t asn_PER_type_Int3_constr_1 GCC_NOTUSED = {
 	{ APC_CONSTRAINED,	 4,  4,  0,  10 }	/* (0..10) */,
 	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
 	0, 0	/* No PER value map */
@@ -456,15 +219,15 @@ static const ber_tlv_tag_t asn_DEF_Int3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int3 = {
 	"Int3",
 	"Int3",
-	Int3_free,
-	Int3_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	Int3_constraint,
-	Int3_decode_ber,
-	Int3_encode_der,
-	Int3_decode_xer,
-	Int3_encode_xer,
-	Int3_decode_uper,
-	Int3_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int3_tags_1,
 	sizeof(asn_DEF_Int3_tags_1)
@@ -488,6 +251,7 @@ typedef Int3_t	 Int4_t;
 
 /*** <<< FUNC-DECLS [Int4] >>> ***/
 
+extern asn_per_constraints_t asn_PER_type_Int4_constr_1;
 extern asn_TYPE_descriptor_t asn_DEF_Int4;
 asn_struct_free_f Int4_free;
 asn_struct_print_f Int4_print;
@@ -530,87 +294,10 @@ Int4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using Int3,
  * so here we adjust the DEF accordingly.
  */
-static void
-Int4_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Int3.free_struct;
-	td->print_struct   = asn_DEF_Int3.print_struct;
-	td->check_constraints = asn_DEF_Int3.check_constraints;
-	td->ber_decoder    = asn_DEF_Int3.ber_decoder;
-	td->der_encoder    = asn_DEF_Int3.der_encoder;
-	td->xer_decoder    = asn_DEF_Int3.xer_decoder;
-	td->xer_encoder    = asn_DEF_Int3.xer_encoder;
-	td->uper_decoder   = asn_DEF_Int3.uper_decoder;
-	td->uper_encoder   = asn_DEF_Int3.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Int3.per_constraints;
-	td->elements       = asn_DEF_Int3.elements;
-	td->elements_count = asn_DEF_Int3.elements_count;
-	td->specifics      = asn_DEF_Int3.specifics;
-}
-
-void
-Int4_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Int4_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Int4_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Int4_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Int4_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Int4_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Int4_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int4_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Int4_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Int4_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Int4_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int4_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Int4_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Int4_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Int4_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Int4_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [Int4] >>> ***/
 
-static asn_per_constraints_t asn_PER_type_Int4_constr_1 GCC_NOTUSED = {
+asn_per_constraints_t asn_PER_type_Int4_constr_1 GCC_NOTUSED = {
 	{ APC_CONSTRAINED | APC_EXTENSIBLE,  4,  4,  1,  10 }	/* (1..10,...) */,
 	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
 	0, 0	/* No PER value map */
@@ -624,15 +311,15 @@ static const ber_tlv_tag_t asn_DEF_Int4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int4 = {
 	"Int4",
 	"Int4",
-	Int4_free,
-	Int4_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	Int4_constraint,
-	Int4_decode_ber,
-	Int4_encode_der,
-	Int4_decode_xer,
-	Int4_encode_xer,
-	Int4_decode_uper,
-	Int4_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int4_tags_1,
 	sizeof(asn_DEF_Int4_tags_1)
@@ -656,6 +343,7 @@ typedef Int4_t	 Int5_t;
 
 /*** <<< FUNC-DECLS [Int5] >>> ***/
 
+extern asn_per_constraints_t asn_PER_type_Int5_constr_1;
 extern asn_TYPE_descriptor_t asn_DEF_Int5;
 asn_struct_free_f Int5_free;
 asn_struct_print_f Int5_print;
@@ -698,87 +386,10 @@ Int5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using Int4,
  * so here we adjust the DEF accordingly.
  */
-static void
-Int5_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Int4.free_struct;
-	td->print_struct   = asn_DEF_Int4.print_struct;
-	td->check_constraints = asn_DEF_Int4.check_constraints;
-	td->ber_decoder    = asn_DEF_Int4.ber_decoder;
-	td->der_encoder    = asn_DEF_Int4.der_encoder;
-	td->xer_decoder    = asn_DEF_Int4.xer_decoder;
-	td->xer_encoder    = asn_DEF_Int4.xer_encoder;
-	td->uper_decoder   = asn_DEF_Int4.uper_decoder;
-	td->uper_encoder   = asn_DEF_Int4.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Int4.per_constraints;
-	td->elements       = asn_DEF_Int4.elements;
-	td->elements_count = asn_DEF_Int4.elements_count;
-	td->specifics      = asn_DEF_Int4.specifics;
-}
-
-void
-Int5_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Int5_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Int5_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Int5_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Int5_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Int5_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Int5_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int5_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Int5_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Int5_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Int5_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Int5_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Int5_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Int5_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Int5_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Int5_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [Int5] >>> ***/
 
-static asn_per_constraints_t asn_PER_type_Int5_constr_1 GCC_NOTUSED = {
+asn_per_constraints_t asn_PER_type_Int5_constr_1 GCC_NOTUSED = {
 	{ APC_CONSTRAINED,	 0,  0,  5,  5 }	/* (5..5) */,
 	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
 	0, 0	/* No PER value map */
@@ -792,15 +403,15 @@ static const ber_tlv_tag_t asn_DEF_Int5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int5 = {
 	"Int5",
 	"Int5",
-	Int5_free,
-	Int5_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	Int5_constraint,
-	Int5_decode_ber,
-	Int5_encode_der,
-	Int5_decode_xer,
-	Int5_encode_xer,
-	Int5_decode_uper,
-	Int5_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int5_tags_1,
 	sizeof(asn_DEF_Int5_tags_1)
@@ -866,83 +477,6 @@ ExtensibleExtensions_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-ExtensibleExtensions_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-ExtensibleExtensions_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	ExtensibleExtensions_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-ExtensibleExtensions_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	ExtensibleExtensions_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-ExtensibleExtensions_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	ExtensibleExtensions_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-ExtensibleExtensions_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	ExtensibleExtensions_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-ExtensibleExtensions_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	ExtensibleExtensions_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-ExtensibleExtensions_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	ExtensibleExtensions_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-ExtensibleExtensions_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	ExtensibleExtensions_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-ExtensibleExtensions_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	ExtensibleExtensions_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [ExtensibleExtensions] >>> ***/
 
@@ -960,15 +494,15 @@ static const ber_tlv_tag_t asn_DEF_ExtensibleExtensions_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_ExtensibleExtensions = {
 	"ExtensibleExtensions",
 	"ExtensibleExtensions",
-	ExtensibleExtensions_free,
-	ExtensibleExtensions_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	ExtensibleExtensions_constraint,
-	ExtensibleExtensions_decode_ber,
-	ExtensibleExtensions_encode_der,
-	ExtensibleExtensions_decode_xer,
-	ExtensibleExtensions_encode_xer,
-	ExtensibleExtensions_decode_uper,
-	ExtensibleExtensions_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_ExtensibleExtensions_tags_1,
 	sizeof(asn_DEF_ExtensibleExtensions_tags_1)
@@ -1005,95 +539,10 @@ per_type_encoder_f Str1_encode_uper;
 
 /*** <<< CODE [Str1] >>> ***/
 
-int
-Str1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_IA5String.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using IA5String,
  * so here we adjust the DEF accordingly.
  */
-static void
-Str1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_IA5String.free_struct;
-	td->print_struct   = asn_DEF_IA5String.print_struct;
-	td->check_constraints = asn_DEF_IA5String.check_constraints;
-	td->ber_decoder    = asn_DEF_IA5String.ber_decoder;
-	td->der_encoder    = asn_DEF_IA5String.der_encoder;
-	td->xer_decoder    = asn_DEF_IA5String.xer_decoder;
-	td->xer_encoder    = asn_DEF_IA5String.xer_encoder;
-	td->uper_decoder   = asn_DEF_IA5String.uper_decoder;
-	td->uper_encoder   = asn_DEF_IA5String.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_IA5String.per_constraints;
-	td->elements       = asn_DEF_IA5String.elements;
-	td->elements_count = asn_DEF_IA5String.elements_count;
-	td->specifics      = asn_DEF_IA5String.specifics;
-}
-
-void
-Str1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Str1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Str1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Str1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Str1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Str1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Str1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Str1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Str1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Str1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Str1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Str1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Str1_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Str1_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Str1_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Str1_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< STAT-DEFS [Str1] >>> ***/
 
@@ -1103,15 +552,15 @@ static const ber_tlv_tag_t asn_DEF_Str1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Str1 = {
 	"Str1",
 	"Str1",
-	Str1_free,
-	Str1_print,
-	Str1_constraint,
-	Str1_decode_ber,
-	Str1_encode_der,
-	Str1_decode_xer,
-	Str1_encode_xer,
-	Str1_decode_uper,
-	Str1_encode_uper,
+	IA5String_free,
+	IA5String_print,
+	IA5String_constraint,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
+	IA5String_decode_uper,
+	IA5String_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Str1_tags_1,
 	sizeof(asn_DEF_Str1_tags_1)
@@ -1135,6 +584,7 @@ typedef Str1_t	 Str2_t;
 
 /*** <<< FUNC-DECLS [Str2] >>> ***/
 
+extern asn_per_constraints_t asn_PER_type_Str2_constr_1;
 extern asn_TYPE_descriptor_t asn_DEF_Str2;
 asn_struct_free_f Str2_free;
 asn_struct_print_f Str2_print;
@@ -1195,87 +645,10 @@ Str2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using Str1,
  * so here we adjust the DEF accordingly.
  */
-static void
-Str2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Str1.free_struct;
-	td->print_struct   = asn_DEF_Str1.print_struct;
-	td->check_constraints = asn_DEF_Str1.check_constraints;
-	td->ber_decoder    = asn_DEF_Str1.ber_decoder;
-	td->der_encoder    = asn_DEF_Str1.der_encoder;
-	td->xer_decoder    = asn_DEF_Str1.xer_decoder;
-	td->xer_encoder    = asn_DEF_Str1.xer_encoder;
-	td->uper_decoder   = asn_DEF_Str1.uper_decoder;
-	td->uper_encoder   = asn_DEF_Str1.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Str1.per_constraints;
-	td->elements       = asn_DEF_Str1.elements;
-	td->elements_count = asn_DEF_Str1.elements_count;
-	td->specifics      = asn_DEF_Str1.specifics;
-}
-
-void
-Str2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Str2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Str2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Str2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Str2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Str2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Str2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Str2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Str2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Str2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Str2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Str2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Str2_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Str2_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Str2_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Str2_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [Str2] >>> ***/
 
-static asn_per_constraints_t asn_PER_type_Str2_constr_1 GCC_NOTUSED = {
+asn_per_constraints_t asn_PER_type_Str2_constr_1 GCC_NOTUSED = {
 	{ APC_CONSTRAINED,	 7,  7,  0,  127 }	/* (0..127) */,
 	{ APC_CONSTRAINED,	 5,  5,  0,  30 }	/* (SIZE(0..30)) */,
 	0, 0	/* No PER character map necessary */
@@ -1289,15 +662,15 @@ static const ber_tlv_tag_t asn_DEF_Str2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Str2 = {
 	"Str2",
 	"Str2",
-	Str2_free,
-	Str2_print,
+	IA5String_free,
+	IA5String_print,
 	Str2_constraint,
-	Str2_decode_ber,
-	Str2_encode_der,
-	Str2_decode_xer,
-	Str2_encode_xer,
-	Str2_decode_uper,
-	Str2_encode_uper,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
+	IA5String_decode_uper,
+	IA5String_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Str2_tags_1,
 	sizeof(asn_DEF_Str2_tags_1)
@@ -1405,83 +778,6 @@ static int asn_PER_MAP_Str3_1_c2v(unsigned int code) {
  * This type is implemented using Str2,
  * so here we adjust the DEF accordingly.
  */
-static void
-Str3_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Str2.free_struct;
-	td->print_struct   = asn_DEF_Str2.print_struct;
-	td->check_constraints = asn_DEF_Str2.check_constraints;
-	td->ber_decoder    = asn_DEF_Str2.ber_decoder;
-	td->der_encoder    = asn_DEF_Str2.der_encoder;
-	td->xer_decoder    = asn_DEF_Str2.xer_decoder;
-	td->xer_encoder    = asn_DEF_Str2.xer_encoder;
-	td->uper_decoder   = asn_DEF_Str2.uper_decoder;
-	td->uper_encoder   = asn_DEF_Str2.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Str2.per_constraints;
-	td->elements       = asn_DEF_Str2.elements;
-	td->elements_count = asn_DEF_Str2.elements_count;
-	td->specifics      = asn_DEF_Str2.specifics;
-}
-
-void
-Str3_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Str3_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Str3_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Str3_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Str3_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Str3_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Str3_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Str3_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Str3_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Str3_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Str3_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Str3_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Str3_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Str3_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Str3_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Str3_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [Str3] >>> ***/
 
@@ -1500,15 +796,15 @@ static const ber_tlv_tag_t asn_DEF_Str3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Str3 = {
 	"Str3",
 	"Str3",
-	Str3_free,
-	Str3_print,
+	IA5String_free,
+	IA5String_print,
 	Str3_constraint,
-	Str3_decode_ber,
-	Str3_encode_der,
-	Str3_decode_xer,
-	Str3_encode_xer,
-	Str3_decode_uper,
-	Str3_encode_uper,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
+	IA5String_decode_uper,
+	IA5String_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Str3_tags_1,
 	sizeof(asn_DEF_Str3_tags_1)
@@ -1589,83 +885,6 @@ Str4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using IA5String,
  * so here we adjust the DEF accordingly.
  */
-static void
-Str4_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_IA5String.free_struct;
-	td->print_struct   = asn_DEF_IA5String.print_struct;
-	td->check_constraints = asn_DEF_IA5String.check_constraints;
-	td->ber_decoder    = asn_DEF_IA5String.ber_decoder;
-	td->der_encoder    = asn_DEF_IA5String.der_encoder;
-	td->xer_decoder    = asn_DEF_IA5String.xer_decoder;
-	td->xer_encoder    = asn_DEF_IA5String.xer_encoder;
-	td->uper_decoder   = asn_DEF_IA5String.uper_decoder;
-	td->uper_encoder   = asn_DEF_IA5String.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_IA5String.per_constraints;
-	td->elements       = asn_DEF_IA5String.elements;
-	td->elements_count = asn_DEF_IA5String.elements_count;
-	td->specifics      = asn_DEF_IA5String.specifics;
-}
-
-void
-Str4_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Str4_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Str4_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Str4_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Str4_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Str4_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Str4_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Str4_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Str4_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Str4_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Str4_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Str4_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Str4_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Str4_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Str4_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Str4_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [Str4] >>> ***/
 
@@ -1683,15 +902,15 @@ static const ber_tlv_tag_t asn_DEF_Str4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Str4 = {
 	"Str4",
 	"Str4",
-	Str4_free,
-	Str4_print,
+	IA5String_free,
+	IA5String_print,
 	Str4_constraint,
-	Str4_decode_ber,
-	Str4_encode_der,
-	Str4_decode_xer,
-	Str4_encode_xer,
-	Str4_decode_uper,
-	Str4_encode_uper,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
+	IA5String_decode_uper,
+	IA5String_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Str4_tags_1,
 	sizeof(asn_DEF_Str4_tags_1)
@@ -1715,6 +934,7 @@ typedef IA5String_t	 PER_Visible_t;
 
 /*** <<< FUNC-DECLS [PER-Visible] >>> ***/
 
+extern asn_per_constraints_t asn_PER_type_PER_Visible_constr_1;
 extern asn_TYPE_descriptor_t asn_DEF_PER_Visible;
 asn_struct_free_f PER_Visible_free;
 asn_struct_print_f PER_Visible_print;
@@ -1772,87 +992,10 @@ PER_Visible_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using IA5String,
  * so here we adjust the DEF accordingly.
  */
-static void
-PER_Visible_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_IA5String.free_struct;
-	td->print_struct   = asn_DEF_IA5String.print_struct;
-	td->check_constraints = asn_DEF_IA5String.check_constraints;
-	td->ber_decoder    = asn_DEF_IA5String.ber_decoder;
-	td->der_encoder    = asn_DEF_IA5String.der_encoder;
-	td->xer_decoder    = asn_DEF_IA5String.xer_decoder;
-	td->xer_encoder    = asn_DEF_IA5String.xer_encoder;
-	td->uper_decoder   = asn_DEF_IA5String.uper_decoder;
-	td->uper_encoder   = asn_DEF_IA5String.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_IA5String.per_constraints;
-	td->elements       = asn_DEF_IA5String.elements;
-	td->elements_count = asn_DEF_IA5String.elements_count;
-	td->specifics      = asn_DEF_IA5String.specifics;
-}
-
-void
-PER_Visible_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	PER_Visible_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-PER_Visible_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	PER_Visible_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-PER_Visible_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	PER_Visible_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-PER_Visible_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	PER_Visible_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-PER_Visible_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	PER_Visible_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-PER_Visible_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	PER_Visible_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-PER_Visible_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	PER_Visible_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-PER_Visible_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	PER_Visible_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [PER-Visible] >>> ***/
 
-static asn_per_constraints_t asn_PER_type_PER_Visible_constr_1 GCC_NOTUSED = {
+asn_per_constraints_t asn_PER_type_PER_Visible_constr_1 GCC_NOTUSED = {
 	{ APC_CONSTRAINED,	 3,  3,  65,  70 }	/* (65..70) */,
 	{ APC_SEMI_CONSTRAINED,	-1, -1,  0,  0 }	/* (SIZE(0..MAX)) */,
 	0, 0	/* No PER character map necessary */
@@ -1866,15 +1009,15 @@ static const ber_tlv_tag_t asn_DEF_PER_Visible_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_PER_Visible = {
 	"PER-Visible",
 	"PER-Visible",
-	PER_Visible_free,
-	PER_Visible_print,
+	IA5String_free,
+	IA5String_print,
 	PER_Visible_constraint,
-	PER_Visible_decode_ber,
-	PER_Visible_encode_der,
-	PER_Visible_decode_xer,
-	PER_Visible_encode_xer,
-	PER_Visible_decode_uper,
-	PER_Visible_encode_uper,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
+	IA5String_decode_uper,
+	IA5String_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_PER_Visible_tags_1,
 	sizeof(asn_DEF_PER_Visible_tags_1)
@@ -1955,83 +1098,6 @@ PER_Visible_2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using PER_Visible,
  * so here we adjust the DEF accordingly.
  */
-static void
-PER_Visible_2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_PER_Visible.free_struct;
-	td->print_struct   = asn_DEF_PER_Visible.print_struct;
-	td->check_constraints = asn_DEF_PER_Visible.check_constraints;
-	td->ber_decoder    = asn_DEF_PER_Visible.ber_decoder;
-	td->der_encoder    = asn_DEF_PER_Visible.der_encoder;
-	td->xer_decoder    = asn_DEF_PER_Visible.xer_decoder;
-	td->xer_encoder    = asn_DEF_PER_Visible.xer_encoder;
-	td->uper_decoder   = asn_DEF_PER_Visible.uper_decoder;
-	td->uper_encoder   = asn_DEF_PER_Visible.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_PER_Visible.per_constraints;
-	td->elements       = asn_DEF_PER_Visible.elements;
-	td->elements_count = asn_DEF_PER_Visible.elements_count;
-	td->specifics      = asn_DEF_PER_Visible.specifics;
-}
-
-void
-PER_Visible_2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-PER_Visible_2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-PER_Visible_2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-PER_Visible_2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-PER_Visible_2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-PER_Visible_2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-PER_Visible_2_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-PER_Visible_2_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [PER-Visible-2] >>> ***/
 
@@ -2049,15 +1115,15 @@ static const ber_tlv_tag_t asn_DEF_PER_Visible_2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_PER_Visible_2 = {
 	"PER-Visible-2",
 	"PER-Visible-2",
-	PER_Visible_2_free,
-	PER_Visible_2_print,
+	IA5String_free,
+	IA5String_print,
 	PER_Visible_2_constraint,
-	PER_Visible_2_decode_ber,
-	PER_Visible_2_encode_der,
-	PER_Visible_2_decode_xer,
-	PER_Visible_2_encode_xer,
-	PER_Visible_2_decode_uper,
-	PER_Visible_2_encode_uper,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
+	IA5String_decode_uper,
+	IA5String_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_PER_Visible_2_tags_1,
 	sizeof(asn_DEF_PER_Visible_2_tags_1)
@@ -2138,83 +1204,6 @@ Not_PER_Visible_1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using PER_Visible,
  * so here we adjust the DEF accordingly.
  */
-static void
-Not_PER_Visible_1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_PER_Visible.free_struct;
-	td->print_struct   = asn_DEF_PER_Visible.print_struct;
-	td->check_constraints = asn_DEF_PER_Visible.check_constraints;
-	td->ber_decoder    = asn_DEF_PER_Visible.ber_decoder;
-	td->der_encoder    = asn_DEF_PER_Visible.der_encoder;
-	td->xer_decoder    = asn_DEF_PER_Visible.xer_decoder;
-	td->xer_encoder    = asn_DEF_PER_Visible.xer_encoder;
-	td->uper_decoder   = asn_DEF_PER_Visible.uper_decoder;
-	td->uper_encoder   = asn_DEF_PER_Visible.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_PER_Visible.per_constraints;
-	td->elements       = asn_DEF_PER_Visible.elements;
-	td->elements_count = asn_DEF_PER_Visible.elements_count;
-	td->specifics      = asn_DEF_PER_Visible.specifics;
-}
-
-void
-Not_PER_Visible_1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Not_PER_Visible_1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Not_PER_Visible_1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Not_PER_Visible_1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Not_PER_Visible_1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Not_PER_Visible_1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Not_PER_Visible_1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Not_PER_Visible_1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Not_PER_Visible_1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Not_PER_Visible_1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Not_PER_Visible_1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Not_PER_Visible_1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Not_PER_Visible_1_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Not_PER_Visible_1_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Not_PER_Visible_1_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Not_PER_Visible_1_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [Not-PER-Visible-1] >>> ***/
 
@@ -2232,15 +1221,15 @@ static const ber_tlv_tag_t asn_DEF_Not_PER_Visible_1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Not_PER_Visible_1 = {
 	"Not-PER-Visible-1",
 	"Not-PER-Visible-1",
-	Not_PER_Visible_1_free,
-	Not_PER_Visible_1_print,
+	IA5String_free,
+	IA5String_print,
 	Not_PER_Visible_1_constraint,
-	Not_PER_Visible_1_decode_ber,
-	Not_PER_Visible_1_encode_der,
-	Not_PER_Visible_1_decode_xer,
-	Not_PER_Visible_1_encode_xer,
-	Not_PER_Visible_1_decode_uper,
-	Not_PER_Visible_1_encode_uper,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
+	IA5String_decode_uper,
+	IA5String_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Not_PER_Visible_1_tags_1,
 	sizeof(asn_DEF_Not_PER_Visible_1_tags_1)
@@ -2321,83 +1310,6 @@ Not_PER_Visible_2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using PER_Visible,
  * so here we adjust the DEF accordingly.
  */
-static void
-Not_PER_Visible_2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_PER_Visible.free_struct;
-	td->print_struct   = asn_DEF_PER_Visible.print_struct;
-	td->check_constraints = asn_DEF_PER_Visible.check_constraints;
-	td->ber_decoder    = asn_DEF_PER_Visible.ber_decoder;
-	td->der_encoder    = asn_DEF_PER_Visible.der_encoder;
-	td->xer_decoder    = asn_DEF_PER_Visible.xer_decoder;
-	td->xer_encoder    = asn_DEF_PER_Visible.xer_encoder;
-	td->uper_decoder   = asn_DEF_PER_Visible.uper_decoder;
-	td->uper_encoder   = asn_DEF_PER_Visible.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_PER_Visible.per_constraints;
-	td->elements       = asn_DEF_PER_Visible.elements;
-	td->elements_count = asn_DEF_PER_Visible.elements_count;
-	td->specifics      = asn_DEF_PER_Visible.specifics;
-}
-
-void
-Not_PER_Visible_2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Not_PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Not_PER_Visible_2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Not_PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Not_PER_Visible_2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Not_PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Not_PER_Visible_2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Not_PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Not_PER_Visible_2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Not_PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Not_PER_Visible_2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Not_PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Not_PER_Visible_2_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Not_PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Not_PER_Visible_2_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Not_PER_Visible_2_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [Not-PER-Visible-2] >>> ***/
 
@@ -2415,15 +1327,15 @@ static const ber_tlv_tag_t asn_DEF_Not_PER_Visible_2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Not_PER_Visible_2 = {
 	"Not-PER-Visible-2",
 	"Not-PER-Visible-2",
-	Not_PER_Visible_2_free,
-	Not_PER_Visible_2_print,
+	IA5String_free,
+	IA5String_print,
 	Not_PER_Visible_2_constraint,
-	Not_PER_Visible_2_decode_ber,
-	Not_PER_Visible_2_encode_der,
-	Not_PER_Visible_2_decode_xer,
-	Not_PER_Visible_2_encode_xer,
-	Not_PER_Visible_2_decode_uper,
-	Not_PER_Visible_2_encode_uper,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
+	IA5String_decode_uper,
+	IA5String_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Not_PER_Visible_2_tags_1,
 	sizeof(asn_DEF_Not_PER_Visible_2_tags_1)
@@ -2504,83 +1416,6 @@ Not_PER_Visible_3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using PER_Visible,
  * so here we adjust the DEF accordingly.
  */
-static void
-Not_PER_Visible_3_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_PER_Visible.free_struct;
-	td->print_struct   = asn_DEF_PER_Visible.print_struct;
-	td->check_constraints = asn_DEF_PER_Visible.check_constraints;
-	td->ber_decoder    = asn_DEF_PER_Visible.ber_decoder;
-	td->der_encoder    = asn_DEF_PER_Visible.der_encoder;
-	td->xer_decoder    = asn_DEF_PER_Visible.xer_decoder;
-	td->xer_encoder    = asn_DEF_PER_Visible.xer_encoder;
-	td->uper_decoder   = asn_DEF_PER_Visible.uper_decoder;
-	td->uper_encoder   = asn_DEF_PER_Visible.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_PER_Visible.per_constraints;
-	td->elements       = asn_DEF_PER_Visible.elements;
-	td->elements_count = asn_DEF_PER_Visible.elements_count;
-	td->specifics      = asn_DEF_PER_Visible.specifics;
-}
-
-void
-Not_PER_Visible_3_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Not_PER_Visible_3_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Not_PER_Visible_3_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Not_PER_Visible_3_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Not_PER_Visible_3_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Not_PER_Visible_3_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Not_PER_Visible_3_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Not_PER_Visible_3_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Not_PER_Visible_3_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Not_PER_Visible_3_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Not_PER_Visible_3_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Not_PER_Visible_3_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Not_PER_Visible_3_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Not_PER_Visible_3_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Not_PER_Visible_3_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Not_PER_Visible_3_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [Not-PER-Visible-3] >>> ***/
 
@@ -2598,15 +1433,15 @@ static const ber_tlv_tag_t asn_DEF_Not_PER_Visible_3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Not_PER_Visible_3 = {
 	"Not-PER-Visible-3",
 	"Not-PER-Visible-3",
-	Not_PER_Visible_3_free,
-	Not_PER_Visible_3_print,
+	IA5String_free,
+	IA5String_print,
 	Not_PER_Visible_3_constraint,
-	Not_PER_Visible_3_decode_ber,
-	Not_PER_Visible_3_encode_der,
-	Not_PER_Visible_3_decode_xer,
-	Not_PER_Visible_3_encode_xer,
-	Not_PER_Visible_3_decode_uper,
-	Not_PER_Visible_3_encode_uper,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
+	IA5String_decode_uper,
+	IA5String_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Not_PER_Visible_3_tags_1,
 	sizeof(asn_DEF_Not_PER_Visible_3_tags_1)
@@ -2690,83 +1525,6 @@ SIZE_but_not_FROM_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using PER_Visible,
  * so here we adjust the DEF accordingly.
  */
-static void
-SIZE_but_not_FROM_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_PER_Visible.free_struct;
-	td->print_struct   = asn_DEF_PER_Visible.print_struct;
-	td->check_constraints = asn_DEF_PER_Visible.check_constraints;
-	td->ber_decoder    = asn_DEF_PER_Visible.ber_decoder;
-	td->der_encoder    = asn_DEF_PER_Visible.der_encoder;
-	td->xer_decoder    = asn_DEF_PER_Visible.xer_decoder;
-	td->xer_encoder    = asn_DEF_PER_Visible.xer_encoder;
-	td->uper_decoder   = asn_DEF_PER_Visible.uper_decoder;
-	td->uper_encoder   = asn_DEF_PER_Visible.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_PER_Visible.per_constraints;
-	td->elements       = asn_DEF_PER_Visible.elements;
-	td->elements_count = asn_DEF_PER_Visible.elements_count;
-	td->specifics      = asn_DEF_PER_Visible.specifics;
-}
-
-void
-SIZE_but_not_FROM_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	SIZE_but_not_FROM_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-SIZE_but_not_FROM_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	SIZE_but_not_FROM_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-SIZE_but_not_FROM_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	SIZE_but_not_FROM_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-SIZE_but_not_FROM_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	SIZE_but_not_FROM_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-SIZE_but_not_FROM_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	SIZE_but_not_FROM_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-SIZE_but_not_FROM_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	SIZE_but_not_FROM_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-SIZE_but_not_FROM_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	SIZE_but_not_FROM_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-SIZE_but_not_FROM_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	SIZE_but_not_FROM_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [SIZE-but-not-FROM] >>> ***/
 
@@ -2784,15 +1542,15 @@ static const ber_tlv_tag_t asn_DEF_SIZE_but_not_FROM_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_SIZE_but_not_FROM = {
 	"SIZE-but-not-FROM",
 	"SIZE-but-not-FROM",
-	SIZE_but_not_FROM_free,
-	SIZE_but_not_FROM_print,
+	IA5String_free,
+	IA5String_print,
 	SIZE_but_not_FROM_constraint,
-	SIZE_but_not_FROM_decode_ber,
-	SIZE_but_not_FROM_encode_der,
-	SIZE_but_not_FROM_decode_xer,
-	SIZE_but_not_FROM_encode_xer,
-	SIZE_but_not_FROM_decode_uper,
-	SIZE_but_not_FROM_encode_uper,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
+	IA5String_decode_uper,
+	IA5String_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SIZE_but_not_FROM_tags_1,
 	sizeof(asn_DEF_SIZE_but_not_FROM_tags_1)
@@ -2876,83 +1634,6 @@ SIZE_and_FROM_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using PER_Visible,
  * so here we adjust the DEF accordingly.
  */
-static void
-SIZE_and_FROM_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_PER_Visible.free_struct;
-	td->print_struct   = asn_DEF_PER_Visible.print_struct;
-	td->check_constraints = asn_DEF_PER_Visible.check_constraints;
-	td->ber_decoder    = asn_DEF_PER_Visible.ber_decoder;
-	td->der_encoder    = asn_DEF_PER_Visible.der_encoder;
-	td->xer_decoder    = asn_DEF_PER_Visible.xer_decoder;
-	td->xer_encoder    = asn_DEF_PER_Visible.xer_encoder;
-	td->uper_decoder   = asn_DEF_PER_Visible.uper_decoder;
-	td->uper_encoder   = asn_DEF_PER_Visible.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_PER_Visible.per_constraints;
-	td->elements       = asn_DEF_PER_Visible.elements;
-	td->elements_count = asn_DEF_PER_Visible.elements_count;
-	td->specifics      = asn_DEF_PER_Visible.specifics;
-}
-
-void
-SIZE_and_FROM_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	SIZE_and_FROM_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-SIZE_and_FROM_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	SIZE_and_FROM_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-SIZE_and_FROM_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	SIZE_and_FROM_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-SIZE_and_FROM_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	SIZE_and_FROM_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-SIZE_and_FROM_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	SIZE_and_FROM_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-SIZE_and_FROM_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	SIZE_and_FROM_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-SIZE_and_FROM_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	SIZE_and_FROM_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-SIZE_and_FROM_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	SIZE_and_FROM_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [SIZE-and-FROM] >>> ***/
 
@@ -2970,15 +1651,15 @@ static const ber_tlv_tag_t asn_DEF_SIZE_and_FROM_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_SIZE_and_FROM = {
 	"SIZE-and-FROM",
 	"SIZE-and-FROM",
-	SIZE_and_FROM_free,
-	SIZE_and_FROM_print,
+	IA5String_free,
+	IA5String_print,
 	SIZE_and_FROM_constraint,
-	SIZE_and_FROM_decode_ber,
-	SIZE_and_FROM_encode_der,
-	SIZE_and_FROM_decode_xer,
-	SIZE_and_FROM_encode_xer,
-	SIZE_and_FROM_decode_uper,
-	SIZE_and_FROM_encode_uper,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
+	IA5String_decode_uper,
+	IA5String_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SIZE_and_FROM_tags_1,
 	sizeof(asn_DEF_SIZE_and_FROM_tags_1)
@@ -3059,83 +1740,6 @@ Neither_SIZE_nor_FROM_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using PER_Visible,
  * so here we adjust the DEF accordingly.
  */
-static void
-Neither_SIZE_nor_FROM_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_PER_Visible.free_struct;
-	td->print_struct   = asn_DEF_PER_Visible.print_struct;
-	td->check_constraints = asn_DEF_PER_Visible.check_constraints;
-	td->ber_decoder    = asn_DEF_PER_Visible.ber_decoder;
-	td->der_encoder    = asn_DEF_PER_Visible.der_encoder;
-	td->xer_decoder    = asn_DEF_PER_Visible.xer_decoder;
-	td->xer_encoder    = asn_DEF_PER_Visible.xer_encoder;
-	td->uper_decoder   = asn_DEF_PER_Visible.uper_decoder;
-	td->uper_encoder   = asn_DEF_PER_Visible.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_PER_Visible.per_constraints;
-	td->elements       = asn_DEF_PER_Visible.elements;
-	td->elements_count = asn_DEF_PER_Visible.elements_count;
-	td->specifics      = asn_DEF_PER_Visible.specifics;
-}
-
-void
-Neither_SIZE_nor_FROM_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Neither_SIZE_nor_FROM_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Neither_SIZE_nor_FROM_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Neither_SIZE_nor_FROM_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Neither_SIZE_nor_FROM_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Neither_SIZE_nor_FROM_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Neither_SIZE_nor_FROM_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Neither_SIZE_nor_FROM_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Neither_SIZE_nor_FROM_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Neither_SIZE_nor_FROM_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Neither_SIZE_nor_FROM_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Neither_SIZE_nor_FROM_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Neither_SIZE_nor_FROM_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Neither_SIZE_nor_FROM_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Neither_SIZE_nor_FROM_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Neither_SIZE_nor_FROM_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [Neither-SIZE-nor-FROM] >>> ***/
 
@@ -3153,15 +1757,15 @@ static const ber_tlv_tag_t asn_DEF_Neither_SIZE_nor_FROM_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Neither_SIZE_nor_FROM = {
 	"Neither-SIZE-nor-FROM",
 	"Neither-SIZE-nor-FROM",
-	Neither_SIZE_nor_FROM_free,
-	Neither_SIZE_nor_FROM_print,
+	IA5String_free,
+	IA5String_print,
 	Neither_SIZE_nor_FROM_constraint,
-	Neither_SIZE_nor_FROM_decode_ber,
-	Neither_SIZE_nor_FROM_encode_der,
-	Neither_SIZE_nor_FROM_decode_xer,
-	Neither_SIZE_nor_FROM_encode_xer,
-	Neither_SIZE_nor_FROM_decode_uper,
-	Neither_SIZE_nor_FROM_encode_uper,
+	IA5String_decode_ber,
+	IA5String_encode_der,
+	IA5String_decode_xer,
+	IA5String_encode_xer,
+	IA5String_decode_uper,
+	IA5String_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Neither_SIZE_nor_FROM_tags_1,
 	sizeof(asn_DEF_Neither_SIZE_nor_FROM_tags_1)
@@ -3236,83 +1840,6 @@ Utf8_4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using UTF8String,
  * so here we adjust the DEF accordingly.
  */
-static void
-Utf8_4_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_UTF8String.free_struct;
-	td->print_struct   = asn_DEF_UTF8String.print_struct;
-	td->check_constraints = asn_DEF_UTF8String.check_constraints;
-	td->ber_decoder    = asn_DEF_UTF8String.ber_decoder;
-	td->der_encoder    = asn_DEF_UTF8String.der_encoder;
-	td->xer_decoder    = asn_DEF_UTF8String.xer_decoder;
-	td->xer_encoder    = asn_DEF_UTF8String.xer_encoder;
-	td->uper_decoder   = asn_DEF_UTF8String.uper_decoder;
-	td->uper_encoder   = asn_DEF_UTF8String.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_UTF8String.per_constraints;
-	td->elements       = asn_DEF_UTF8String.elements;
-	td->elements_count = asn_DEF_UTF8String.elements_count;
-	td->specifics      = asn_DEF_UTF8String.specifics;
-}
-
-void
-Utf8_4_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Utf8_4_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Utf8_4_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_4_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_4_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Utf8_4_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Utf8_4_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_4_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_4_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Utf8_4_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Utf8_4_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_4_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_4_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Utf8_4_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Utf8_4_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Utf8_4_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [Utf8-4] >>> ***/
 
@@ -3330,15 +1857,15 @@ static const ber_tlv_tag_t asn_DEF_Utf8_4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Utf8_4 = {
 	"Utf8-4",
 	"Utf8-4",
-	Utf8_4_free,
-	Utf8_4_print,
+	UTF8String_free,
+	UTF8String_print,
 	Utf8_4_constraint,
-	Utf8_4_decode_ber,
-	Utf8_4_encode_der,
-	Utf8_4_decode_xer,
-	Utf8_4_encode_xer,
-	Utf8_4_decode_uper,
-	Utf8_4_encode_uper,
+	UTF8String_decode_ber,
+	UTF8String_encode_der,
+	UTF8String_decode_xer,
+	UTF8String_encode_xer,
+	UTF8String_decode_uper,
+	UTF8String_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Utf8_4_tags_1,
 	sizeof(asn_DEF_Utf8_4_tags_1)
@@ -3441,83 +1968,6 @@ Utf8_3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using Utf8_2,
  * so here we adjust the DEF accordingly.
  */
-static void
-Utf8_3_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Utf8_2.free_struct;
-	td->print_struct   = asn_DEF_Utf8_2.print_struct;
-	td->check_constraints = asn_DEF_Utf8_2.check_constraints;
-	td->ber_decoder    = asn_DEF_Utf8_2.ber_decoder;
-	td->der_encoder    = asn_DEF_Utf8_2.der_encoder;
-	td->xer_decoder    = asn_DEF_Utf8_2.xer_decoder;
-	td->xer_encoder    = asn_DEF_Utf8_2.xer_encoder;
-	td->uper_decoder   = asn_DEF_Utf8_2.uper_decoder;
-	td->uper_encoder   = asn_DEF_Utf8_2.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Utf8_2.per_constraints;
-	td->elements       = asn_DEF_Utf8_2.elements;
-	td->elements_count = asn_DEF_Utf8_2.elements_count;
-	td->specifics      = asn_DEF_Utf8_2.specifics;
-}
-
-void
-Utf8_3_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Utf8_3_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Utf8_3_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_3_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_3_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Utf8_3_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Utf8_3_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_3_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_3_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Utf8_3_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Utf8_3_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_3_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_3_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Utf8_3_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Utf8_3_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Utf8_3_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [Utf8-3] >>> ***/
 
@@ -3535,15 +1985,15 @@ static const ber_tlv_tag_t asn_DEF_Utf8_3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Utf8_3 = {
 	"Utf8-3",
 	"Utf8-3",
-	Utf8_3_free,
-	Utf8_3_print,
+	UTF8String_free,
+	UTF8String_print,
 	Utf8_3_constraint,
-	Utf8_3_decode_ber,
-	Utf8_3_encode_der,
-	Utf8_3_decode_xer,
-	Utf8_3_encode_xer,
-	Utf8_3_decode_uper,
-	Utf8_3_encode_uper,
+	UTF8String_decode_ber,
+	UTF8String_encode_der,
+	UTF8String_decode_xer,
+	UTF8String_encode_xer,
+	UTF8String_decode_uper,
+	UTF8String_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Utf8_3_tags_1,
 	sizeof(asn_DEF_Utf8_3_tags_1)
@@ -3567,6 +2017,7 @@ typedef Utf8_1_t	 Utf8_2_t;
 
 /*** <<< FUNC-DECLS [Utf8-2] >>> ***/
 
+extern asn_per_constraints_t asn_PER_type_Utf8_2_constr_1;
 extern asn_TYPE_descriptor_t asn_DEF_Utf8_2;
 asn_struct_free_f Utf8_2_free;
 asn_struct_print_f Utf8_2_print;
@@ -3616,87 +2067,10 @@ Utf8_2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using Utf8_1,
  * so here we adjust the DEF accordingly.
  */
-static void
-Utf8_2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Utf8_1.free_struct;
-	td->print_struct   = asn_DEF_Utf8_1.print_struct;
-	td->check_constraints = asn_DEF_Utf8_1.check_constraints;
-	td->ber_decoder    = asn_DEF_Utf8_1.ber_decoder;
-	td->der_encoder    = asn_DEF_Utf8_1.der_encoder;
-	td->xer_decoder    = asn_DEF_Utf8_1.xer_decoder;
-	td->xer_encoder    = asn_DEF_Utf8_1.xer_encoder;
-	td->uper_decoder   = asn_DEF_Utf8_1.uper_decoder;
-	td->uper_encoder   = asn_DEF_Utf8_1.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Utf8_1.per_constraints;
-	td->elements       = asn_DEF_Utf8_1.elements;
-	td->elements_count = asn_DEF_Utf8_1.elements_count;
-	td->specifics      = asn_DEF_Utf8_1.specifics;
-}
-
-void
-Utf8_2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Utf8_2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Utf8_2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Utf8_2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Utf8_2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Utf8_2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Utf8_2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_2_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Utf8_2_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Utf8_2_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Utf8_2_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [Utf8-2] >>> ***/
 
-static asn_per_constraints_t asn_PER_type_Utf8_2_constr_1 GCC_NOTUSED = {
+asn_per_constraints_t asn_PER_type_Utf8_2_constr_1 GCC_NOTUSED = {
 	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
 	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
 	0, 0	/* No PER value map */
@@ -3710,15 +2084,15 @@ static const ber_tlv_tag_t asn_DEF_Utf8_2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Utf8_2 = {
 	"Utf8-2",
 	"Utf8-2",
-	Utf8_2_free,
-	Utf8_2_print,
+	UTF8String_free,
+	UTF8String_print,
 	Utf8_2_constraint,
-	Utf8_2_decode_ber,
-	Utf8_2_encode_der,
-	Utf8_2_decode_xer,
-	Utf8_2_encode_xer,
-	Utf8_2_decode_uper,
-	Utf8_2_encode_uper,
+	UTF8String_decode_ber,
+	UTF8String_encode_der,
+	UTF8String_decode_xer,
+	UTF8String_encode_xer,
+	UTF8String_decode_uper,
+	UTF8String_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Utf8_2_tags_1,
 	sizeof(asn_DEF_Utf8_2_tags_1)
@@ -3755,95 +2129,10 @@ per_type_encoder_f Utf8_1_encode_uper;
 
 /*** <<< CODE [Utf8-1] >>> ***/
 
-int
-Utf8_1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_UTF8String.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using UTF8String,
  * so here we adjust the DEF accordingly.
  */
-static void
-Utf8_1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_UTF8String.free_struct;
-	td->print_struct   = asn_DEF_UTF8String.print_struct;
-	td->check_constraints = asn_DEF_UTF8String.check_constraints;
-	td->ber_decoder    = asn_DEF_UTF8String.ber_decoder;
-	td->der_encoder    = asn_DEF_UTF8String.der_encoder;
-	td->xer_decoder    = asn_DEF_UTF8String.xer_decoder;
-	td->xer_encoder    = asn_DEF_UTF8String.xer_encoder;
-	td->uper_decoder   = asn_DEF_UTF8String.uper_decoder;
-	td->uper_encoder   = asn_DEF_UTF8String.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_UTF8String.per_constraints;
-	td->elements       = asn_DEF_UTF8String.elements;
-	td->elements_count = asn_DEF_UTF8String.elements_count;
-	td->specifics      = asn_DEF_UTF8String.specifics;
-}
-
-void
-Utf8_1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Utf8_1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Utf8_1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Utf8_1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Utf8_1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Utf8_1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Utf8_1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Utf8_1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Utf8_1_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Utf8_1_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Utf8_1_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Utf8_1_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< STAT-DEFS [Utf8-1] >>> ***/
 
@@ -3853,15 +2142,15 @@ static const ber_tlv_tag_t asn_DEF_Utf8_1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Utf8_1 = {
 	"Utf8-1",
 	"Utf8-1",
-	Utf8_1_free,
-	Utf8_1_print,
-	Utf8_1_constraint,
-	Utf8_1_decode_ber,
-	Utf8_1_encode_der,
-	Utf8_1_decode_xer,
-	Utf8_1_encode_xer,
-	Utf8_1_decode_uper,
-	Utf8_1_encode_uper,
+	UTF8String_free,
+	UTF8String_print,
+	UTF8String_constraint,
+	UTF8String_decode_ber,
+	UTF8String_encode_der,
+	UTF8String_decode_xer,
+	UTF8String_encode_xer,
+	UTF8String_decode_uper,
+	UTF8String_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Utf8_1_tags_1,
 	sizeof(asn_DEF_Utf8_1_tags_1)
@@ -3964,83 +2253,6 @@ VisibleIdentifier_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using Identifier,
  * so here we adjust the DEF accordingly.
  */
-static void
-VisibleIdentifier_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Identifier.free_struct;
-	td->print_struct   = asn_DEF_Identifier.print_struct;
-	td->check_constraints = asn_DEF_Identifier.check_constraints;
-	td->ber_decoder    = asn_DEF_Identifier.ber_decoder;
-	td->der_encoder    = asn_DEF_Identifier.der_encoder;
-	td->xer_decoder    = asn_DEF_Identifier.xer_decoder;
-	td->xer_encoder    = asn_DEF_Identifier.xer_encoder;
-	td->uper_decoder   = asn_DEF_Identifier.uper_decoder;
-	td->uper_encoder   = asn_DEF_Identifier.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Identifier.per_constraints;
-	td->elements       = asn_DEF_Identifier.elements;
-	td->elements_count = asn_DEF_Identifier.elements_count;
-	td->specifics      = asn_DEF_Identifier.specifics;
-}
-
-void
-VisibleIdentifier_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	VisibleIdentifier_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-VisibleIdentifier_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	VisibleIdentifier_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-VisibleIdentifier_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	VisibleIdentifier_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-VisibleIdentifier_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	VisibleIdentifier_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-VisibleIdentifier_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	VisibleIdentifier_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-VisibleIdentifier_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	VisibleIdentifier_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-VisibleIdentifier_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	VisibleIdentifier_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-VisibleIdentifier_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	VisibleIdentifier_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< STAT-DEFS [VisibleIdentifier] >>> ***/
 
@@ -4050,15 +2262,15 @@ static const ber_tlv_tag_t asn_DEF_VisibleIdentifier_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_VisibleIdentifier = {
 	"VisibleIdentifier",
 	"VisibleIdentifier",
-	VisibleIdentifier_free,
-	VisibleIdentifier_print,
+	VisibleString_free,
+	VisibleString_print,
 	VisibleIdentifier_constraint,
-	VisibleIdentifier_decode_ber,
-	VisibleIdentifier_encode_der,
-	VisibleIdentifier_decode_xer,
-	VisibleIdentifier_encode_xer,
-	VisibleIdentifier_decode_uper,
-	VisibleIdentifier_encode_uper,
+	VisibleString_decode_ber,
+	VisibleString_encode_der,
+	VisibleString_decode_xer,
+	VisibleString_encode_xer,
+	VisibleString_decode_uper,
+	VisibleString_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_VisibleIdentifier_tags_1,
 	sizeof(asn_DEF_VisibleIdentifier_tags_1)
@@ -4116,98 +2328,15 @@ typedef struct Sequence {
 
 /* extern asn_TYPE_descriptor_t asn_DEF_enum_c_6;	// (Use -fall-defs-global to expose) */
 extern asn_TYPE_descriptor_t asn_DEF_Sequence;
+extern asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1;
+extern asn_TYPE_member_t asn_MBR_Sequence_1[7];
 
 /*** <<< CODE [Sequence] >>> ***/
-
-static int
-enum_c_6_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_NativeEnumerated.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
 
 /*
  * This type is implemented using NativeEnumerated,
  * so here we adjust the DEF accordingly.
  */
-static void
-enum_c_6_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeEnumerated.free_struct;
-	td->print_struct   = asn_DEF_NativeEnumerated.print_struct;
-	td->check_constraints = asn_DEF_NativeEnumerated.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeEnumerated.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeEnumerated.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeEnumerated.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeEnumerated.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeEnumerated.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeEnumerated.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeEnumerated.per_constraints;
-	td->elements       = asn_DEF_NativeEnumerated.elements;
-	td->elements_count = asn_DEF_NativeEnumerated.elements_count;
-     /* td->specifics      = asn_DEF_NativeEnumerated.specifics;	// Defined explicitly */
-}
-
-static void
-enum_c_6_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	enum_c_6_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-static int
-enum_c_6_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	enum_c_6_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-static asn_dec_rval_t
-enum_c_6_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	enum_c_6_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-static asn_enc_rval_t
-enum_c_6_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	enum_c_6_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-static asn_dec_rval_t
-enum_c_6_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	enum_c_6_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-static asn_enc_rval_t
-enum_c_6_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	enum_c_6_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-static asn_dec_rval_t
-enum_c_6_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	enum_c_6_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-static asn_enc_rval_t
-enum_c_6_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	enum_c_6_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 static int
 memb_int1_c_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
@@ -4373,15 +2502,15 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_enum_c_6 = {
 	"enum-c",
 	"enum-c",
-	enum_c_6_free,
-	enum_c_6_print,
-	enum_c_6_constraint,
-	enum_c_6_decode_ber,
-	enum_c_6_encode_der,
-	enum_c_6_decode_xer,
-	enum_c_6_encode_xer,
-	enum_c_6_decode_uper,
-	enum_c_6_encode_uper,
+	NativeEnumerated_free,
+	NativeEnumerated_print,
+	NativeEnumerated_constraint,
+	NativeEnumerated_decode_ber,
+	NativeEnumerated_encode_der,
+	NativeEnumerated_decode_xer,
+	NativeEnumerated_encode_xer,
+	NativeEnumerated_decode_uper,
+	NativeEnumerated_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_enum_c_tags_6,
 	sizeof(asn_DEF_enum_c_tags_6)
@@ -4394,7 +2523,7 @@ asn_TYPE_descriptor_t asn_DEF_enum_c_6 = {
 	&asn_SPC_enum_c_specs_6	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_Sequence_1[] = {
+asn_TYPE_member_t asn_MBR_Sequence_1[] = {
 	{ ATF_POINTER, 1, offsetof(struct Sequence, int1_c),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
 		.tag_mode = 0,
@@ -4472,7 +2601,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Sequence_tag2el_1[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (10 << 2)), 4, 0, 0 }, /* enum-c */
     { (ASN_TAG_CLASS_CONTEXT | (2 << 2)), 1, 0, 0 } /* int4 */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1 = {
 	sizeof(struct Sequence),
 	offsetof(struct Sequence, _asn_ctx),
 	asn_MAP_Sequence_tag2el_1,
@@ -4619,95 +2748,10 @@ per_type_encoder_f Enum0_encode_uper;
 
 /*** <<< CODE [Enum0] >>> ***/
 
-int
-Enum0_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_NativeEnumerated.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using NativeEnumerated,
  * so here we adjust the DEF accordingly.
  */
-static void
-Enum0_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeEnumerated.free_struct;
-	td->print_struct   = asn_DEF_NativeEnumerated.print_struct;
-	td->check_constraints = asn_DEF_NativeEnumerated.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeEnumerated.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeEnumerated.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeEnumerated.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeEnumerated.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeEnumerated.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeEnumerated.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeEnumerated.per_constraints;
-	td->elements       = asn_DEF_NativeEnumerated.elements;
-	td->elements_count = asn_DEF_NativeEnumerated.elements_count;
-     /* td->specifics      = asn_DEF_NativeEnumerated.specifics;	// Defined explicitly */
-}
-
-void
-Enum0_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Enum0_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Enum0_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum0_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum0_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Enum0_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Enum0_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum0_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum0_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Enum0_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Enum0_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum0_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum0_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Enum0_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Enum0_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Enum0_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [Enum0] >>> ***/
 
@@ -4742,15 +2786,15 @@ static const ber_tlv_tag_t asn_DEF_Enum0_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Enum0 = {
 	"Enum0",
 	"Enum0",
-	Enum0_free,
-	Enum0_print,
-	Enum0_constraint,
-	Enum0_decode_ber,
-	Enum0_encode_der,
-	Enum0_decode_xer,
-	Enum0_encode_xer,
-	Enum0_decode_uper,
-	Enum0_encode_uper,
+	NativeEnumerated_free,
+	NativeEnumerated_print,
+	NativeEnumerated_constraint,
+	NativeEnumerated_decode_ber,
+	NativeEnumerated_encode_der,
+	NativeEnumerated_decode_xer,
+	NativeEnumerated_encode_xer,
+	NativeEnumerated_decode_uper,
+	NativeEnumerated_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Enum0_tags_1,
 	sizeof(asn_DEF_Enum0_tags_1)
@@ -4823,83 +2867,6 @@ Enum1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeEnumerated,
  * so here we adjust the DEF accordingly.
  */
-static void
-Enum1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeEnumerated.free_struct;
-	td->print_struct   = asn_DEF_NativeEnumerated.print_struct;
-	td->check_constraints = asn_DEF_NativeEnumerated.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeEnumerated.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeEnumerated.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeEnumerated.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeEnumerated.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeEnumerated.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeEnumerated.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeEnumerated.per_constraints;
-	td->elements       = asn_DEF_NativeEnumerated.elements;
-	td->elements_count = asn_DEF_NativeEnumerated.elements_count;
-     /* td->specifics      = asn_DEF_NativeEnumerated.specifics;	// Defined explicitly */
-}
-
-void
-Enum1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Enum1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Enum1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Enum1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Enum1_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Enum1_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Enum1_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [Enum1] >>> ***/
 
@@ -4934,15 +2901,15 @@ static const ber_tlv_tag_t asn_DEF_Enum1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Enum1 = {
 	"Enum1",
 	"Enum1",
-	Enum1_free,
-	Enum1_print,
+	NativeEnumerated_free,
+	NativeEnumerated_print,
 	Enum1_constraint,
-	Enum1_decode_ber,
-	Enum1_encode_der,
-	Enum1_decode_xer,
-	Enum1_encode_xer,
-	Enum1_decode_uper,
-	Enum1_encode_uper,
+	NativeEnumerated_decode_ber,
+	NativeEnumerated_encode_der,
+	NativeEnumerated_decode_xer,
+	NativeEnumerated_encode_xer,
+	NativeEnumerated_decode_uper,
+	NativeEnumerated_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Enum1_tags_1,
 	sizeof(asn_DEF_Enum1_tags_1)
@@ -4966,6 +2933,7 @@ typedef VisibleString_t	 Identifier_t;
 
 /*** <<< FUNC-DECLS [Identifier] >>> ***/
 
+extern asn_per_constraints_t asn_PER_type_Identifier_constr_1;
 extern asn_TYPE_descriptor_t asn_DEF_Identifier;
 asn_struct_free_f Identifier_free;
 asn_struct_print_f Identifier_print;
@@ -5055,87 +3023,10 @@ static int asn_PER_MAP_Identifier_1_c2v(unsigned int code) {
  * This type is implemented using VisibleString,
  * so here we adjust the DEF accordingly.
  */
-static void
-Identifier_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_VisibleString.free_struct;
-	td->print_struct   = asn_DEF_VisibleString.print_struct;
-	td->check_constraints = asn_DEF_VisibleString.check_constraints;
-	td->ber_decoder    = asn_DEF_VisibleString.ber_decoder;
-	td->der_encoder    = asn_DEF_VisibleString.der_encoder;
-	td->xer_decoder    = asn_DEF_VisibleString.xer_decoder;
-	td->xer_encoder    = asn_DEF_VisibleString.xer_encoder;
-	td->uper_decoder   = asn_DEF_VisibleString.uper_decoder;
-	td->uper_encoder   = asn_DEF_VisibleString.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_VisibleString.per_constraints;
-	td->elements       = asn_DEF_VisibleString.elements;
-	td->elements_count = asn_DEF_VisibleString.elements_count;
-	td->specifics      = asn_DEF_VisibleString.specifics;
-}
-
-void
-Identifier_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Identifier_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-Identifier_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Identifier_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-Identifier_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Identifier_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-Identifier_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Identifier_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-Identifier_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Identifier_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-Identifier_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Identifier_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-Identifier_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	Identifier_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-Identifier_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	Identifier_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [Identifier] >>> ***/
 
-static asn_per_constraints_t asn_PER_type_Identifier_constr_1 GCC_NOTUSED = {
+asn_per_constraints_t asn_PER_type_Identifier_constr_1 GCC_NOTUSED = {
 	{ APC_CONSTRAINED,	 6,  6,  36,  122 }	/* (36..122) */,
 	{ APC_CONSTRAINED,	 5,  5,  1,  32 }	/* (SIZE(1..32)) */,
 	asn_PER_MAP_Identifier_1_v2c,	/* Value to PER code map */
@@ -5150,15 +3041,15 @@ static const ber_tlv_tag_t asn_DEF_Identifier_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Identifier = {
 	"Identifier",
 	"Identifier",
-	Identifier_free,
-	Identifier_print,
+	VisibleString_free,
+	VisibleString_print,
 	Identifier_constraint,
-	Identifier_decode_ber,
-	Identifier_encode_der,
-	Identifier_decode_xer,
-	Identifier_encode_xer,
-	Identifier_decode_uper,
-	Identifier_encode_uper,
+	VisibleString_decode_ber,
+	VisibleString_encode_der,
+	VisibleString_decode_xer,
+	VisibleString_encode_xer,
+	VisibleString_decode_uper,
+	VisibleString_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Identifier_tags_1,
 	sizeof(asn_DEF_Identifier_tags_1)

--- a/tests/59-choice-extended-OK.asn1.-Pfwide-types
+++ b/tests/59-choice-extended-OK.asn1.-Pfwide-types
@@ -39,6 +39,8 @@ typedef struct Choice {
 /*** <<< FUNC-DECLS [Choice] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Choice;
+extern asn_CHOICE_specifics_t asn_SPC_Choice_specs_1;
+extern asn_TYPE_member_t asn_MBR_Choice_1[3];
 
 /*** <<< POST-INCLUDE [Choice] >>> ***/
 
@@ -46,7 +48,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Choice;
 
 /*** <<< STAT-DEFS [Choice] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Choice_1[] = {
+asn_TYPE_member_t asn_MBR_Choice_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Choice, choice.a),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -83,7 +85,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Choice_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 }, /* b */
     { (ASN_TAG_CLASS_CONTEXT | (2 << 2)), 2, 0, 0 } /* c */
 };
-static asn_CHOICE_specifics_t asn_SPC_Choice_specs_1 = {
+asn_CHOICE_specifics_t asn_SPC_Choice_specs_1 = {
 	sizeof(struct Choice),
 	offsetof(struct Choice, _asn_ctx),
 	offsetof(struct Choice, present),

--- a/tests/65-multi-tag-OK.asn1.-Pfnative-types
+++ b/tests/65-multi-tag-OK.asn1.-Pfnative-types
@@ -20,80 +20,10 @@ xer_type_encoder_f T1_encode_xer;
 
 /*** <<< CODE [T1] >>> ***/
 
-int
-T1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_T2.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using T2,
  * so here we adjust the DEF accordingly.
  */
-static void
-T1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_T2.free_struct;
-	td->print_struct   = asn_DEF_T2.print_struct;
-	td->check_constraints = asn_DEF_T2.check_constraints;
-	td->ber_decoder    = asn_DEF_T2.ber_decoder;
-	td->der_encoder    = asn_DEF_T2.der_encoder;
-	td->xer_decoder    = asn_DEF_T2.xer_decoder;
-	td->xer_encoder    = asn_DEF_T2.xer_encoder;
-	td->uper_decoder   = asn_DEF_T2.uper_decoder;
-	td->uper_encoder   = asn_DEF_T2.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_T2.per_constraints;
-	td->elements       = asn_DEF_T2.elements;
-	td->elements_count = asn_DEF_T2.elements_count;
-	td->specifics      = asn_DEF_T2.specifics;
-}
-
-void
-T1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	T1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-T1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	T1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-T1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	T1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-T1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-T1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	T1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-T1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [T1] >>> ***/
 
@@ -114,13 +44,13 @@ static const ber_tlv_tag_t asn_DEF_T1_all_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T1 = {
 	"T1",
 	"T1",
-	T1_free,
-	T1_print,
-	T1_constraint,
-	T1_decode_ber,
-	T1_encode_der,
-	T1_decode_xer,
-	T1_encode_xer,
+	NativeReal_free,
+	NativeReal_print,
+	NativeReal_constraint,
+	NativeReal_decode_ber,
+	NativeReal_encode_der,
+	NativeReal_decode_xer,
+	NativeReal_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T1_tags_1,
@@ -156,80 +86,10 @@ xer_type_encoder_f T2_encode_xer;
 
 /*** <<< CODE [T2] >>> ***/
 
-int
-T2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_T3.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using T3,
  * so here we adjust the DEF accordingly.
  */
-static void
-T2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_T3.free_struct;
-	td->print_struct   = asn_DEF_T3.print_struct;
-	td->check_constraints = asn_DEF_T3.check_constraints;
-	td->ber_decoder    = asn_DEF_T3.ber_decoder;
-	td->der_encoder    = asn_DEF_T3.der_encoder;
-	td->xer_decoder    = asn_DEF_T3.xer_decoder;
-	td->xer_encoder    = asn_DEF_T3.xer_encoder;
-	td->uper_decoder   = asn_DEF_T3.uper_decoder;
-	td->uper_encoder   = asn_DEF_T3.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_T3.per_constraints;
-	td->elements       = asn_DEF_T3.elements;
-	td->elements_count = asn_DEF_T3.elements_count;
-	td->specifics      = asn_DEF_T3.specifics;
-}
-
-void
-T2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	T2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-T2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	T2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-T2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	T2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-T2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-T2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	T2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-T2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [T2] >>> ***/
 
@@ -248,13 +108,13 @@ static const ber_tlv_tag_t asn_DEF_T2_all_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T2 = {
 	"T2",
 	"T2",
-	T2_free,
-	T2_print,
-	T2_constraint,
-	T2_decode_ber,
-	T2_encode_der,
-	T2_decode_xer,
-	T2_encode_xer,
+	NativeReal_free,
+	NativeReal_print,
+	NativeReal_constraint,
+	NativeReal_decode_ber,
+	NativeReal_encode_der,
+	NativeReal_decode_xer,
+	NativeReal_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T2_tags_1,
@@ -290,80 +150,10 @@ xer_type_encoder_f T3_encode_xer;
 
 /*** <<< CODE [T3] >>> ***/
 
-int
-T3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_T4.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using T4,
  * so here we adjust the DEF accordingly.
  */
-static void
-T3_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_T4.free_struct;
-	td->print_struct   = asn_DEF_T4.print_struct;
-	td->check_constraints = asn_DEF_T4.check_constraints;
-	td->ber_decoder    = asn_DEF_T4.ber_decoder;
-	td->der_encoder    = asn_DEF_T4.der_encoder;
-	td->xer_decoder    = asn_DEF_T4.xer_decoder;
-	td->xer_encoder    = asn_DEF_T4.xer_encoder;
-	td->uper_decoder   = asn_DEF_T4.uper_decoder;
-	td->uper_encoder   = asn_DEF_T4.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_T4.per_constraints;
-	td->elements       = asn_DEF_T4.elements;
-	td->elements_count = asn_DEF_T4.elements_count;
-	td->specifics      = asn_DEF_T4.specifics;
-}
-
-void
-T3_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	T3_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-T3_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	T3_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-T3_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	T3_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-T3_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T3_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-T3_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	T3_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-T3_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T3_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [T3] >>> ***/
 
@@ -380,13 +170,13 @@ static const ber_tlv_tag_t asn_DEF_T3_all_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T3 = {
 	"T3",
 	"T3",
-	T3_free,
-	T3_print,
-	T3_constraint,
-	T3_decode_ber,
-	T3_encode_der,
-	T3_decode_xer,
-	T3_encode_xer,
+	NativeReal_free,
+	NativeReal_print,
+	NativeReal_constraint,
+	NativeReal_decode_ber,
+	NativeReal_encode_der,
+	NativeReal_decode_xer,
+	NativeReal_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T3_tags_1,
@@ -422,80 +212,10 @@ xer_type_encoder_f T4_encode_xer;
 
 /*** <<< CODE [T4] >>> ***/
 
-int
-T4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_T5.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using T5,
  * so here we adjust the DEF accordingly.
  */
-static void
-T4_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_T5.free_struct;
-	td->print_struct   = asn_DEF_T5.print_struct;
-	td->check_constraints = asn_DEF_T5.check_constraints;
-	td->ber_decoder    = asn_DEF_T5.ber_decoder;
-	td->der_encoder    = asn_DEF_T5.der_encoder;
-	td->xer_decoder    = asn_DEF_T5.xer_decoder;
-	td->xer_encoder    = asn_DEF_T5.xer_encoder;
-	td->uper_decoder   = asn_DEF_T5.uper_decoder;
-	td->uper_encoder   = asn_DEF_T5.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_T5.per_constraints;
-	td->elements       = asn_DEF_T5.elements;
-	td->elements_count = asn_DEF_T5.elements_count;
-	td->specifics      = asn_DEF_T5.specifics;
-}
-
-void
-T4_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	T4_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-T4_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	T4_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-T4_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	T4_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-T4_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T4_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-T4_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	T4_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-T4_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T4_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [T4] >>> ***/
 
@@ -507,13 +227,13 @@ static const ber_tlv_tag_t asn_DEF_T4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T4 = {
 	"T4",
 	"T4",
-	T4_free,
-	T4_print,
-	T4_constraint,
-	T4_decode_ber,
-	T4_encode_der,
-	T4_decode_xer,
-	T4_encode_xer,
+	NativeReal_free,
+	NativeReal_print,
+	NativeReal_constraint,
+	NativeReal_decode_ber,
+	NativeReal_encode_der,
+	NativeReal_decode_xer,
+	NativeReal_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T4_tags_1,
@@ -549,80 +269,10 @@ xer_type_encoder_f T5_encode_xer;
 
 /*** <<< CODE [T5] >>> ***/
 
-int
-T5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_T6.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using T6,
  * so here we adjust the DEF accordingly.
  */
-static void
-T5_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_T6.free_struct;
-	td->print_struct   = asn_DEF_T6.print_struct;
-	td->check_constraints = asn_DEF_T6.check_constraints;
-	td->ber_decoder    = asn_DEF_T6.ber_decoder;
-	td->der_encoder    = asn_DEF_T6.der_encoder;
-	td->xer_decoder    = asn_DEF_T6.xer_decoder;
-	td->xer_encoder    = asn_DEF_T6.xer_encoder;
-	td->uper_decoder   = asn_DEF_T6.uper_decoder;
-	td->uper_encoder   = asn_DEF_T6.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_T6.per_constraints;
-	td->elements       = asn_DEF_T6.elements;
-	td->elements_count = asn_DEF_T6.elements_count;
-	td->specifics      = asn_DEF_T6.specifics;
-}
-
-void
-T5_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	T5_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-T5_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	T5_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-T5_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	T5_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-T5_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T5_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-T5_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	T5_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-T5_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T5_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [T5] >>> ***/
 
@@ -633,13 +283,13 @@ static const ber_tlv_tag_t asn_DEF_T5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T5 = {
 	"T5",
 	"T5",
-	T5_free,
-	T5_print,
-	T5_constraint,
-	T5_decode_ber,
-	T5_encode_der,
-	T5_decode_xer,
-	T5_encode_xer,
+	NativeReal_free,
+	NativeReal_print,
+	NativeReal_constraint,
+	NativeReal_decode_ber,
+	NativeReal_encode_der,
+	NativeReal_decode_xer,
+	NativeReal_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T5_tags_1,
@@ -675,80 +325,10 @@ xer_type_encoder_f T6_encode_xer;
 
 /*** <<< CODE [T6] >>> ***/
 
-int
-T6_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_NativeReal.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using NativeReal,
  * so here we adjust the DEF accordingly.
  */
-static void
-T6_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeReal.free_struct;
-	td->print_struct   = asn_DEF_NativeReal.print_struct;
-	td->check_constraints = asn_DEF_NativeReal.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeReal.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeReal.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeReal.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeReal.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeReal.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeReal.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeReal.per_constraints;
-	td->elements       = asn_DEF_NativeReal.elements;
-	td->elements_count = asn_DEF_NativeReal.elements_count;
-	td->specifics      = asn_DEF_NativeReal.specifics;
-}
-
-void
-T6_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	T6_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-T6_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	T6_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-T6_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	T6_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-T6_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T6_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-T6_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	T6_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-T6_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T6_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [T6] >>> ***/
 
@@ -758,13 +338,13 @@ static const ber_tlv_tag_t asn_DEF_T6_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T6 = {
 	"T6",
 	"T6",
-	T6_free,
-	T6_print,
-	T6_constraint,
-	T6_decode_ber,
-	T6_encode_der,
-	T6_decode_xer,
-	T6_encode_xer,
+	NativeReal_free,
+	NativeReal_print,
+	NativeReal_constraint,
+	NativeReal_decode_ber,
+	NativeReal_encode_der,
+	NativeReal_decode_xer,
+	NativeReal_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T6_tags_1,
@@ -800,80 +380,10 @@ xer_type_encoder_f T_encode_xer;
 
 /*** <<< CODE [T] >>> ***/
 
-int
-T_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_Ts.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using Ts,
  * so here we adjust the DEF accordingly.
  */
-static void
-T_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Ts.free_struct;
-	td->print_struct   = asn_DEF_Ts.print_struct;
-	td->check_constraints = asn_DEF_Ts.check_constraints;
-	td->ber_decoder    = asn_DEF_Ts.ber_decoder;
-	td->der_encoder    = asn_DEF_Ts.der_encoder;
-	td->xer_decoder    = asn_DEF_Ts.xer_decoder;
-	td->xer_encoder    = asn_DEF_Ts.xer_encoder;
-	td->uper_decoder   = asn_DEF_Ts.uper_decoder;
-	td->uper_encoder   = asn_DEF_Ts.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Ts.per_constraints;
-	td->elements       = asn_DEF_Ts.elements;
-	td->elements_count = asn_DEF_Ts.elements_count;
-	td->specifics      = asn_DEF_Ts.specifics;
-}
-
-void
-T_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	T_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-T_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-T_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-T_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-T_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-T_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [T] >>> ***/
 
@@ -885,13 +395,13 @@ static const ber_tlv_tag_t asn_DEF_T_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	T_free,
-	T_print,
-	T_constraint,
-	T_decode_ber,
-	T_encode_der,
-	T_decode_xer,
-	T_encode_xer,
+	SEQUENCE_free,
+	SEQUENCE_print,
+	SEQUENCE_constraint,
+	SEQUENCE_decode_ber,
+	SEQUENCE_encode_der,
+	SEQUENCE_decode_xer,
+	SEQUENCE_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
@@ -901,8 +411,9 @@ asn_TYPE_descriptor_t asn_DEF_T = {
 	sizeof(asn_DEF_T_tags_1)
 		/sizeof(asn_DEF_T_tags_1[0]), /* 3 */
 	0,	/* No PER visible constraints */
-	0, 0,	/* Defined elsewhere */
-	0	/* No specifics */
+	asn_MBR_Ts_1,
+	3,	/* Elements count */
+	&asn_SPC_Ts_specs_1	/* Additional specs */
 };
 
 
@@ -926,10 +437,12 @@ typedef struct Ts {
 /*** <<< FUNC-DECLS [Ts] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Ts;
+extern asn_SEQUENCE_specifics_t asn_SPC_Ts_specs_1;
+extern asn_TYPE_member_t asn_MBR_Ts_1[3];
 
 /*** <<< STAT-DEFS [Ts] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Ts_1[] = {
+asn_TYPE_member_t asn_MBR_Ts_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Ts, m1),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (1 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -967,7 +480,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Ts_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (2 << 2)), 1, 0, 0 }, /* m2 */
     { (ASN_TAG_CLASS_CONTEXT | (3 << 2)), 2, 0, 0 } /* m3 */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Ts_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Ts_specs_1 = {
 	sizeof(struct Ts),
 	offsetof(struct Ts, _asn_ctx),
 	asn_MAP_Ts_tag2el_1,

--- a/tests/65-multi-tag-OK.asn1.-Pfwide-types
+++ b/tests/65-multi-tag-OK.asn1.-Pfwide-types
@@ -20,80 +20,10 @@ xer_type_encoder_f T1_encode_xer;
 
 /*** <<< CODE [T1] >>> ***/
 
-int
-T1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_T2.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using T2,
  * so here we adjust the DEF accordingly.
  */
-static void
-T1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_T2.free_struct;
-	td->print_struct   = asn_DEF_T2.print_struct;
-	td->check_constraints = asn_DEF_T2.check_constraints;
-	td->ber_decoder    = asn_DEF_T2.ber_decoder;
-	td->der_encoder    = asn_DEF_T2.der_encoder;
-	td->xer_decoder    = asn_DEF_T2.xer_decoder;
-	td->xer_encoder    = asn_DEF_T2.xer_encoder;
-	td->uper_decoder   = asn_DEF_T2.uper_decoder;
-	td->uper_encoder   = asn_DEF_T2.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_T2.per_constraints;
-	td->elements       = asn_DEF_T2.elements;
-	td->elements_count = asn_DEF_T2.elements_count;
-	td->specifics      = asn_DEF_T2.specifics;
-}
-
-void
-T1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	T1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-T1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	T1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-T1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	T1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-T1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-T1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	T1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-T1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [T1] >>> ***/
 
@@ -114,13 +44,13 @@ static const ber_tlv_tag_t asn_DEF_T1_all_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T1 = {
 	"T1",
 	"T1",
-	T1_free,
-	T1_print,
-	T1_constraint,
-	T1_decode_ber,
-	T1_encode_der,
-	T1_decode_xer,
-	T1_encode_xer,
+	REAL_free,
+	REAL_print,
+	REAL_constraint,
+	REAL_decode_ber,
+	REAL_encode_der,
+	REAL_decode_xer,
+	REAL_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T1_tags_1,
@@ -156,80 +86,10 @@ xer_type_encoder_f T2_encode_xer;
 
 /*** <<< CODE [T2] >>> ***/
 
-int
-T2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_T3.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using T3,
  * so here we adjust the DEF accordingly.
  */
-static void
-T2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_T3.free_struct;
-	td->print_struct   = asn_DEF_T3.print_struct;
-	td->check_constraints = asn_DEF_T3.check_constraints;
-	td->ber_decoder    = asn_DEF_T3.ber_decoder;
-	td->der_encoder    = asn_DEF_T3.der_encoder;
-	td->xer_decoder    = asn_DEF_T3.xer_decoder;
-	td->xer_encoder    = asn_DEF_T3.xer_encoder;
-	td->uper_decoder   = asn_DEF_T3.uper_decoder;
-	td->uper_encoder   = asn_DEF_T3.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_T3.per_constraints;
-	td->elements       = asn_DEF_T3.elements;
-	td->elements_count = asn_DEF_T3.elements_count;
-	td->specifics      = asn_DEF_T3.specifics;
-}
-
-void
-T2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	T2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-T2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	T2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-T2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	T2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-T2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-T2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	T2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-T2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [T2] >>> ***/
 
@@ -248,13 +108,13 @@ static const ber_tlv_tag_t asn_DEF_T2_all_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T2 = {
 	"T2",
 	"T2",
-	T2_free,
-	T2_print,
-	T2_constraint,
-	T2_decode_ber,
-	T2_encode_der,
-	T2_decode_xer,
-	T2_encode_xer,
+	REAL_free,
+	REAL_print,
+	REAL_constraint,
+	REAL_decode_ber,
+	REAL_encode_der,
+	REAL_decode_xer,
+	REAL_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T2_tags_1,
@@ -290,80 +150,10 @@ xer_type_encoder_f T3_encode_xer;
 
 /*** <<< CODE [T3] >>> ***/
 
-int
-T3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_T4.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using T4,
  * so here we adjust the DEF accordingly.
  */
-static void
-T3_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_T4.free_struct;
-	td->print_struct   = asn_DEF_T4.print_struct;
-	td->check_constraints = asn_DEF_T4.check_constraints;
-	td->ber_decoder    = asn_DEF_T4.ber_decoder;
-	td->der_encoder    = asn_DEF_T4.der_encoder;
-	td->xer_decoder    = asn_DEF_T4.xer_decoder;
-	td->xer_encoder    = asn_DEF_T4.xer_encoder;
-	td->uper_decoder   = asn_DEF_T4.uper_decoder;
-	td->uper_encoder   = asn_DEF_T4.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_T4.per_constraints;
-	td->elements       = asn_DEF_T4.elements;
-	td->elements_count = asn_DEF_T4.elements_count;
-	td->specifics      = asn_DEF_T4.specifics;
-}
-
-void
-T3_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	T3_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-T3_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	T3_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-T3_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	T3_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-T3_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T3_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-T3_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	T3_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-T3_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T3_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [T3] >>> ***/
 
@@ -380,13 +170,13 @@ static const ber_tlv_tag_t asn_DEF_T3_all_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T3 = {
 	"T3",
 	"T3",
-	T3_free,
-	T3_print,
-	T3_constraint,
-	T3_decode_ber,
-	T3_encode_der,
-	T3_decode_xer,
-	T3_encode_xer,
+	REAL_free,
+	REAL_print,
+	REAL_constraint,
+	REAL_decode_ber,
+	REAL_encode_der,
+	REAL_decode_xer,
+	REAL_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T3_tags_1,
@@ -422,80 +212,10 @@ xer_type_encoder_f T4_encode_xer;
 
 /*** <<< CODE [T4] >>> ***/
 
-int
-T4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_T5.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using T5,
  * so here we adjust the DEF accordingly.
  */
-static void
-T4_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_T5.free_struct;
-	td->print_struct   = asn_DEF_T5.print_struct;
-	td->check_constraints = asn_DEF_T5.check_constraints;
-	td->ber_decoder    = asn_DEF_T5.ber_decoder;
-	td->der_encoder    = asn_DEF_T5.der_encoder;
-	td->xer_decoder    = asn_DEF_T5.xer_decoder;
-	td->xer_encoder    = asn_DEF_T5.xer_encoder;
-	td->uper_decoder   = asn_DEF_T5.uper_decoder;
-	td->uper_encoder   = asn_DEF_T5.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_T5.per_constraints;
-	td->elements       = asn_DEF_T5.elements;
-	td->elements_count = asn_DEF_T5.elements_count;
-	td->specifics      = asn_DEF_T5.specifics;
-}
-
-void
-T4_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	T4_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-T4_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	T4_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-T4_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	T4_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-T4_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T4_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-T4_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	T4_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-T4_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T4_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [T4] >>> ***/
 
@@ -507,13 +227,13 @@ static const ber_tlv_tag_t asn_DEF_T4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T4 = {
 	"T4",
 	"T4",
-	T4_free,
-	T4_print,
-	T4_constraint,
-	T4_decode_ber,
-	T4_encode_der,
-	T4_decode_xer,
-	T4_encode_xer,
+	REAL_free,
+	REAL_print,
+	REAL_constraint,
+	REAL_decode_ber,
+	REAL_encode_der,
+	REAL_decode_xer,
+	REAL_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T4_tags_1,
@@ -549,80 +269,10 @@ xer_type_encoder_f T5_encode_xer;
 
 /*** <<< CODE [T5] >>> ***/
 
-int
-T5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_T6.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using T6,
  * so here we adjust the DEF accordingly.
  */
-static void
-T5_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_T6.free_struct;
-	td->print_struct   = asn_DEF_T6.print_struct;
-	td->check_constraints = asn_DEF_T6.check_constraints;
-	td->ber_decoder    = asn_DEF_T6.ber_decoder;
-	td->der_encoder    = asn_DEF_T6.der_encoder;
-	td->xer_decoder    = asn_DEF_T6.xer_decoder;
-	td->xer_encoder    = asn_DEF_T6.xer_encoder;
-	td->uper_decoder   = asn_DEF_T6.uper_decoder;
-	td->uper_encoder   = asn_DEF_T6.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_T6.per_constraints;
-	td->elements       = asn_DEF_T6.elements;
-	td->elements_count = asn_DEF_T6.elements_count;
-	td->specifics      = asn_DEF_T6.specifics;
-}
-
-void
-T5_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	T5_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-T5_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	T5_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-T5_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	T5_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-T5_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T5_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-T5_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	T5_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-T5_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T5_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [T5] >>> ***/
 
@@ -633,13 +283,13 @@ static const ber_tlv_tag_t asn_DEF_T5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T5 = {
 	"T5",
 	"T5",
-	T5_free,
-	T5_print,
-	T5_constraint,
-	T5_decode_ber,
-	T5_encode_der,
-	T5_decode_xer,
-	T5_encode_xer,
+	REAL_free,
+	REAL_print,
+	REAL_constraint,
+	REAL_decode_ber,
+	REAL_encode_der,
+	REAL_decode_xer,
+	REAL_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T5_tags_1,
@@ -675,80 +325,10 @@ xer_type_encoder_f T6_encode_xer;
 
 /*** <<< CODE [T6] >>> ***/
 
-int
-T6_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_REAL.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using REAL,
  * so here we adjust the DEF accordingly.
  */
-static void
-T6_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_REAL.free_struct;
-	td->print_struct   = asn_DEF_REAL.print_struct;
-	td->check_constraints = asn_DEF_REAL.check_constraints;
-	td->ber_decoder    = asn_DEF_REAL.ber_decoder;
-	td->der_encoder    = asn_DEF_REAL.der_encoder;
-	td->xer_decoder    = asn_DEF_REAL.xer_decoder;
-	td->xer_encoder    = asn_DEF_REAL.xer_encoder;
-	td->uper_decoder   = asn_DEF_REAL.uper_decoder;
-	td->uper_encoder   = asn_DEF_REAL.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_REAL.per_constraints;
-	td->elements       = asn_DEF_REAL.elements;
-	td->elements_count = asn_DEF_REAL.elements_count;
-	td->specifics      = asn_DEF_REAL.specifics;
-}
-
-void
-T6_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	T6_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-T6_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	T6_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-T6_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	T6_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-T6_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T6_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-T6_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	T6_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-T6_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T6_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [T6] >>> ***/
 
@@ -758,13 +338,13 @@ static const ber_tlv_tag_t asn_DEF_T6_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T6 = {
 	"T6",
 	"T6",
-	T6_free,
-	T6_print,
-	T6_constraint,
-	T6_decode_ber,
-	T6_encode_der,
-	T6_decode_xer,
-	T6_encode_xer,
+	REAL_free,
+	REAL_print,
+	REAL_constraint,
+	REAL_decode_ber,
+	REAL_encode_der,
+	REAL_decode_xer,
+	REAL_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T6_tags_1,
@@ -800,80 +380,10 @@ xer_type_encoder_f T_encode_xer;
 
 /*** <<< CODE [T] >>> ***/
 
-int
-T_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_Ts.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using Ts,
  * so here we adjust the DEF accordingly.
  */
-static void
-T_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Ts.free_struct;
-	td->print_struct   = asn_DEF_Ts.print_struct;
-	td->check_constraints = asn_DEF_Ts.check_constraints;
-	td->ber_decoder    = asn_DEF_Ts.ber_decoder;
-	td->der_encoder    = asn_DEF_Ts.der_encoder;
-	td->xer_decoder    = asn_DEF_Ts.xer_decoder;
-	td->xer_encoder    = asn_DEF_Ts.xer_encoder;
-	td->uper_decoder   = asn_DEF_Ts.uper_decoder;
-	td->uper_encoder   = asn_DEF_Ts.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Ts.per_constraints;
-	td->elements       = asn_DEF_Ts.elements;
-	td->elements_count = asn_DEF_Ts.elements_count;
-	td->specifics      = asn_DEF_Ts.specifics;
-}
-
-void
-T_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	T_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-T_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-T_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-T_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-T_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-T_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [T] >>> ***/
 
@@ -885,13 +395,13 @@ static const ber_tlv_tag_t asn_DEF_T_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	T_free,
-	T_print,
-	T_constraint,
-	T_decode_ber,
-	T_encode_der,
-	T_decode_xer,
-	T_encode_xer,
+	SEQUENCE_free,
+	SEQUENCE_print,
+	SEQUENCE_constraint,
+	SEQUENCE_decode_ber,
+	SEQUENCE_encode_der,
+	SEQUENCE_decode_xer,
+	SEQUENCE_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
@@ -901,8 +411,9 @@ asn_TYPE_descriptor_t asn_DEF_T = {
 	sizeof(asn_DEF_T_tags_1)
 		/sizeof(asn_DEF_T_tags_1[0]), /* 3 */
 	0,	/* No PER visible constraints */
-	0, 0,	/* Defined elsewhere */
-	0	/* No specifics */
+	asn_MBR_Ts_1,
+	3,	/* Elements count */
+	&asn_SPC_Ts_specs_1	/* Additional specs */
 };
 
 
@@ -926,10 +437,12 @@ typedef struct Ts {
 /*** <<< FUNC-DECLS [Ts] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Ts;
+extern asn_SEQUENCE_specifics_t asn_SPC_Ts_specs_1;
+extern asn_TYPE_member_t asn_MBR_Ts_1[3];
 
 /*** <<< STAT-DEFS [Ts] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Ts_1[] = {
+asn_TYPE_member_t asn_MBR_Ts_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Ts, m1),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (1 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -967,7 +480,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Ts_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (2 << 2)), 1, 0, 0 }, /* m2 */
     { (ASN_TAG_CLASS_CONTEXT | (3 << 2)), 2, 0, 0 } /* m3 */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Ts_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Ts_specs_1 = {
 	sizeof(struct Ts),
 	offsetof(struct Ts, _asn_ctx),
 	asn_MAP_Ts_tag2el_1,

--- a/tests/66-ref-simple-OK.asn1.-Pfwide-types
+++ b/tests/66-ref-simple-OK.asn1.-Pfwide-types
@@ -83,6 +83,7 @@ typedef ENUMERATED_t	 SimpleType_t;
 /*** <<< FUNC-DECLS [SimpleType] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_SimpleType;
+extern asn_INTEGER_specifics_t asn_SPC_SimpleType_specs_1;
 asn_struct_free_f SimpleType_free;
 asn_struct_print_f SimpleType_print;
 asn_constr_check_f SimpleType_constraint;
@@ -93,80 +94,10 @@ xer_type_encoder_f SimpleType_encode_xer;
 
 /*** <<< CODE [SimpleType] >>> ***/
 
-int
-SimpleType_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using ENUMERATED,
  * so here we adjust the DEF accordingly.
  */
-static void
-SimpleType_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_ENUMERATED.free_struct;
-	td->print_struct   = asn_DEF_ENUMERATED.print_struct;
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	td->ber_decoder    = asn_DEF_ENUMERATED.ber_decoder;
-	td->der_encoder    = asn_DEF_ENUMERATED.der_encoder;
-	td->xer_decoder    = asn_DEF_ENUMERATED.xer_decoder;
-	td->xer_encoder    = asn_DEF_ENUMERATED.xer_encoder;
-	td->uper_decoder   = asn_DEF_ENUMERATED.uper_decoder;
-	td->uper_encoder   = asn_DEF_ENUMERATED.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_ENUMERATED.per_constraints;
-	td->elements       = asn_DEF_ENUMERATED.elements;
-	td->elements_count = asn_DEF_ENUMERATED.elements_count;
-     /* td->specifics      = asn_DEF_ENUMERATED.specifics;	// Defined explicitly */
-}
-
-void
-SimpleType_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	SimpleType_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-SimpleType_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	SimpleType_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-SimpleType_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	SimpleType_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-SimpleType_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	SimpleType_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-SimpleType_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	SimpleType_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-SimpleType_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	SimpleType_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [SimpleType] >>> ***/
 
@@ -180,7 +111,7 @@ static const unsigned int asn_MAP_SimpleType_enum2value_1[] = {
 	2,	/* three(2) */
 	1	/* two(1) */
 };
-static const asn_INTEGER_specifics_t asn_SPC_SimpleType_specs_1 = {
+const asn_INTEGER_specifics_t asn_SPC_SimpleType_specs_1 = {
 	asn_MAP_SimpleType_value2enum_1,	/* "tag" => N; sorted by tag */
 	asn_MAP_SimpleType_enum2value_1,	/* N => "tag"; sorted by N */
 	3,	/* Number of elements in the maps */
@@ -195,13 +126,13 @@ static const ber_tlv_tag_t asn_DEF_SimpleType_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_SimpleType = {
 	"SimpleType",
 	"SimpleType",
-	SimpleType_free,
-	SimpleType_print,
-	SimpleType_constraint,
-	SimpleType_decode_ber,
-	SimpleType_encode_der,
-	SimpleType_decode_xer,
-	SimpleType_encode_xer,
+	ENUMERATED_free,
+	ENUMERATED_print,
+	ENUMERATED_constraint,
+	ENUMERATED_decode_ber,
+	ENUMERATED_encode_der,
+	ENUMERATED_decode_xer,
+	ENUMERATED_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SimpleType_tags_1,

--- a/tests/69-reserved-words-OK.asn1.-Pfwide-types
+++ b/tests/69-reserved-words-OK.asn1.-Pfwide-types
@@ -81,7 +81,8 @@ static const ber_tlv_tag_t asn_DEF_class_tags_4[] = {
 static const uint8_t asn_MAP_class_mmap_4[(0 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	0
 };
-static asn_SET_specifics_t asn_SPC_class_specs_4 = {
+static 
+asn_SET_specifics_t asn_SPC_class_specs_4 = {
 	sizeof(struct Class),
 	offsetof(struct Class, _asn_ctx),
 	offsetof(struct Class, _presence_map),

--- a/tests/70-xer-test-OK.asn1.-Pfwide-types
+++ b/tests/70-xer-test-OK.asn1.-Pfwide-types
@@ -290,6 +290,8 @@ typedef struct Sequence {
 /*** <<< FUNC-DECLS [Sequence] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Sequence;
+extern asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1;
+extern asn_TYPE_member_t asn_MBR_Sequence_1[4];
 
 /*** <<< POST-INCLUDE [Sequence] >>> ***/
 
@@ -297,7 +299,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Sequence;
 
 /*** <<< STAT-DEFS [Sequence] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Sequence_1[] = {
+asn_TYPE_member_t asn_MBR_Sequence_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Sequence, integer),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -344,7 +346,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Sequence_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (2 << 2)), 2, 0, 0 }, /* bits */
     { (ASN_TAG_CLASS_CONTEXT | (3 << 2)), 3, 0, 0 } /* string */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1 = {
 	sizeof(struct Sequence),
 	offsetof(struct Sequence, _asn_ctx),
 	asn_MAP_Sequence_tag2el_1,
@@ -412,10 +414,12 @@ typedef struct Set {
 /*** <<< FUNC-DECLS [Set] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Set;
+extern asn_SET_specifics_t asn_SPC_Set_specs_1;
+extern asn_TYPE_member_t asn_MBR_Set_1[2];
 
 /*** <<< STAT-DEFS [Set] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Set_1[] = {
+asn_TYPE_member_t asn_MBR_Set_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Set, roid),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -445,7 +449,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Set_tag2el_1[] = {
 static const uint8_t asn_MAP_Set_mmap_1[(2 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	(1 << 7) | (0 << 6)
 };
-static asn_SET_specifics_t asn_SPC_Set_specs_1 = {
+asn_SET_specifics_t asn_SPC_Set_specs_1 = {
 	sizeof(struct Set),
 	offsetof(struct Set, _asn_ctx),
 	offsetof(struct Set, _presence_map),
@@ -524,83 +528,15 @@ typedef struct ExtensibleSet {
 
 /* extern asn_TYPE_descriptor_t asn_DEF_enum_4;	// (Use -fall-defs-global to expose) */
 extern asn_TYPE_descriptor_t asn_DEF_ExtensibleSet;
+extern asn_SET_specifics_t asn_SPC_ExtensibleSet_specs_1;
+extern asn_TYPE_member_t asn_MBR_ExtensibleSet_1[2];
 
 /*** <<< CODE [ExtensibleSet] >>> ***/
-
-static int
-enum_4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
 
 /*
  * This type is implemented using ENUMERATED,
  * so here we adjust the DEF accordingly.
  */
-static void
-enum_4_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_ENUMERATED.free_struct;
-	td->print_struct   = asn_DEF_ENUMERATED.print_struct;
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	td->ber_decoder    = asn_DEF_ENUMERATED.ber_decoder;
-	td->der_encoder    = asn_DEF_ENUMERATED.der_encoder;
-	td->xer_decoder    = asn_DEF_ENUMERATED.xer_decoder;
-	td->xer_encoder    = asn_DEF_ENUMERATED.xer_encoder;
-	td->uper_decoder   = asn_DEF_ENUMERATED.uper_decoder;
-	td->uper_encoder   = asn_DEF_ENUMERATED.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_ENUMERATED.per_constraints;
-	td->elements       = asn_DEF_ENUMERATED.elements;
-	td->elements_count = asn_DEF_ENUMERATED.elements_count;
-     /* td->specifics      = asn_DEF_ENUMERATED.specifics;	// Defined explicitly */
-}
-
-static void
-enum_4_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	enum_4_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-static int
-enum_4_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	enum_4_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-static asn_dec_rval_t
-enum_4_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	enum_4_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-static asn_enc_rval_t
-enum_4_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	enum_4_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-static asn_dec_rval_t
-enum_4_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	enum_4_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-static asn_enc_rval_t
-enum_4_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	enum_4_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [ExtensibleSet] >>> ***/
 
@@ -629,13 +565,13 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_enum_4 = {
 	"enum",
 	"enum",
-	enum_4_free,
-	enum_4_print,
-	enum_4_constraint,
-	enum_4_decode_ber,
-	enum_4_encode_der,
-	enum_4_decode_xer,
-	enum_4_encode_xer,
+	ENUMERATED_free,
+	ENUMERATED_print,
+	ENUMERATED_constraint,
+	ENUMERATED_decode_ber,
+	ENUMERATED_encode_der,
+	ENUMERATED_decode_xer,
+	ENUMERATED_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_enum_tags_4,
@@ -649,7 +585,7 @@ asn_TYPE_descriptor_t asn_DEF_enum_4 = {
 	&asn_SPC_enum_specs_4	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_ExtensibleSet_1[] = {
+asn_TYPE_member_t asn_MBR_ExtensibleSet_1[] = {
 	{ ATF_POINTER, 2, offsetof(struct ExtensibleSet, string),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -679,7 +615,7 @@ static const asn_TYPE_tag2member_t asn_MAP_ExtensibleSet_tag2el_1[] = {
 static const uint8_t asn_MAP_ExtensibleSet_mmap_1[(2 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	(0 << 7) | (0 << 6)
 };
-static asn_SET_specifics_t asn_SPC_ExtensibleSet_specs_1 = {
+asn_SET_specifics_t asn_SPC_ExtensibleSet_specs_1 = {
 	sizeof(struct ExtensibleSet),
 	offsetof(struct ExtensibleSet, _asn_ctx),
 	offsetof(struct ExtensibleSet, _presence_map),
@@ -740,10 +676,12 @@ typedef struct ExtensibleSequence {
 /*** <<< FUNC-DECLS [ExtensibleSequence] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_ExtensibleSequence;
+extern asn_SEQUENCE_specifics_t asn_SPC_ExtensibleSequence_specs_1;
+extern asn_TYPE_member_t asn_MBR_ExtensibleSequence_1[3];
 
 /*** <<< STAT-DEFS [ExtensibleSequence] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_ExtensibleSequence_1[] = {
+asn_TYPE_member_t asn_MBR_ExtensibleSequence_1[] = {
 	{ ATF_POINTER, 3, offsetof(struct ExtensibleSequence, string),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -780,7 +718,7 @@ static const asn_TYPE_tag2member_t asn_MAP_ExtensibleSequence_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 }, /* integer */
     { (ASN_TAG_CLASS_CONTEXT | (2 << 2)), 2, 0, 0 } /* gtime */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_ExtensibleSequence_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_ExtensibleSequence_specs_1 = {
 	sizeof(struct ExtensibleSequence),
 	offsetof(struct ExtensibleSequence, _asn_ctx),
 	asn_MAP_ExtensibleSequence_tag2el_1,
@@ -837,10 +775,12 @@ typedef struct ExtensibleSequence2 {
 /*** <<< FUNC-DECLS [ExtensibleSequence2] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_ExtensibleSequence2;
+extern asn_SEQUENCE_specifics_t asn_SPC_ExtensibleSequence2_specs_1;
+extern asn_TYPE_member_t asn_MBR_ExtensibleSequence2_1[2];
 
 /*** <<< STAT-DEFS [ExtensibleSequence2] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_ExtensibleSequence2_1[] = {
+asn_TYPE_member_t asn_MBR_ExtensibleSequence2_1[] = {
 	{ ATF_POINTER, 2, offsetof(struct ExtensibleSequence2, string),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -867,7 +807,7 @@ static const asn_TYPE_tag2member_t asn_MAP_ExtensibleSequence2_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* string */
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 } /* integer */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_ExtensibleSequence2_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_ExtensibleSequence2_specs_1 = {
 	sizeof(struct ExtensibleSequence2),
 	offsetof(struct ExtensibleSequence2, _asn_ctx),
 	asn_MAP_ExtensibleSequence2_tag2el_1,
@@ -919,10 +859,12 @@ typedef struct SetOfNULL {
 /*** <<< FUNC-DECLS [SetOfNULL] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_SetOfNULL;
+extern asn_SET_OF_specifics_t asn_SPC_SetOfNULL_specs_1;
+extern asn_TYPE_member_t asn_MBR_SetOfNULL_1[1];
 
 /*** <<< STAT-DEFS [SetOfNULL] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_SetOfNULL_1[] = {
+asn_TYPE_member_t asn_MBR_SetOfNULL_1[] = {
 	{ ATF_POINTER, 0, 0,
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (5 << 2)),
 		.tag_mode = 0,
@@ -936,7 +878,7 @@ static asn_TYPE_member_t asn_MBR_SetOfNULL_1[] = {
 static const ber_tlv_tag_t asn_DEF_SetOfNULL_tags_1[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (17 << 2))
 };
-static asn_SET_OF_specifics_t asn_SPC_SetOfNULL_specs_1 = {
+asn_SET_OF_specifics_t asn_SPC_SetOfNULL_specs_1 = {
 	sizeof(struct SetOfNULL),
 	offsetof(struct SetOfNULL, _asn_ctx),
 	1,	/* XER encoding is XMLValueList */
@@ -984,10 +926,12 @@ typedef struct SetOfREAL {
 /*** <<< FUNC-DECLS [SetOfREAL] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_SetOfREAL;
+extern asn_SET_OF_specifics_t asn_SPC_SetOfREAL_specs_1;
+extern asn_TYPE_member_t asn_MBR_SetOfREAL_1[1];
 
 /*** <<< STAT-DEFS [SetOfREAL] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_SetOfREAL_1[] = {
+asn_TYPE_member_t asn_MBR_SetOfREAL_1[] = {
 	{ ATF_POINTER, 0, 0,
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (9 << 2)),
 		.tag_mode = 0,
@@ -1001,7 +945,7 @@ static asn_TYPE_member_t asn_MBR_SetOfREAL_1[] = {
 static const ber_tlv_tag_t asn_DEF_SetOfREAL_tags_1[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (17 << 2))
 };
-static asn_SET_OF_specifics_t asn_SPC_SetOfREAL_specs_1 = {
+asn_SET_OF_specifics_t asn_SPC_SetOfREAL_specs_1 = {
 	sizeof(struct SetOfREAL),
 	offsetof(struct SetOfREAL, _asn_ctx),
 	0,	/* XER encoding is XMLDelimitedItemList */
@@ -1057,83 +1001,15 @@ typedef struct SetOfEnums {
 
 /* extern asn_TYPE_descriptor_t asn_DEF_Member_2;	// (Use -fall-defs-global to expose) */
 extern asn_TYPE_descriptor_t asn_DEF_SetOfEnums;
+extern asn_SET_OF_specifics_t asn_SPC_SetOfEnums_specs_1;
+extern asn_TYPE_member_t asn_MBR_SetOfEnums_1[1];
 
 /*** <<< CODE [SetOfEnums] >>> ***/
-
-static int
-Member_2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
 
 /*
  * This type is implemented using ENUMERATED,
  * so here we adjust the DEF accordingly.
  */
-static void
-Member_2_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_ENUMERATED.free_struct;
-	td->print_struct   = asn_DEF_ENUMERATED.print_struct;
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	td->ber_decoder    = asn_DEF_ENUMERATED.ber_decoder;
-	td->der_encoder    = asn_DEF_ENUMERATED.der_encoder;
-	td->xer_decoder    = asn_DEF_ENUMERATED.xer_decoder;
-	td->xer_encoder    = asn_DEF_ENUMERATED.xer_encoder;
-	td->uper_decoder   = asn_DEF_ENUMERATED.uper_decoder;
-	td->uper_encoder   = asn_DEF_ENUMERATED.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_ENUMERATED.per_constraints;
-	td->elements       = asn_DEF_ENUMERATED.elements;
-	td->elements_count = asn_DEF_ENUMERATED.elements_count;
-     /* td->specifics      = asn_DEF_ENUMERATED.specifics;	// Defined explicitly */
-}
-
-static void
-Member_2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	Member_2_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-static int
-Member_2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	Member_2_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-static asn_dec_rval_t
-Member_2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	Member_2_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-static asn_enc_rval_t
-Member_2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Member_2_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-static asn_dec_rval_t
-Member_2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	Member_2_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-static asn_enc_rval_t
-Member_2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	Member_2_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [SetOfEnums] >>> ***/
 
@@ -1161,13 +1037,13 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_Member_2 = {
 	"ENUMERATED",
 	"ENUMERATED",
-	Member_2_free,
-	Member_2_print,
-	Member_2_constraint,
-	Member_2_decode_ber,
-	Member_2_encode_der,
-	Member_2_decode_xer,
-	Member_2_encode_xer,
+	ENUMERATED_free,
+	ENUMERATED_print,
+	ENUMERATED_constraint,
+	ENUMERATED_decode_ber,
+	ENUMERATED_encode_der,
+	ENUMERATED_decode_xer,
+	ENUMERATED_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Member_tags_2,
@@ -1181,7 +1057,7 @@ asn_TYPE_descriptor_t asn_DEF_Member_2 = {
 	&asn_SPC_Member_specs_2	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_SetOfEnums_1[] = {
+asn_TYPE_member_t asn_MBR_SetOfEnums_1[] = {
 	{ ATF_POINTER, 0, 0,
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (10 << 2)),
 		.tag_mode = 0,
@@ -1195,7 +1071,7 @@ static asn_TYPE_member_t asn_MBR_SetOfEnums_1[] = {
 static const ber_tlv_tag_t asn_DEF_SetOfEnums_tags_1[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (17 << 2))
 };
-static asn_SET_OF_specifics_t asn_SPC_SetOfEnums_specs_1 = {
+asn_SET_OF_specifics_t asn_SPC_SetOfEnums_specs_1 = {
 	sizeof(struct SetOfEnums),
 	offsetof(struct SetOfEnums, _asn_ctx),
 	1,	/* XER encoding is XMLValueList */
@@ -1243,10 +1119,12 @@ typedef struct NamedSetOfNULL {
 /*** <<< FUNC-DECLS [NamedSetOfNULL] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_NamedSetOfNULL;
+extern asn_SET_OF_specifics_t asn_SPC_NamedSetOfNULL_specs_1;
+extern asn_TYPE_member_t asn_MBR_NamedSetOfNULL_1[1];
 
 /*** <<< STAT-DEFS [NamedSetOfNULL] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_NamedSetOfNULL_1[] = {
+asn_TYPE_member_t asn_MBR_NamedSetOfNULL_1[] = {
 	{ ATF_POINTER, 0, 0,
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (5 << 2)),
 		.tag_mode = 0,
@@ -1260,7 +1138,7 @@ static asn_TYPE_member_t asn_MBR_NamedSetOfNULL_1[] = {
 static const ber_tlv_tag_t asn_DEF_NamedSetOfNULL_tags_1[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (17 << 2))
 };
-static asn_SET_OF_specifics_t asn_SPC_NamedSetOfNULL_specs_1 = {
+asn_SET_OF_specifics_t asn_SPC_NamedSetOfNULL_specs_1 = {
 	sizeof(struct NamedSetOfNULL),
 	offsetof(struct NamedSetOfNULL, _asn_ctx),
 	1,	/* XER encoding is XMLValueList */
@@ -1308,10 +1186,12 @@ typedef struct NamedSetOfREAL {
 /*** <<< FUNC-DECLS [NamedSetOfREAL] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_NamedSetOfREAL;
+extern asn_SET_OF_specifics_t asn_SPC_NamedSetOfREAL_specs_1;
+extern asn_TYPE_member_t asn_MBR_NamedSetOfREAL_1[1];
 
 /*** <<< STAT-DEFS [NamedSetOfREAL] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_NamedSetOfREAL_1[] = {
+asn_TYPE_member_t asn_MBR_NamedSetOfREAL_1[] = {
 	{ ATF_POINTER, 0, 0,
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (9 << 2)),
 		.tag_mode = 0,
@@ -1325,7 +1205,7 @@ static asn_TYPE_member_t asn_MBR_NamedSetOfREAL_1[] = {
 static const ber_tlv_tag_t asn_DEF_NamedSetOfREAL_tags_1[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (17 << 2))
 };
-static asn_SET_OF_specifics_t asn_SPC_NamedSetOfREAL_specs_1 = {
+asn_SET_OF_specifics_t asn_SPC_NamedSetOfREAL_specs_1 = {
 	sizeof(struct NamedSetOfREAL),
 	offsetof(struct NamedSetOfREAL, _asn_ctx),
 	0,	/* XER encoding is XMLDelimitedItemList */
@@ -1381,83 +1261,15 @@ typedef struct NamedSetOfEnums {
 
 /* extern asn_TYPE_descriptor_t asn_DEF_name_2;	// (Use -fall-defs-global to expose) */
 extern asn_TYPE_descriptor_t asn_DEF_NamedSetOfEnums;
+extern asn_SET_OF_specifics_t asn_SPC_NamedSetOfEnums_specs_1;
+extern asn_TYPE_member_t asn_MBR_NamedSetOfEnums_1[1];
 
 /*** <<< CODE [NamedSetOfEnums] >>> ***/
-
-static int
-name_2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
 
 /*
  * This type is implemented using ENUMERATED,
  * so here we adjust the DEF accordingly.
  */
-static void
-name_2_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_ENUMERATED.free_struct;
-	td->print_struct   = asn_DEF_ENUMERATED.print_struct;
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	td->ber_decoder    = asn_DEF_ENUMERATED.ber_decoder;
-	td->der_encoder    = asn_DEF_ENUMERATED.der_encoder;
-	td->xer_decoder    = asn_DEF_ENUMERATED.xer_decoder;
-	td->xer_encoder    = asn_DEF_ENUMERATED.xer_encoder;
-	td->uper_decoder   = asn_DEF_ENUMERATED.uper_decoder;
-	td->uper_encoder   = asn_DEF_ENUMERATED.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_ENUMERATED.per_constraints;
-	td->elements       = asn_DEF_ENUMERATED.elements;
-	td->elements_count = asn_DEF_ENUMERATED.elements_count;
-     /* td->specifics      = asn_DEF_ENUMERATED.specifics;	// Defined explicitly */
-}
-
-static void
-name_2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	name_2_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-static int
-name_2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	name_2_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-static asn_dec_rval_t
-name_2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	name_2_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-static asn_enc_rval_t
-name_2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	name_2_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-static asn_dec_rval_t
-name_2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	name_2_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-static asn_enc_rval_t
-name_2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	name_2_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NamedSetOfEnums] >>> ***/
 
@@ -1485,13 +1297,13 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_name_2 = {
 	"ENUMERATED",
 	"ENUMERATED",
-	name_2_free,
-	name_2_print,
-	name_2_constraint,
-	name_2_decode_ber,
-	name_2_encode_der,
-	name_2_decode_xer,
-	name_2_encode_xer,
+	ENUMERATED_free,
+	ENUMERATED_print,
+	ENUMERATED_constraint,
+	ENUMERATED_decode_ber,
+	ENUMERATED_encode_der,
+	ENUMERATED_decode_xer,
+	ENUMERATED_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_name_tags_2,
@@ -1505,7 +1317,7 @@ asn_TYPE_descriptor_t asn_DEF_name_2 = {
 	&asn_SPC_name_specs_2	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_NamedSetOfEnums_1[] = {
+asn_TYPE_member_t asn_MBR_NamedSetOfEnums_1[] = {
 	{ ATF_POINTER, 0, 0,
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (10 << 2)),
 		.tag_mode = 0,
@@ -1519,7 +1331,7 @@ static asn_TYPE_member_t asn_MBR_NamedSetOfEnums_1[] = {
 static const ber_tlv_tag_t asn_DEF_NamedSetOfEnums_tags_1[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (17 << 2))
 };
-static asn_SET_OF_specifics_t asn_SPC_NamedSetOfEnums_specs_1 = {
+asn_SET_OF_specifics_t asn_SPC_NamedSetOfEnums_specs_1 = {
 	sizeof(struct NamedSetOfEnums),
 	offsetof(struct NamedSetOfEnums, _asn_ctx),
 	1,	/* XER encoding is XMLValueList */
@@ -1567,10 +1379,12 @@ typedef struct SequenceOf {
 /*** <<< FUNC-DECLS [SequenceOf] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_SequenceOf;
+extern asn_SET_OF_specifics_t asn_SPC_SequenceOf_specs_1;
+extern asn_TYPE_member_t asn_MBR_SequenceOf_1[1];
 
 /*** <<< STAT-DEFS [SequenceOf] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_SequenceOf_1[] = {
+asn_TYPE_member_t asn_MBR_SequenceOf_1[] = {
 	{ ATF_POINTER, 0, 0,
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
 		.tag_mode = 0,
@@ -1584,7 +1398,7 @@ static asn_TYPE_member_t asn_MBR_SequenceOf_1[] = {
 static const ber_tlv_tag_t asn_DEF_SequenceOf_tags_1[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
 };
-static asn_SET_OF_specifics_t asn_SPC_SequenceOf_specs_1 = {
+asn_SET_OF_specifics_t asn_SPC_SequenceOf_specs_1 = {
 	sizeof(struct SequenceOf),
 	offsetof(struct SequenceOf, _asn_ctx),
 	0,	/* XER encoding is XMLDelimitedItemList */
@@ -1632,10 +1446,12 @@ typedef struct SeqOfZuka {
 /*** <<< FUNC-DECLS [SeqOfZuka] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_SeqOfZuka;
+extern asn_SET_OF_specifics_t asn_SPC_SeqOfZuka_specs_1;
+extern asn_TYPE_member_t asn_MBR_SeqOfZuka_1[1];
 
 /*** <<< STAT-DEFS [SeqOfZuka] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_SeqOfZuka_1[] = {
+asn_TYPE_member_t asn_MBR_SeqOfZuka_1[] = {
 	{ ATF_POINTER, 0, 0,
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (5 << 2)),
 		.tag_mode = 0,
@@ -1649,7 +1465,7 @@ static asn_TYPE_member_t asn_MBR_SeqOfZuka_1[] = {
 static const ber_tlv_tag_t asn_DEF_SeqOfZuka_tags_1[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
 };
-static asn_SET_OF_specifics_t asn_SPC_SeqOfZuka_specs_1 = {
+asn_SET_OF_specifics_t asn_SPC_SeqOfZuka_specs_1 = {
 	sizeof(struct SeqOfZuka),
 	offsetof(struct SeqOfZuka, _asn_ctx),
 	1,	/* XER encoding is XMLValueList */
@@ -1700,6 +1516,8 @@ typedef struct SetOfChoice {
 /*** <<< FUNC-DECLS [SetOfChoice] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_SetOfChoice;
+extern asn_SET_OF_specifics_t asn_SPC_SetOfChoice_specs_1;
+extern asn_TYPE_member_t asn_MBR_SetOfChoice_1[1];
 
 /*** <<< POST-INCLUDE [SetOfChoice] >>> ***/
 
@@ -1707,7 +1525,7 @@ extern asn_TYPE_descriptor_t asn_DEF_SetOfChoice;
 
 /*** <<< STAT-DEFS [SetOfChoice] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_SetOfChoice_1[] = {
+asn_TYPE_member_t asn_MBR_SetOfChoice_1[] = {
 	{ ATF_POINTER, 0, 0,
 		.tag = -1 /* Ambiguous tag (CHOICE?) */,
 		.tag_mode = 0,
@@ -1721,7 +1539,7 @@ static asn_TYPE_member_t asn_MBR_SetOfChoice_1[] = {
 static const ber_tlv_tag_t asn_DEF_SetOfChoice_tags_1[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (17 << 2))
 };
-static asn_SET_OF_specifics_t asn_SPC_SetOfChoice_specs_1 = {
+asn_SET_OF_specifics_t asn_SPC_SetOfChoice_specs_1 = {
 	sizeof(struct SetOfChoice),
 	offsetof(struct SetOfChoice, _asn_ctx),
 	2,	/* XER encoding is XMLValueList */
@@ -1772,6 +1590,8 @@ typedef struct NamedSetOfChoice {
 /*** <<< FUNC-DECLS [NamedSetOfChoice] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_NamedSetOfChoice;
+extern asn_SET_OF_specifics_t asn_SPC_NamedSetOfChoice_specs_1;
+extern asn_TYPE_member_t asn_MBR_NamedSetOfChoice_1[1];
 
 /*** <<< POST-INCLUDE [NamedSetOfChoice] >>> ***/
 
@@ -1779,7 +1599,7 @@ extern asn_TYPE_descriptor_t asn_DEF_NamedSetOfChoice;
 
 /*** <<< STAT-DEFS [NamedSetOfChoice] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_NamedSetOfChoice_1[] = {
+asn_TYPE_member_t asn_MBR_NamedSetOfChoice_1[] = {
 	{ ATF_POINTER, 0, 0,
 		.tag = -1 /* Ambiguous tag (CHOICE?) */,
 		.tag_mode = 0,
@@ -1793,7 +1613,7 @@ static asn_TYPE_member_t asn_MBR_NamedSetOfChoice_1[] = {
 static const ber_tlv_tag_t asn_DEF_NamedSetOfChoice_tags_1[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (17 << 2))
 };
-static asn_SET_OF_specifics_t asn_SPC_NamedSetOfChoice_specs_1 = {
+asn_SET_OF_specifics_t asn_SPC_NamedSetOfChoice_specs_1 = {
 	sizeof(struct NamedSetOfChoice),
 	offsetof(struct NamedSetOfChoice, _asn_ctx),
 	2,	/* XER encoding is XMLValueList */
@@ -1853,10 +1673,12 @@ typedef struct SimpleChoice {
 /*** <<< FUNC-DECLS [SimpleChoice] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_SimpleChoice;
+extern asn_CHOICE_specifics_t asn_SPC_SimpleChoice_specs_1;
+extern asn_TYPE_member_t asn_MBR_SimpleChoice_1[2];
 
 /*** <<< STAT-DEFS [SimpleChoice] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_SimpleChoice_1[] = {
+asn_TYPE_member_t asn_MBR_SimpleChoice_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct SimpleChoice, choice.a),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -1880,7 +1702,7 @@ static const asn_TYPE_tag2member_t asn_MAP_SimpleChoice_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* a */
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 } /* b */
 };
-static asn_CHOICE_specifics_t asn_SPC_SimpleChoice_specs_1 = {
+asn_CHOICE_specifics_t asn_SPC_SimpleChoice_specs_1 = {
 	sizeof(struct SimpleChoice),
 	offsetof(struct SimpleChoice, _asn_ctx),
 	offsetof(struct SimpleChoice, present),

--- a/tests/72-same-names-OK.asn1.-Pfwide-types
+++ b/tests/72-same-names-OK.asn1.-Pfwide-types
@@ -177,6 +177,8 @@ typedef struct Type1 {
 /*** <<< FUNC-DECLS [Type1] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Type1;
+extern asn_SEQUENCE_specifics_t asn_SPC_Type1_specs_1;
+extern asn_TYPE_member_t asn_MBR_Type1_1[1];
 
 /*** <<< STAT-DEFS [Type1] >>> ***/
 
@@ -288,7 +290,7 @@ asn_TYPE_descriptor_t asn_DEF_one_name_2 = {
 	&asn_SPC_one_name_specs_2	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_Type1_1[] = {
+asn_TYPE_member_t asn_MBR_Type1_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Type1, one_name),
 		.tag = -1 /* Ambiguous tag (CHOICE?) */,
 		.tag_mode = 0,
@@ -305,7 +307,7 @@ static const ber_tlv_tag_t asn_DEF_Type1_tags_1[] = {
 static const asn_TYPE_tag2member_t asn_MAP_Type1_tag2el_1[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)), 0, 0, 0 } /* another-name */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Type1_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Type1_specs_1 = {
 	sizeof(struct Type1),
 	offsetof(struct Type1, _asn_ctx),
 	asn_MAP_Type1_tag2el_1,
@@ -410,6 +412,8 @@ typedef struct Type2 {
 /*** <<< FUNC-DECLS [Type2] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Type2;
+extern asn_CHOICE_specifics_t asn_SPC_Type2_specs_1;
+extern asn_TYPE_member_t asn_MBR_Type2_1[2];
 
 /*** <<< CODE [Type2] >>> ***/
 
@@ -671,7 +675,8 @@ static const asn_TYPE_tag2member_t asn_MAP_two_name_tag2el_7[] = {
 static const uint8_t asn_MAP_two_name_mmap_7[(1 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	(1 << 7)
 };
-static asn_SET_specifics_t asn_SPC_two_name_specs_7 = {
+static 
+asn_SET_specifics_t asn_SPC_two_name_specs_7 = {
 	sizeof(struct two_name),
 	offsetof(struct two_name, _asn_ctx),
 	offsetof(struct two_name, _presence_map),
@@ -707,7 +712,7 @@ asn_TYPE_descriptor_t asn_DEF_two_name_7 = {
 	&asn_SPC_two_name_specs_7	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_Type2_1[] = {
+asn_TYPE_member_t asn_MBR_Type2_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Type2, choice.one_name),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
@@ -731,7 +736,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Type2_tag2el_1[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)), 0, 0, 0 }, /* one-name */
     { (ASN_TAG_CLASS_UNIVERSAL | (17 << 2)), 1, 0, 0 } /* two-name */
 };
-static asn_CHOICE_specifics_t asn_SPC_Type2_specs_1 = {
+asn_CHOICE_specifics_t asn_SPC_Type2_specs_1 = {
 	sizeof(struct Type2),
 	offsetof(struct Type2, _asn_ctx),
 	offsetof(struct Type2, present),

--- a/tests/73-circular-OK.asn1.-Pfwide-types
+++ b/tests/73-circular-OK.asn1.-Pfwide-types
@@ -26,6 +26,8 @@ typedef struct Type {
 /*** <<< FUNC-DECLS [Type] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Type;
+extern asn_SEQUENCE_specifics_t asn_SPC_Type_specs_1;
+extern asn_TYPE_member_t asn_MBR_Type_1[1];
 
 /*** <<< POST-INCLUDE [Type] >>> ***/
 
@@ -77,7 +79,7 @@ asn_TYPE_descriptor_t asn_DEF_data_2 = {
 	&asn_SPC_data_specs_2	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_Type_1[] = {
+asn_TYPE_member_t asn_MBR_Type_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Type, data),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
@@ -94,7 +96,7 @@ static const ber_tlv_tag_t asn_DEF_Type_tags_1[] = {
 static const asn_TYPE_tag2member_t asn_MAP_Type_tag2el_1[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)), 0, 0, 0 } /* data */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Type_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Type_specs_1 = {
 	sizeof(struct Type),
 	offsetof(struct Type, _asn_ctx),
 	asn_MAP_Type_tag2el_1,
@@ -149,80 +151,10 @@ xer_type_encoder_f EpytRef_encode_xer;
 
 /*** <<< CODE [EpytRef] >>> ***/
 
-int
-EpytRef_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_Epyt.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using Epyt,
  * so here we adjust the DEF accordingly.
  */
-static void
-EpytRef_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Epyt.free_struct;
-	td->print_struct   = asn_DEF_Epyt.print_struct;
-	td->check_constraints = asn_DEF_Epyt.check_constraints;
-	td->ber_decoder    = asn_DEF_Epyt.ber_decoder;
-	td->der_encoder    = asn_DEF_Epyt.der_encoder;
-	td->xer_decoder    = asn_DEF_Epyt.xer_decoder;
-	td->xer_encoder    = asn_DEF_Epyt.xer_encoder;
-	td->uper_decoder   = asn_DEF_Epyt.uper_decoder;
-	td->uper_encoder   = asn_DEF_Epyt.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Epyt.per_constraints;
-	td->elements       = asn_DEF_Epyt.elements;
-	td->elements_count = asn_DEF_Epyt.elements_count;
-	td->specifics      = asn_DEF_Epyt.specifics;
-}
-
-void
-EpytRef_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	EpytRef_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-EpytRef_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	EpytRef_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-EpytRef_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	EpytRef_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-EpytRef_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	EpytRef_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-EpytRef_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	EpytRef_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-EpytRef_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	EpytRef_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [EpytRef] >>> ***/
 
@@ -232,13 +164,13 @@ static const ber_tlv_tag_t asn_DEF_EpytRef_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_EpytRef = {
 	"EpytRef",
 	"EpytRef",
-	EpytRef_free,
-	EpytRef_print,
-	EpytRef_constraint,
-	EpytRef_decode_ber,
-	EpytRef_encode_der,
-	EpytRef_decode_xer,
-	EpytRef_encode_xer,
+	SEQUENCE_free,
+	SEQUENCE_print,
+	SEQUENCE_constraint,
+	SEQUENCE_decode_ber,
+	SEQUENCE_encode_der,
+	SEQUENCE_decode_xer,
+	SEQUENCE_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_EpytRef_tags_1,
@@ -248,8 +180,9 @@ asn_TYPE_descriptor_t asn_DEF_EpytRef = {
 	sizeof(asn_DEF_EpytRef_tags_1)
 		/sizeof(asn_DEF_EpytRef_tags_1[0]), /* 1 */
 	0,	/* No PER visible constraints */
-	0, 0,	/* Defined elsewhere */
-	0	/* No specifics */
+	asn_MBR_Epyt_1,
+	3,	/* Elements count */
+	&asn_SPC_Epyt_specs_1	/* Additional specs */
 };
 
 
@@ -283,6 +216,8 @@ typedef struct Epyt {
 /*** <<< FUNC-DECLS [Epyt] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Epyt;
+extern asn_SEQUENCE_specifics_t asn_SPC_Epyt_specs_1;
+extern asn_TYPE_member_t asn_MBR_Epyt_1[3];
 
 /*** <<< POST-INCLUDE [Epyt] >>> ***/
 
@@ -335,7 +270,7 @@ asn_TYPE_descriptor_t asn_DEF_stype_2 = {
 	&asn_SPC_stype_specs_2	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_Epyt_1[] = {
+asn_TYPE_member_t asn_MBR_Epyt_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Epyt, stype),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (17 << 2)),
 		.tag_mode = 0,
@@ -372,7 +307,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Epyt_tag2el_1[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (17 << 2)), 0, 0, 1 }, /* stype */
     { (ASN_TAG_CLASS_UNIVERSAL | (17 << 2)), 2, -1, 0 } /* ypet */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Epyt_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Epyt_specs_1 = {
 	sizeof(struct Epyt),
 	offsetof(struct Epyt, _asn_ctx),
 	asn_MAP_Epyt_tag2el_1,
@@ -458,6 +393,8 @@ typedef struct Ypet {
 /*** <<< FUNC-DECLS [Ypet] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Ypet;
+extern asn_SET_specifics_t asn_SPC_Ypet_specs_1;
+extern asn_TYPE_member_t asn_MBR_Ypet_1[5];
 
 /*** <<< POST-INCLUDE [Ypet] >>> ***/
 
@@ -609,7 +546,7 @@ asn_TYPE_descriptor_t asn_DEF_senums_4 = {
 	&asn_SPC_senums_specs_4	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_Ypet_1[] = {
+asn_TYPE_member_t asn_MBR_Ypet_1[] = {
 	{ ATF_POINTER, 0, offsetof(struct Ypet, epyt),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
@@ -669,7 +606,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Ypet_tag2el_1[] = {
 static const uint8_t asn_MAP_Ypet_mmap_1[(5 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	(1 << 7) | (0 << 6) | (1 << 5) | (1 << 4) | (1 << 3)
 };
-static asn_SET_specifics_t asn_SPC_Ypet_specs_1 = {
+asn_SET_specifics_t asn_SPC_Ypet_specs_1 = {
 	sizeof(struct Ypet),
 	offsetof(struct Ypet, _asn_ctx),
 	offsetof(struct Ypet, _presence_map),
@@ -723,6 +660,7 @@ typedef ENUMERATED_t	 EnumType_t;
 /*** <<< FUNC-DECLS [EnumType] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_EnumType;
+extern asn_INTEGER_specifics_t asn_SPC_EnumType_specs_1;
 asn_struct_free_f EnumType_free;
 asn_struct_print_f EnumType_print;
 asn_constr_check_f EnumType_constraint;
@@ -733,80 +671,10 @@ xer_type_encoder_f EnumType_encode_xer;
 
 /*** <<< CODE [EnumType] >>> ***/
 
-int
-EnumType_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using ENUMERATED,
  * so here we adjust the DEF accordingly.
  */
-static void
-EnumType_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_ENUMERATED.free_struct;
-	td->print_struct   = asn_DEF_ENUMERATED.print_struct;
-	td->check_constraints = asn_DEF_ENUMERATED.check_constraints;
-	td->ber_decoder    = asn_DEF_ENUMERATED.ber_decoder;
-	td->der_encoder    = asn_DEF_ENUMERATED.der_encoder;
-	td->xer_decoder    = asn_DEF_ENUMERATED.xer_decoder;
-	td->xer_encoder    = asn_DEF_ENUMERATED.xer_encoder;
-	td->uper_decoder   = asn_DEF_ENUMERATED.uper_decoder;
-	td->uper_encoder   = asn_DEF_ENUMERATED.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_ENUMERATED.per_constraints;
-	td->elements       = asn_DEF_ENUMERATED.elements;
-	td->elements_count = asn_DEF_ENUMERATED.elements_count;
-     /* td->specifics      = asn_DEF_ENUMERATED.specifics;	// Defined explicitly */
-}
-
-void
-EnumType_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	EnumType_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-EnumType_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	EnumType_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-EnumType_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	EnumType_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-EnumType_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	EnumType_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-EnumType_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	EnumType_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-EnumType_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	EnumType_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [EnumType] >>> ***/
 
@@ -818,7 +686,7 @@ static const unsigned int asn_MAP_EnumType_enum2value_1[] = {
 	0,	/* one(0) */
 	1	/* two(1) */
 };
-static const asn_INTEGER_specifics_t asn_SPC_EnumType_specs_1 = {
+const asn_INTEGER_specifics_t asn_SPC_EnumType_specs_1 = {
 	asn_MAP_EnumType_value2enum_1,	/* "tag" => N; sorted by tag */
 	asn_MAP_EnumType_enum2value_1,	/* N => "tag"; sorted by N */
 	2,	/* Number of elements in the maps */
@@ -833,13 +701,13 @@ static const ber_tlv_tag_t asn_DEF_EnumType_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_EnumType = {
 	"EnumType",
 	"EnumType",
-	EnumType_free,
-	EnumType_print,
-	EnumType_constraint,
-	EnumType_decode_ber,
-	EnumType_encode_der,
-	EnumType_decode_xer,
-	EnumType_encode_xer,
+	ENUMERATED_free,
+	ENUMERATED_print,
+	ENUMERATED_constraint,
+	ENUMERATED_decode_ber,
+	ENUMERATED_encode_der,
+	ENUMERATED_decode_xer,
+	ENUMERATED_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_EnumType_tags_1,

--- a/tests/84-param-tags-OK.asn1.-Pfwide-types
+++ b/tests/84-param-tags-OK.asn1.-Pfwide-types
@@ -23,7 +23,11 @@ typedef struct TestType_16P1 {
 /*** <<< FUNC-DECLS [TestType] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_TestType_16P0;
+extern asn_SEQUENCE_specifics_t asn_SPC_TestType_16P0_specs_1;
+extern asn_TYPE_member_t asn_MBR_TestType_16P0_1[1];
 extern asn_TYPE_descriptor_t asn_DEF_TestType_16P1;
+extern asn_SEQUENCE_specifics_t asn_SPC_TestType_16P1_specs_3;
+extern asn_TYPE_member_t asn_MBR_TestType_16P1_3[1];
 
 /*** <<< CODE [TestType] >>> ***/
 
@@ -73,7 +77,7 @@ static int asn_DFL_2_set_0(int set_value, void **sptr) {
 		return (*st == 0);
 	}
 }
-static asn_TYPE_member_t asn_MBR_TestType_16P0_1[] = {
+asn_TYPE_member_t asn_MBR_TestType_16P0_1[] = {
 	{ ATF_NOFLAGS, 1, offsetof(struct TestType_16P0, common),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
 		.tag_mode = 0,
@@ -90,7 +94,7 @@ static const ber_tlv_tag_t asn_DEF_TestType_16P0_tags_1[] = {
 static const asn_TYPE_tag2member_t asn_MAP_TestType_16P0_tag2el_1[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)), 0, 0, 0 } /* common */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_TestType_16P0_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_TestType_16P0_specs_1 = {
 	sizeof(struct TestType_16P0),
 	offsetof(struct TestType_16P0, _asn_ctx),
 	asn_MAP_TestType_16P0_tag2el_1,
@@ -141,7 +145,7 @@ static int asn_DFL_4_set_0(int set_value, void **sptr) {
 		return (*st == 0);
 	}
 }
-static asn_TYPE_member_t asn_MBR_TestType_16P1_3[] = {
+asn_TYPE_member_t asn_MBR_TestType_16P1_3[] = {
 	{ ATF_NOFLAGS, 1, offsetof(struct TestType_16P1, common),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (1 << 2)),
 		.tag_mode = 0,
@@ -158,7 +162,7 @@ static const ber_tlv_tag_t asn_DEF_TestType_16P1_tags_3[] = {
 static const asn_TYPE_tag2member_t asn_MAP_TestType_16P1_tag2el_3[] = {
     { (ASN_TAG_CLASS_UNIVERSAL | (1 << 2)), 0, 0, 0 } /* common */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_TestType_16P1_specs_3 = {
+asn_SEQUENCE_specifics_t asn_SPC_TestType_16P1_specs_3 = {
 	sizeof(struct TestType_16P1),
 	offsetof(struct TestType_16P1, _asn_ctx),
 	asn_MAP_TestType_16P1_tag2el_3,
@@ -305,7 +309,11 @@ typedef struct AutoType_34P1 {
 /*** <<< FUNC-DECLS [AutoType] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_AutoType_34P0;
+extern asn_SEQUENCE_specifics_t asn_SPC_AutoType_34P0_specs_1;
+extern asn_TYPE_member_t asn_MBR_AutoType_34P0_1[1];
 extern asn_TYPE_descriptor_t asn_DEF_AutoType_34P1;
+extern asn_SEQUENCE_specifics_t asn_SPC_AutoType_34P1_specs_3;
+extern asn_TYPE_member_t asn_MBR_AutoType_34P1_3[1];
 
 /*** <<< CODE [AutoType] >>> ***/
 
@@ -362,7 +370,7 @@ memb_common_constraint_3(asn_TYPE_descriptor_t *td, const void *sptr,
 
 /*** <<< STAT-DEFS [AutoType] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_AutoType_34P0_1[] = {
+asn_TYPE_member_t asn_MBR_AutoType_34P0_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct AutoType_34P0, common),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -379,7 +387,7 @@ static const ber_tlv_tag_t asn_DEF_AutoType_34P0_tags_1[] = {
 static const asn_TYPE_tag2member_t asn_MAP_AutoType_34P0_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 } /* common */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_AutoType_34P0_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_AutoType_34P0_specs_1 = {
 	sizeof(struct AutoType_34P0),
 	offsetof(struct AutoType_34P0, _asn_ctx),
 	asn_MAP_AutoType_34P0_tag2el_1,
@@ -412,7 +420,7 @@ asn_TYPE_descriptor_t asn_DEF_AutoType_34P0 = {
 	&asn_SPC_AutoType_34P0_specs_1	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_AutoType_34P1_3[] = {
+asn_TYPE_member_t asn_MBR_AutoType_34P1_3[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct AutoType_34P1, common),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -429,7 +437,7 @@ static const ber_tlv_tag_t asn_DEF_AutoType_34P1_tags_3[] = {
 static const asn_TYPE_tag2member_t asn_MAP_AutoType_34P1_tag2el_3[] = {
     { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 } /* common */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_AutoType_34P1_specs_3 = {
+asn_SEQUENCE_specifics_t asn_SPC_AutoType_34P1_specs_3 = {
 	sizeof(struct AutoType_34P1),
 	offsetof(struct AutoType_34P1, _asn_ctx),
 	asn_MAP_AutoType_34P1_tag2el_3,

--- a/tests/88-integer-enum-OK.asn1.-Pfwide-types
+++ b/tests/88-integer-enum-OK.asn1.-Pfwide-types
@@ -27,80 +27,10 @@ xer_type_encoder_f T_encode_xer;
 
 /*** <<< CODE [T] >>> ***/
 
-int
-T_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-T_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-T_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	T_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-T_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-T_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-T_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-T_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-T_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	T_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [T] >>> ***/
 
@@ -110,13 +40,13 @@ static const ber_tlv_tag_t asn_DEF_T_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	T_free,
-	T_print,
-	T_constraint,
-	T_decode_ber,
-	T_encode_der,
-	T_decode_xer,
-	T_encode_xer,
+	INTEGER_free,
+	INTEGER_print,
+	INTEGER_constraint,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,

--- a/tests/90-cond-int-type-OK.asn1.-P
+++ b/tests/90-cond-int-type-OK.asn1.-P
@@ -20,80 +20,10 @@ xer_type_encoder_f CN_IntegerUnlimited_encode_xer;
 
 /*** <<< CODE [CN-IntegerUnlimited] >>> ***/
 
-int
-CN_IntegerUnlimited_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-CN_IntegerUnlimited_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-CN_IntegerUnlimited_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-CN_IntegerUnlimited_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerUnlimited_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-CN_IntegerUnlimited_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerUnlimited_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-CN_IntegerUnlimited_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [CN-IntegerUnlimited] >>> ***/
 
@@ -103,13 +33,13 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerUnlimited_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerUnlimited = {
 	"CN-IntegerUnlimited",
 	"CN-IntegerUnlimited",
-	CN_IntegerUnlimited_free,
-	CN_IntegerUnlimited_print,
-	CN_IntegerUnlimited_constraint,
-	CN_IntegerUnlimited_decode_ber,
-	CN_IntegerUnlimited_encode_der,
-	CN_IntegerUnlimited_decode_xer,
-	CN_IntegerUnlimited_encode_xer,
+	NativeInteger_free,
+	NativeInteger_print,
+	NativeInteger_constraint,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerUnlimited_tags_1,
@@ -170,68 +100,6 @@ CN_IntegerMinMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-CN_IntegerMinMax_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-CN_IntegerMinMax_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-CN_IntegerMinMax_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerMinMax_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-CN_IntegerMinMax_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerMinMax_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-CN_IntegerMinMax_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [CN-IntegerMinMax] >>> ***/
 
@@ -241,13 +109,13 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerMinMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerMinMax = {
 	"CN-IntegerMinMax",
 	"CN-IntegerMinMax",
-	CN_IntegerMinMax_free,
-	CN_IntegerMinMax_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	CN_IntegerMinMax_constraint,
-	CN_IntegerMinMax_decode_ber,
-	CN_IntegerMinMax_encode_der,
-	CN_IntegerMinMax_decode_xer,
-	CN_IntegerMinMax_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerMinMax_tags_1,
@@ -312,68 +180,6 @@ CN_IntegerMinLow_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-CN_IntegerMinLow_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-CN_IntegerMinLow_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-CN_IntegerMinLow_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerMinLow_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-CN_IntegerMinLow_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerMinLow_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-CN_IntegerMinLow_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [CN-IntegerMinLow] >>> ***/
 
@@ -383,13 +189,13 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerMinLow_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerMinLow = {
 	"CN-IntegerMinLow",
 	"CN-IntegerMinLow",
-	CN_IntegerMinLow_free,
-	CN_IntegerMinLow_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	CN_IntegerMinLow_constraint,
-	CN_IntegerMinLow_decode_ber,
-	CN_IntegerMinLow_encode_der,
-	CN_IntegerMinLow_decode_xer,
-	CN_IntegerMinLow_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerMinLow_tags_1,
@@ -460,68 +266,6 @@ NO_IntegerMinHigh_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerMinHigh_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-NO_IntegerMinHigh_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerMinHigh_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerMinHigh_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerMinHigh_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerMinHigh_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerMinHigh_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NO-IntegerMinHigh] >>> ***/
 
@@ -531,13 +275,13 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerMinHigh_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerMinHigh = {
 	"NO-IntegerMinHigh",
 	"NO-IntegerMinHigh",
-	NO_IntegerMinHigh_free,
-	NO_IntegerMinHigh_print,
+	INTEGER_free,
+	INTEGER_print,
 	NO_IntegerMinHigh_constraint,
-	NO_IntegerMinHigh_decode_ber,
-	NO_IntegerMinHigh_encode_der,
-	NO_IntegerMinHigh_decode_xer,
-	NO_IntegerMinHigh_encode_xer,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerMinHigh_tags_1,
@@ -602,68 +346,6 @@ NO_IntegerLowHigh_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerLowHigh_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-     /* td->specifics      = asn_DEF_NativeInteger.specifics;	// Defined explicitly */
-}
-
-void
-NO_IntegerLowHigh_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerLowHigh_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerLowHigh_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerLowHigh_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerLowHigh_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerLowHigh_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NO-IntegerLowHigh] >>> ***/
 
@@ -678,13 +360,13 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerLowHigh_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerLowHigh = {
 	"NO-IntegerLowHigh",
 	"NO-IntegerLowHigh",
-	NO_IntegerLowHigh_free,
-	NO_IntegerLowHigh_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	NO_IntegerLowHigh_constraint,
-	NO_IntegerLowHigh_decode_ber,
-	NO_IntegerLowHigh_encode_der,
-	NO_IntegerLowHigh_decode_xer,
-	NO_IntegerLowHigh_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerLowHigh_tags_1,
@@ -749,68 +431,6 @@ CN_IntegerLowMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-CN_IntegerLowMax_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-CN_IntegerLowMax_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-CN_IntegerLowMax_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerLowMax_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-CN_IntegerLowMax_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerLowMax_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-CN_IntegerLowMax_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [CN-IntegerLowMax] >>> ***/
 
@@ -820,13 +440,13 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerLowMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerLowMax = {
 	"CN-IntegerLowMax",
 	"CN-IntegerLowMax",
-	CN_IntegerLowMax_free,
-	CN_IntegerLowMax_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	CN_IntegerLowMax_constraint,
-	CN_IntegerLowMax_decode_ber,
-	CN_IntegerLowMax_encode_der,
-	CN_IntegerLowMax_decode_xer,
-	CN_IntegerLowMax_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerLowMax_tags_1,
@@ -897,68 +517,6 @@ NO_IntegerHighMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerHighMax_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-NO_IntegerHighMax_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerHighMax_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerHighMax_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerHighMax_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerHighMax_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerHighMax_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NO-IntegerHighMax] >>> ***/
 
@@ -968,13 +526,13 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerHighMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerHighMax = {
 	"NO-IntegerHighMax",
 	"NO-IntegerHighMax",
-	NO_IntegerHighMax_free,
-	NO_IntegerHighMax_print,
+	INTEGER_free,
+	INTEGER_print,
 	NO_IntegerHighMax_constraint,
-	NO_IntegerHighMax_decode_ber,
-	NO_IntegerHighMax_encode_der,
-	NO_IntegerHighMax_decode_xer,
-	NO_IntegerHighMax_encode_xer,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerHighMax_tags_1,
@@ -1045,68 +603,6 @@ NO_IntegerLowestMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerLowestMax_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-NO_IntegerLowestMax_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerLowestMax_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerLowestMax_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerLowestMax_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerLowestMax_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerLowestMax_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NO-IntegerLowestMax] >>> ***/
 
@@ -1116,13 +612,13 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerLowestMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerLowestMax = {
 	"NO-IntegerLowestMax",
 	"NO-IntegerLowestMax",
-	NO_IntegerLowestMax_free,
-	NO_IntegerLowestMax_print,
+	INTEGER_free,
+	INTEGER_print,
 	NO_IntegerLowestMax_constraint,
-	NO_IntegerLowestMax_decode_ber,
-	NO_IntegerLowestMax_encode_der,
-	NO_IntegerLowestMax_decode_xer,
-	NO_IntegerLowestMax_encode_xer,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerLowestMax_tags_1,
@@ -1187,68 +683,6 @@ NO_IntegerOutRange_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerOutRange_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-     /* td->specifics      = asn_DEF_NativeInteger.specifics;	// Defined explicitly */
-}
-
-void
-NO_IntegerOutRange_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerOutRange_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerOutRange_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerOutRange_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerOutRange_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerOutRange_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NO-IntegerOutRange] >>> ***/
 
@@ -1263,13 +697,13 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerOutRange_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerOutRange = {
 	"NO-IntegerOutRange",
 	"NO-IntegerOutRange",
-	NO_IntegerOutRange_free,
-	NO_IntegerOutRange_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	NO_IntegerOutRange_constraint,
-	NO_IntegerOutRange_decode_ber,
-	NO_IntegerOutRange_encode_der,
-	NO_IntegerOutRange_decode_xer,
-	NO_IntegerOutRange_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerOutRange_tags_1,
@@ -1334,68 +768,6 @@ NO_IntegerOutValue_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerOutValue_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-     /* td->specifics      = asn_DEF_NativeInteger.specifics;	// Defined explicitly */
-}
-
-void
-NO_IntegerOutValue_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerOutValue_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerOutValue_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerOutValue_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerOutValue_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerOutValue_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NO-IntegerOutValue] >>> ***/
 
@@ -1410,13 +782,13 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerOutValue_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerOutValue = {
 	"NO-IntegerOutValue",
 	"NO-IntegerOutValue",
-	NO_IntegerOutValue_free,
-	NO_IntegerOutValue_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	NO_IntegerOutValue_constraint,
-	NO_IntegerOutValue_decode_ber,
-	NO_IntegerOutValue_encode_der,
-	NO_IntegerOutValue_decode_xer,
-	NO_IntegerOutValue_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerOutValue_tags_1,
@@ -1481,68 +853,6 @@ OK_IntegerInRange1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_IntegerInRange1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-OK_IntegerInRange1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_IntegerInRange1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [OK-IntegerInRange1] >>> ***/
 
@@ -1552,13 +862,13 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange1 = {
 	"OK-IntegerInRange1",
 	"OK-IntegerInRange1",
-	OK_IntegerInRange1_free,
-	OK_IntegerInRange1_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	OK_IntegerInRange1_constraint,
-	OK_IntegerInRange1_decode_ber,
-	OK_IntegerInRange1_encode_der,
-	OK_IntegerInRange1_decode_xer,
-	OK_IntegerInRange1_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange1_tags_1,
@@ -1623,68 +933,6 @@ OK_IntegerInRange2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_IntegerInRange2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-OK_IntegerInRange2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_IntegerInRange2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [OK-IntegerInRange2] >>> ***/
 
@@ -1694,13 +942,13 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange2 = {
 	"OK-IntegerInRange2",
 	"OK-IntegerInRange2",
-	OK_IntegerInRange2_free,
-	OK_IntegerInRange2_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	OK_IntegerInRange2_constraint,
-	OK_IntegerInRange2_decode_ber,
-	OK_IntegerInRange2_encode_der,
-	OK_IntegerInRange2_decode_xer,
-	OK_IntegerInRange2_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange2_tags_1,
@@ -1765,68 +1013,6 @@ OK_IntegerInRange3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_IntegerInRange3_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-OK_IntegerInRange3_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_IntegerInRange3_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange3_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange3_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange3_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange3_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [OK-IntegerInRange3] >>> ***/
 
@@ -1836,13 +1022,13 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange3 = {
 	"OK-IntegerInRange3",
 	"OK-IntegerInRange3",
-	OK_IntegerInRange3_free,
-	OK_IntegerInRange3_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	OK_IntegerInRange3_constraint,
-	OK_IntegerInRange3_decode_ber,
-	OK_IntegerInRange3_encode_der,
-	OK_IntegerInRange3_decode_xer,
-	OK_IntegerInRange3_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange3_tags_1,
@@ -1907,68 +1093,6 @@ OK_IntegerInRange4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_IntegerInRange4_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-OK_IntegerInRange4_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_IntegerInRange4_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange4_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange4_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange4_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange4_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [OK-IntegerInRange4] >>> ***/
 
@@ -1978,13 +1102,13 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange4 = {
 	"OK-IntegerInRange4",
 	"OK-IntegerInRange4",
-	OK_IntegerInRange4_free,
-	OK_IntegerInRange4_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	OK_IntegerInRange4_constraint,
-	OK_IntegerInRange4_decode_ber,
-	OK_IntegerInRange4_encode_der,
-	OK_IntegerInRange4_decode_xer,
-	OK_IntegerInRange4_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange4_tags_1,
@@ -2049,68 +1173,6 @@ OK_IntegerInRange5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_IntegerInRange5_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-OK_IntegerInRange5_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_IntegerInRange5_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange5_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange5_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange5_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange5_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [OK-IntegerInRange5] >>> ***/
 
@@ -2120,13 +1182,13 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange5 = {
 	"OK-IntegerInRange5",
 	"OK-IntegerInRange5",
-	OK_IntegerInRange5_free,
-	OK_IntegerInRange5_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	OK_IntegerInRange5_constraint,
-	OK_IntegerInRange5_decode_ber,
-	OK_IntegerInRange5_encode_der,
-	OK_IntegerInRange5_decode_xer,
-	OK_IntegerInRange5_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange5_tags_1,
@@ -2182,68 +1244,6 @@ NO_IntegerInRange6_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerInRange6_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-     /* td->specifics      = asn_DEF_NativeInteger.specifics;	// Defined explicitly */
-}
-
-void
-NO_IntegerInRange6_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerInRange6_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerInRange6_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerInRange6_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerInRange6_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerInRange6_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NO-IntegerInRange6] >>> ***/
 
@@ -2258,13 +1258,13 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerInRange6_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerInRange6 = {
 	"NO-IntegerInRange6",
 	"NO-IntegerInRange6",
-	NO_IntegerInRange6_free,
-	NO_IntegerInRange6_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	NO_IntegerInRange6_constraint,
-	NO_IntegerInRange6_decode_ber,
-	NO_IntegerInRange6_encode_der,
-	NO_IntegerInRange6_decode_xer,
-	NO_IntegerInRange6_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerInRange6_tags_1,
@@ -2307,80 +1307,10 @@ xer_type_encoder_f CN_IntegerEnumerated1_encode_xer;
 
 /*** <<< CODE [CN-IntegerEnumerated1] >>> ***/
 
-int
-CN_IntegerEnumerated1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-CN_IntegerEnumerated1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-CN_IntegerEnumerated1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerEnumerated1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-CN_IntegerEnumerated1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerEnumerated1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-CN_IntegerEnumerated1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [CN-IntegerEnumerated1] >>> ***/
 
@@ -2390,13 +1320,13 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerEnumerated1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerEnumerated1 = {
 	"CN-IntegerEnumerated1",
 	"CN-IntegerEnumerated1",
-	CN_IntegerEnumerated1_free,
-	CN_IntegerEnumerated1_print,
-	CN_IntegerEnumerated1_constraint,
-	CN_IntegerEnumerated1_decode_ber,
-	CN_IntegerEnumerated1_encode_der,
-	CN_IntegerEnumerated1_decode_xer,
-	CN_IntegerEnumerated1_encode_xer,
+	NativeInteger_free,
+	NativeInteger_print,
+	NativeInteger_constraint,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerEnumerated1_tags_1,
@@ -2439,80 +1369,10 @@ xer_type_encoder_f NO_IntegerEnumerated2_encode_xer;
 
 /*** <<< CODE [NO-IntegerEnumerated2] >>> ***/
 
-int
-NO_IntegerEnumerated2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-NO_IntegerEnumerated2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerEnumerated2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerEnumerated2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerEnumerated2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerEnumerated2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerEnumerated2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NO-IntegerEnumerated2] >>> ***/
 
@@ -2522,13 +1382,13 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerEnumerated2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerEnumerated2 = {
 	"NO-IntegerEnumerated2",
 	"NO-IntegerEnumerated2",
-	NO_IntegerEnumerated2_free,
-	NO_IntegerEnumerated2_print,
-	NO_IntegerEnumerated2_constraint,
-	NO_IntegerEnumerated2_decode_ber,
-	NO_IntegerEnumerated2_encode_der,
-	NO_IntegerEnumerated2_decode_xer,
-	NO_IntegerEnumerated2_encode_xer,
+	INTEGER_free,
+	INTEGER_print,
+	INTEGER_constraint,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerEnumerated2_tags_1,

--- a/tests/90-cond-int-type-OK.asn1.-Pfwide-types
+++ b/tests/90-cond-int-type-OK.asn1.-Pfwide-types
@@ -20,80 +20,10 @@ xer_type_encoder_f CN_IntegerUnlimited_encode_xer;
 
 /*** <<< CODE [CN-IntegerUnlimited] >>> ***/
 
-int
-CN_IntegerUnlimited_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-CN_IntegerUnlimited_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-CN_IntegerUnlimited_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-CN_IntegerUnlimited_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerUnlimited_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-CN_IntegerUnlimited_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerUnlimited_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-CN_IntegerUnlimited_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [CN-IntegerUnlimited] >>> ***/
 
@@ -103,13 +33,13 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerUnlimited_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerUnlimited = {
 	"CN-IntegerUnlimited",
 	"CN-IntegerUnlimited",
-	CN_IntegerUnlimited_free,
-	CN_IntegerUnlimited_print,
-	CN_IntegerUnlimited_constraint,
-	CN_IntegerUnlimited_decode_ber,
-	CN_IntegerUnlimited_encode_der,
-	CN_IntegerUnlimited_decode_xer,
-	CN_IntegerUnlimited_encode_xer,
+	INTEGER_free,
+	INTEGER_print,
+	INTEGER_constraint,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerUnlimited_tags_1,
@@ -171,68 +101,6 @@ CN_IntegerMinMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-CN_IntegerMinMax_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-CN_IntegerMinMax_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-CN_IntegerMinMax_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerMinMax_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-CN_IntegerMinMax_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerMinMax_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-CN_IntegerMinMax_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [CN-IntegerMinMax] >>> ***/
 
@@ -242,13 +110,13 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerMinMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerMinMax = {
 	"CN-IntegerMinMax",
 	"CN-IntegerMinMax",
-	CN_IntegerMinMax_free,
-	CN_IntegerMinMax_print,
+	INTEGER_free,
+	INTEGER_print,
 	CN_IntegerMinMax_constraint,
-	CN_IntegerMinMax_decode_ber,
-	CN_IntegerMinMax_encode_der,
-	CN_IntegerMinMax_decode_xer,
-	CN_IntegerMinMax_encode_xer,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerMinMax_tags_1,
@@ -319,68 +187,6 @@ CN_IntegerMinLow_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-CN_IntegerMinLow_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-CN_IntegerMinLow_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-CN_IntegerMinLow_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerMinLow_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-CN_IntegerMinLow_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerMinLow_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-CN_IntegerMinLow_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [CN-IntegerMinLow] >>> ***/
 
@@ -390,13 +196,13 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerMinLow_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerMinLow = {
 	"CN-IntegerMinLow",
 	"CN-IntegerMinLow",
-	CN_IntegerMinLow_free,
-	CN_IntegerMinLow_print,
+	INTEGER_free,
+	INTEGER_print,
 	CN_IntegerMinLow_constraint,
-	CN_IntegerMinLow_decode_ber,
-	CN_IntegerMinLow_encode_der,
-	CN_IntegerMinLow_decode_xer,
-	CN_IntegerMinLow_encode_xer,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerMinLow_tags_1,
@@ -467,68 +273,6 @@ NO_IntegerMinHigh_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerMinHigh_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-NO_IntegerMinHigh_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerMinHigh_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerMinHigh_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerMinHigh_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerMinHigh_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerMinHigh_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NO-IntegerMinHigh] >>> ***/
 
@@ -538,13 +282,13 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerMinHigh_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerMinHigh = {
 	"NO-IntegerMinHigh",
 	"NO-IntegerMinHigh",
-	NO_IntegerMinHigh_free,
-	NO_IntegerMinHigh_print,
+	INTEGER_free,
+	INTEGER_print,
 	NO_IntegerMinHigh_constraint,
-	NO_IntegerMinHigh_decode_ber,
-	NO_IntegerMinHigh_encode_der,
-	NO_IntegerMinHigh_decode_xer,
-	NO_IntegerMinHigh_encode_xer,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerMinHigh_tags_1,
@@ -609,68 +353,6 @@ NO_IntegerLowHigh_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerLowHigh_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-     /* td->specifics      = asn_DEF_NativeInteger.specifics;	// Defined explicitly */
-}
-
-void
-NO_IntegerLowHigh_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerLowHigh_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerLowHigh_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerLowHigh_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerLowHigh_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerLowHigh_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NO-IntegerLowHigh] >>> ***/
 
@@ -685,13 +367,13 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerLowHigh_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerLowHigh = {
 	"NO-IntegerLowHigh",
 	"NO-IntegerLowHigh",
-	NO_IntegerLowHigh_free,
-	NO_IntegerLowHigh_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	NO_IntegerLowHigh_constraint,
-	NO_IntegerLowHigh_decode_ber,
-	NO_IntegerLowHigh_encode_der,
-	NO_IntegerLowHigh_decode_xer,
-	NO_IntegerLowHigh_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerLowHigh_tags_1,
@@ -762,68 +444,6 @@ CN_IntegerLowMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-CN_IntegerLowMax_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-CN_IntegerLowMax_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-CN_IntegerLowMax_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerLowMax_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-CN_IntegerLowMax_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerLowMax_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-CN_IntegerLowMax_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [CN-IntegerLowMax] >>> ***/
 
@@ -833,13 +453,13 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerLowMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerLowMax = {
 	"CN-IntegerLowMax",
 	"CN-IntegerLowMax",
-	CN_IntegerLowMax_free,
-	CN_IntegerLowMax_print,
+	INTEGER_free,
+	INTEGER_print,
 	CN_IntegerLowMax_constraint,
-	CN_IntegerLowMax_decode_ber,
-	CN_IntegerLowMax_encode_der,
-	CN_IntegerLowMax_decode_xer,
-	CN_IntegerLowMax_encode_xer,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerLowMax_tags_1,
@@ -910,68 +530,6 @@ NO_IntegerHighMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerHighMax_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-NO_IntegerHighMax_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerHighMax_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerHighMax_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerHighMax_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerHighMax_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerHighMax_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NO-IntegerHighMax] >>> ***/
 
@@ -981,13 +539,13 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerHighMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerHighMax = {
 	"NO-IntegerHighMax",
 	"NO-IntegerHighMax",
-	NO_IntegerHighMax_free,
-	NO_IntegerHighMax_print,
+	INTEGER_free,
+	INTEGER_print,
 	NO_IntegerHighMax_constraint,
-	NO_IntegerHighMax_decode_ber,
-	NO_IntegerHighMax_encode_der,
-	NO_IntegerHighMax_decode_xer,
-	NO_IntegerHighMax_encode_xer,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerHighMax_tags_1,
@@ -1058,68 +616,6 @@ NO_IntegerLowestMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerLowestMax_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-NO_IntegerLowestMax_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerLowestMax_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerLowestMax_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerLowestMax_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerLowestMax_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerLowestMax_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NO-IntegerLowestMax] >>> ***/
 
@@ -1129,13 +625,13 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerLowestMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerLowestMax = {
 	"NO-IntegerLowestMax",
 	"NO-IntegerLowestMax",
-	NO_IntegerLowestMax_free,
-	NO_IntegerLowestMax_print,
+	INTEGER_free,
+	INTEGER_print,
 	NO_IntegerLowestMax_constraint,
-	NO_IntegerLowestMax_decode_ber,
-	NO_IntegerLowestMax_encode_der,
-	NO_IntegerLowestMax_decode_xer,
-	NO_IntegerLowestMax_encode_xer,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerLowestMax_tags_1,
@@ -1200,68 +696,6 @@ NO_IntegerOutRange_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerOutRange_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-     /* td->specifics      = asn_DEF_NativeInteger.specifics;	// Defined explicitly */
-}
-
-void
-NO_IntegerOutRange_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerOutRange_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerOutRange_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerOutRange_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerOutRange_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerOutRange_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NO-IntegerOutRange] >>> ***/
 
@@ -1276,13 +710,13 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerOutRange_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerOutRange = {
 	"NO-IntegerOutRange",
 	"NO-IntegerOutRange",
-	NO_IntegerOutRange_free,
-	NO_IntegerOutRange_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	NO_IntegerOutRange_constraint,
-	NO_IntegerOutRange_decode_ber,
-	NO_IntegerOutRange_encode_der,
-	NO_IntegerOutRange_decode_xer,
-	NO_IntegerOutRange_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerOutRange_tags_1,
@@ -1347,68 +781,6 @@ NO_IntegerOutValue_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerOutValue_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-     /* td->specifics      = asn_DEF_NativeInteger.specifics;	// Defined explicitly */
-}
-
-void
-NO_IntegerOutValue_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerOutValue_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerOutValue_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerOutValue_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerOutValue_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerOutValue_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NO-IntegerOutValue] >>> ***/
 
@@ -1423,13 +795,13 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerOutValue_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerOutValue = {
 	"NO-IntegerOutValue",
 	"NO-IntegerOutValue",
-	NO_IntegerOutValue_free,
-	NO_IntegerOutValue_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	NO_IntegerOutValue_constraint,
-	NO_IntegerOutValue_decode_ber,
-	NO_IntegerOutValue_encode_der,
-	NO_IntegerOutValue_decode_xer,
-	NO_IntegerOutValue_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerOutValue_tags_1,
@@ -1494,68 +866,6 @@ OK_IntegerInRange1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_IntegerInRange1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-OK_IntegerInRange1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_IntegerInRange1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [OK-IntegerInRange1] >>> ***/
 
@@ -1565,13 +875,13 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange1 = {
 	"OK-IntegerInRange1",
 	"OK-IntegerInRange1",
-	OK_IntegerInRange1_free,
-	OK_IntegerInRange1_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	OK_IntegerInRange1_constraint,
-	OK_IntegerInRange1_decode_ber,
-	OK_IntegerInRange1_encode_der,
-	OK_IntegerInRange1_decode_xer,
-	OK_IntegerInRange1_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange1_tags_1,
@@ -1636,68 +946,6 @@ OK_IntegerInRange2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_IntegerInRange2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-OK_IntegerInRange2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_IntegerInRange2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [OK-IntegerInRange2] >>> ***/
 
@@ -1707,13 +955,13 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange2 = {
 	"OK-IntegerInRange2",
 	"OK-IntegerInRange2",
-	OK_IntegerInRange2_free,
-	OK_IntegerInRange2_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	OK_IntegerInRange2_constraint,
-	OK_IntegerInRange2_decode_ber,
-	OK_IntegerInRange2_encode_der,
-	OK_IntegerInRange2_decode_xer,
-	OK_IntegerInRange2_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange2_tags_1,
@@ -1778,68 +1026,6 @@ OK_IntegerInRange3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_IntegerInRange3_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-OK_IntegerInRange3_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_IntegerInRange3_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange3_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange3_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange3_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange3_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [OK-IntegerInRange3] >>> ***/
 
@@ -1849,13 +1035,13 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange3 = {
 	"OK-IntegerInRange3",
 	"OK-IntegerInRange3",
-	OK_IntegerInRange3_free,
-	OK_IntegerInRange3_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	OK_IntegerInRange3_constraint,
-	OK_IntegerInRange3_decode_ber,
-	OK_IntegerInRange3_encode_der,
-	OK_IntegerInRange3_decode_xer,
-	OK_IntegerInRange3_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange3_tags_1,
@@ -1920,68 +1106,6 @@ OK_IntegerInRange4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_IntegerInRange4_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-OK_IntegerInRange4_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_IntegerInRange4_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange4_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange4_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange4_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange4_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [OK-IntegerInRange4] >>> ***/
 
@@ -1991,13 +1115,13 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange4 = {
 	"OK-IntegerInRange4",
 	"OK-IntegerInRange4",
-	OK_IntegerInRange4_free,
-	OK_IntegerInRange4_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	OK_IntegerInRange4_constraint,
-	OK_IntegerInRange4_decode_ber,
-	OK_IntegerInRange4_encode_der,
-	OK_IntegerInRange4_decode_xer,
-	OK_IntegerInRange4_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange4_tags_1,
@@ -2068,68 +1192,6 @@ OK_IntegerInRange5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_IntegerInRange5_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-OK_IntegerInRange5_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_IntegerInRange5_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange5_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange5_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange5_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange5_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [OK-IntegerInRange5] >>> ***/
 
@@ -2139,13 +1201,13 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange5 = {
 	"OK-IntegerInRange5",
 	"OK-IntegerInRange5",
-	OK_IntegerInRange5_free,
-	OK_IntegerInRange5_print,
+	INTEGER_free,
+	INTEGER_print,
 	OK_IntegerInRange5_constraint,
-	OK_IntegerInRange5_decode_ber,
-	OK_IntegerInRange5_encode_der,
-	OK_IntegerInRange5_decode_xer,
-	OK_IntegerInRange5_encode_xer,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange5_tags_1,
@@ -2201,68 +1263,6 @@ NO_IntegerInRange6_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerInRange6_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-     /* td->specifics      = asn_DEF_NativeInteger.specifics;	// Defined explicitly */
-}
-
-void
-NO_IntegerInRange6_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerInRange6_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerInRange6_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerInRange6_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerInRange6_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerInRange6_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NO-IntegerInRange6] >>> ***/
 
@@ -2277,13 +1277,13 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerInRange6_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerInRange6 = {
 	"NO-IntegerInRange6",
 	"NO-IntegerInRange6",
-	NO_IntegerInRange6_free,
-	NO_IntegerInRange6_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	NO_IntegerInRange6_constraint,
-	NO_IntegerInRange6_decode_ber,
-	NO_IntegerInRange6_encode_der,
-	NO_IntegerInRange6_decode_xer,
-	NO_IntegerInRange6_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerInRange6_tags_1,
@@ -2326,80 +1326,10 @@ xer_type_encoder_f CN_IntegerEnumerated1_encode_xer;
 
 /*** <<< CODE [CN-IntegerEnumerated1] >>> ***/
 
-int
-CN_IntegerEnumerated1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-CN_IntegerEnumerated1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-CN_IntegerEnumerated1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerEnumerated1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-CN_IntegerEnumerated1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerEnumerated1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-CN_IntegerEnumerated1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [CN-IntegerEnumerated1] >>> ***/
 
@@ -2409,13 +1339,13 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerEnumerated1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerEnumerated1 = {
 	"CN-IntegerEnumerated1",
 	"CN-IntegerEnumerated1",
-	CN_IntegerEnumerated1_free,
-	CN_IntegerEnumerated1_print,
-	CN_IntegerEnumerated1_constraint,
-	CN_IntegerEnumerated1_decode_ber,
-	CN_IntegerEnumerated1_encode_der,
-	CN_IntegerEnumerated1_decode_xer,
-	CN_IntegerEnumerated1_encode_xer,
+	INTEGER_free,
+	INTEGER_print,
+	INTEGER_constraint,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerEnumerated1_tags_1,
@@ -2458,80 +1388,10 @@ xer_type_encoder_f NO_IntegerEnumerated2_encode_xer;
 
 /*** <<< CODE [NO-IntegerEnumerated2] >>> ***/
 
-int
-NO_IntegerEnumerated2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-NO_IntegerEnumerated2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerEnumerated2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerEnumerated2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerEnumerated2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerEnumerated2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerEnumerated2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NO-IntegerEnumerated2] >>> ***/
 
@@ -2541,13 +1401,13 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerEnumerated2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerEnumerated2 = {
 	"NO-IntegerEnumerated2",
 	"NO-IntegerEnumerated2",
-	NO_IntegerEnumerated2_free,
-	NO_IntegerEnumerated2_print,
-	NO_IntegerEnumerated2_constraint,
-	NO_IntegerEnumerated2_decode_ber,
-	NO_IntegerEnumerated2_encode_der,
-	NO_IntegerEnumerated2_decode_xer,
-	NO_IntegerEnumerated2_encode_xer,
+	INTEGER_free,
+	INTEGER_print,
+	INTEGER_constraint,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerEnumerated2_tags_1,

--- a/tests/90-cond-int-type-OK.asn1.-Pgen-PER
+++ b/tests/90-cond-int-type-OK.asn1.-Pgen-PER
@@ -22,95 +22,10 @@ per_type_encoder_f CN_IntegerUnlimited_encode_uper;
 
 /*** <<< CODE [CN-IntegerUnlimited] >>> ***/
 
-int
-CN_IntegerUnlimited_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-CN_IntegerUnlimited_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-CN_IntegerUnlimited_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-CN_IntegerUnlimited_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerUnlimited_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-CN_IntegerUnlimited_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerUnlimited_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-CN_IntegerUnlimited_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerUnlimited_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-CN_IntegerUnlimited_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	CN_IntegerUnlimited_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< STAT-DEFS [CN-IntegerUnlimited] >>> ***/
 
@@ -120,15 +35,15 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerUnlimited_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerUnlimited = {
 	"CN-IntegerUnlimited",
 	"CN-IntegerUnlimited",
-	CN_IntegerUnlimited_free,
-	CN_IntegerUnlimited_print,
-	CN_IntegerUnlimited_constraint,
-	CN_IntegerUnlimited_decode_ber,
-	CN_IntegerUnlimited_encode_der,
-	CN_IntegerUnlimited_decode_xer,
-	CN_IntegerUnlimited_encode_xer,
-	CN_IntegerUnlimited_decode_uper,
-	CN_IntegerUnlimited_encode_uper,
+	NativeInteger_free,
+	NativeInteger_print,
+	NativeInteger_constraint,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerUnlimited_tags_1,
 	sizeof(asn_DEF_CN_IntegerUnlimited_tags_1)
@@ -190,83 +105,6 @@ CN_IntegerMinMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-CN_IntegerMinMax_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-CN_IntegerMinMax_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-CN_IntegerMinMax_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerMinMax_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-CN_IntegerMinMax_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerMinMax_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-CN_IntegerMinMax_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerMinMax_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-CN_IntegerMinMax_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	CN_IntegerMinMax_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [CN-IntegerMinMax] >>> ***/
 
@@ -284,15 +122,15 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerMinMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerMinMax = {
 	"CN-IntegerMinMax",
 	"CN-IntegerMinMax",
-	CN_IntegerMinMax_free,
-	CN_IntegerMinMax_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	CN_IntegerMinMax_constraint,
-	CN_IntegerMinMax_decode_ber,
-	CN_IntegerMinMax_encode_der,
-	CN_IntegerMinMax_decode_xer,
-	CN_IntegerMinMax_encode_xer,
-	CN_IntegerMinMax_decode_uper,
-	CN_IntegerMinMax_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerMinMax_tags_1,
 	sizeof(asn_DEF_CN_IntegerMinMax_tags_1)
@@ -358,83 +196,6 @@ CN_IntegerMinLow_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-CN_IntegerMinLow_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-CN_IntegerMinLow_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-CN_IntegerMinLow_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerMinLow_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-CN_IntegerMinLow_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerMinLow_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-CN_IntegerMinLow_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerMinLow_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-CN_IntegerMinLow_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	CN_IntegerMinLow_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [CN-IntegerMinLow] >>> ***/
 
@@ -452,15 +213,15 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerMinLow_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerMinLow = {
 	"CN-IntegerMinLow",
 	"CN-IntegerMinLow",
-	CN_IntegerMinLow_free,
-	CN_IntegerMinLow_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	CN_IntegerMinLow_constraint,
-	CN_IntegerMinLow_decode_ber,
-	CN_IntegerMinLow_encode_der,
-	CN_IntegerMinLow_decode_xer,
-	CN_IntegerMinLow_encode_xer,
-	CN_IntegerMinLow_decode_uper,
-	CN_IntegerMinLow_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerMinLow_tags_1,
 	sizeof(asn_DEF_CN_IntegerMinLow_tags_1)
@@ -532,83 +293,6 @@ NO_IntegerMinHigh_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerMinHigh_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-NO_IntegerMinHigh_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerMinHigh_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerMinHigh_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerMinHigh_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerMinHigh_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerMinHigh_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerMinHigh_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-NO_IntegerMinHigh_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	NO_IntegerMinHigh_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [NO-IntegerMinHigh] >>> ***/
 
@@ -626,15 +310,15 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerMinHigh_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerMinHigh = {
 	"NO-IntegerMinHigh",
 	"NO-IntegerMinHigh",
-	NO_IntegerMinHigh_free,
-	NO_IntegerMinHigh_print,
+	INTEGER_free,
+	INTEGER_print,
 	NO_IntegerMinHigh_constraint,
-	NO_IntegerMinHigh_decode_ber,
-	NO_IntegerMinHigh_encode_der,
-	NO_IntegerMinHigh_decode_xer,
-	NO_IntegerMinHigh_encode_xer,
-	NO_IntegerMinHigh_decode_uper,
-	NO_IntegerMinHigh_encode_uper,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
+	INTEGER_decode_uper,
+	INTEGER_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerMinHigh_tags_1,
 	sizeof(asn_DEF_NO_IntegerMinHigh_tags_1)
@@ -700,83 +384,6 @@ NO_IntegerLowHigh_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerLowHigh_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-     /* td->specifics      = asn_DEF_NativeInteger.specifics;	// Defined explicitly */
-}
-
-void
-NO_IntegerLowHigh_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerLowHigh_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerLowHigh_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerLowHigh_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerLowHigh_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerLowHigh_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerLowHigh_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-NO_IntegerLowHigh_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	NO_IntegerLowHigh_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [NO-IntegerLowHigh] >>> ***/
 
@@ -799,15 +406,15 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerLowHigh_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerLowHigh = {
 	"NO-IntegerLowHigh",
 	"NO-IntegerLowHigh",
-	NO_IntegerLowHigh_free,
-	NO_IntegerLowHigh_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	NO_IntegerLowHigh_constraint,
-	NO_IntegerLowHigh_decode_ber,
-	NO_IntegerLowHigh_encode_der,
-	NO_IntegerLowHigh_decode_xer,
-	NO_IntegerLowHigh_encode_xer,
-	NO_IntegerLowHigh_decode_uper,
-	NO_IntegerLowHigh_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerLowHigh_tags_1,
 	sizeof(asn_DEF_NO_IntegerLowHigh_tags_1)
@@ -873,83 +480,6 @@ CN_IntegerLowMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-CN_IntegerLowMax_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-CN_IntegerLowMax_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-CN_IntegerLowMax_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerLowMax_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-CN_IntegerLowMax_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerLowMax_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-CN_IntegerLowMax_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerLowMax_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-CN_IntegerLowMax_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	CN_IntegerLowMax_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [CN-IntegerLowMax] >>> ***/
 
@@ -967,15 +497,15 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerLowMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerLowMax = {
 	"CN-IntegerLowMax",
 	"CN-IntegerLowMax",
-	CN_IntegerLowMax_free,
-	CN_IntegerLowMax_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	CN_IntegerLowMax_constraint,
-	CN_IntegerLowMax_decode_ber,
-	CN_IntegerLowMax_encode_der,
-	CN_IntegerLowMax_decode_xer,
-	CN_IntegerLowMax_encode_xer,
-	CN_IntegerLowMax_decode_uper,
-	CN_IntegerLowMax_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerLowMax_tags_1,
 	sizeof(asn_DEF_CN_IntegerLowMax_tags_1)
@@ -1047,83 +577,6 @@ NO_IntegerHighMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerHighMax_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-NO_IntegerHighMax_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerHighMax_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerHighMax_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerHighMax_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerHighMax_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerHighMax_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerHighMax_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-NO_IntegerHighMax_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	NO_IntegerHighMax_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [NO-IntegerHighMax] >>> ***/
 
@@ -1141,15 +594,15 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerHighMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerHighMax = {
 	"NO-IntegerHighMax",
 	"NO-IntegerHighMax",
-	NO_IntegerHighMax_free,
-	NO_IntegerHighMax_print,
+	INTEGER_free,
+	INTEGER_print,
 	NO_IntegerHighMax_constraint,
-	NO_IntegerHighMax_decode_ber,
-	NO_IntegerHighMax_encode_der,
-	NO_IntegerHighMax_decode_xer,
-	NO_IntegerHighMax_encode_xer,
-	NO_IntegerHighMax_decode_uper,
-	NO_IntegerHighMax_encode_uper,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
+	INTEGER_decode_uper,
+	INTEGER_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerHighMax_tags_1,
 	sizeof(asn_DEF_NO_IntegerHighMax_tags_1)
@@ -1221,83 +674,6 @@ NO_IntegerLowestMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerLowestMax_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-NO_IntegerLowestMax_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerLowestMax_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerLowestMax_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerLowestMax_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerLowestMax_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerLowestMax_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerLowestMax_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-NO_IntegerLowestMax_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	NO_IntegerLowestMax_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [NO-IntegerLowestMax] >>> ***/
 
@@ -1315,15 +691,15 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerLowestMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerLowestMax = {
 	"NO-IntegerLowestMax",
 	"NO-IntegerLowestMax",
-	NO_IntegerLowestMax_free,
-	NO_IntegerLowestMax_print,
+	INTEGER_free,
+	INTEGER_print,
 	NO_IntegerLowestMax_constraint,
-	NO_IntegerLowestMax_decode_ber,
-	NO_IntegerLowestMax_encode_der,
-	NO_IntegerLowestMax_decode_xer,
-	NO_IntegerLowestMax_encode_xer,
-	NO_IntegerLowestMax_decode_uper,
-	NO_IntegerLowestMax_encode_uper,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
+	INTEGER_decode_uper,
+	INTEGER_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerLowestMax_tags_1,
 	sizeof(asn_DEF_NO_IntegerLowestMax_tags_1)
@@ -1389,83 +765,6 @@ NO_IntegerOutRange_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerOutRange_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-     /* td->specifics      = asn_DEF_NativeInteger.specifics;	// Defined explicitly */
-}
-
-void
-NO_IntegerOutRange_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerOutRange_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerOutRange_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerOutRange_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerOutRange_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerOutRange_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerOutRange_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-NO_IntegerOutRange_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	NO_IntegerOutRange_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [NO-IntegerOutRange] >>> ***/
 
@@ -1488,15 +787,15 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerOutRange_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerOutRange = {
 	"NO-IntegerOutRange",
 	"NO-IntegerOutRange",
-	NO_IntegerOutRange_free,
-	NO_IntegerOutRange_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	NO_IntegerOutRange_constraint,
-	NO_IntegerOutRange_decode_ber,
-	NO_IntegerOutRange_encode_der,
-	NO_IntegerOutRange_decode_xer,
-	NO_IntegerOutRange_encode_xer,
-	NO_IntegerOutRange_decode_uper,
-	NO_IntegerOutRange_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerOutRange_tags_1,
 	sizeof(asn_DEF_NO_IntegerOutRange_tags_1)
@@ -1562,83 +861,6 @@ NO_IntegerOutValue_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerOutValue_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-     /* td->specifics      = asn_DEF_NativeInteger.specifics;	// Defined explicitly */
-}
-
-void
-NO_IntegerOutValue_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerOutValue_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerOutValue_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerOutValue_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerOutValue_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerOutValue_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerOutValue_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-NO_IntegerOutValue_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	NO_IntegerOutValue_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [NO-IntegerOutValue] >>> ***/
 
@@ -1661,15 +883,15 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerOutValue_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerOutValue = {
 	"NO-IntegerOutValue",
 	"NO-IntegerOutValue",
-	NO_IntegerOutValue_free,
-	NO_IntegerOutValue_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	NO_IntegerOutValue_constraint,
-	NO_IntegerOutValue_decode_ber,
-	NO_IntegerOutValue_encode_der,
-	NO_IntegerOutValue_decode_xer,
-	NO_IntegerOutValue_encode_xer,
-	NO_IntegerOutValue_decode_uper,
-	NO_IntegerOutValue_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerOutValue_tags_1,
 	sizeof(asn_DEF_NO_IntegerOutValue_tags_1)
@@ -1735,83 +957,6 @@ OK_IntegerInRange1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_IntegerInRange1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-OK_IntegerInRange1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_IntegerInRange1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange1_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange1_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	OK_IntegerInRange1_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [OK-IntegerInRange1] >>> ***/
 
@@ -1829,15 +974,15 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange1 = {
 	"OK-IntegerInRange1",
 	"OK-IntegerInRange1",
-	OK_IntegerInRange1_free,
-	OK_IntegerInRange1_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	OK_IntegerInRange1_constraint,
-	OK_IntegerInRange1_decode_ber,
-	OK_IntegerInRange1_encode_der,
-	OK_IntegerInRange1_decode_xer,
-	OK_IntegerInRange1_encode_xer,
-	OK_IntegerInRange1_decode_uper,
-	OK_IntegerInRange1_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange1_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange1_tags_1)
@@ -1903,83 +1048,6 @@ OK_IntegerInRange2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_IntegerInRange2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-OK_IntegerInRange2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_IntegerInRange2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange2_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange2_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	OK_IntegerInRange2_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [OK-IntegerInRange2] >>> ***/
 
@@ -1997,15 +1065,15 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange2 = {
 	"OK-IntegerInRange2",
 	"OK-IntegerInRange2",
-	OK_IntegerInRange2_free,
-	OK_IntegerInRange2_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	OK_IntegerInRange2_constraint,
-	OK_IntegerInRange2_decode_ber,
-	OK_IntegerInRange2_encode_der,
-	OK_IntegerInRange2_decode_xer,
-	OK_IntegerInRange2_encode_xer,
-	OK_IntegerInRange2_decode_uper,
-	OK_IntegerInRange2_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange2_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange2_tags_1)
@@ -2071,83 +1139,6 @@ OK_IntegerInRange3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_IntegerInRange3_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-OK_IntegerInRange3_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_IntegerInRange3_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange3_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange3_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange3_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange3_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange3_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange3_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	OK_IntegerInRange3_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [OK-IntegerInRange3] >>> ***/
 
@@ -2165,15 +1156,15 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange3 = {
 	"OK-IntegerInRange3",
 	"OK-IntegerInRange3",
-	OK_IntegerInRange3_free,
-	OK_IntegerInRange3_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	OK_IntegerInRange3_constraint,
-	OK_IntegerInRange3_decode_ber,
-	OK_IntegerInRange3_encode_der,
-	OK_IntegerInRange3_decode_xer,
-	OK_IntegerInRange3_encode_xer,
-	OK_IntegerInRange3_decode_uper,
-	OK_IntegerInRange3_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange3_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange3_tags_1)
@@ -2239,83 +1230,6 @@ OK_IntegerInRange4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_IntegerInRange4_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-OK_IntegerInRange4_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_IntegerInRange4_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange4_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange4_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange4_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange4_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange4_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange4_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	OK_IntegerInRange4_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [OK-IntegerInRange4] >>> ***/
 
@@ -2333,15 +1247,15 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange4 = {
 	"OK-IntegerInRange4",
 	"OK-IntegerInRange4",
-	OK_IntegerInRange4_free,
-	OK_IntegerInRange4_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	OK_IntegerInRange4_constraint,
-	OK_IntegerInRange4_decode_ber,
-	OK_IntegerInRange4_encode_der,
-	OK_IntegerInRange4_decode_xer,
-	OK_IntegerInRange4_encode_xer,
-	OK_IntegerInRange4_decode_uper,
-	OK_IntegerInRange4_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange4_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange4_tags_1)
@@ -2407,83 +1321,6 @@ OK_IntegerInRange5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_IntegerInRange5_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-OK_IntegerInRange5_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_IntegerInRange5_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange5_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange5_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange5_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange5_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_IntegerInRange5_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-OK_IntegerInRange5_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	OK_IntegerInRange5_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [OK-IntegerInRange5] >>> ***/
 
@@ -2501,15 +1338,15 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange5 = {
 	"OK-IntegerInRange5",
 	"OK-IntegerInRange5",
-	OK_IntegerInRange5_free,
-	OK_IntegerInRange5_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	OK_IntegerInRange5_constraint,
-	OK_IntegerInRange5_decode_ber,
-	OK_IntegerInRange5_encode_der,
-	OK_IntegerInRange5_decode_xer,
-	OK_IntegerInRange5_encode_xer,
-	OK_IntegerInRange5_decode_uper,
-	OK_IntegerInRange5_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange5_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange5_tags_1)
@@ -2566,83 +1403,6 @@ NO_IntegerInRange6_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerInRange6_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-     /* td->specifics      = asn_DEF_NativeInteger.specifics;	// Defined explicitly */
-}
-
-void
-NO_IntegerInRange6_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerInRange6_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerInRange6_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerInRange6_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerInRange6_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerInRange6_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerInRange6_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-NO_IntegerInRange6_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	NO_IntegerInRange6_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< CTDEFS [NO-IntegerInRange6] >>> ***/
 
@@ -2665,15 +1425,15 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerInRange6_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerInRange6 = {
 	"NO-IntegerInRange6",
 	"NO-IntegerInRange6",
-	NO_IntegerInRange6_free,
-	NO_IntegerInRange6_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	NO_IntegerInRange6_constraint,
-	NO_IntegerInRange6_decode_ber,
-	NO_IntegerInRange6_encode_der,
-	NO_IntegerInRange6_decode_xer,
-	NO_IntegerInRange6_encode_xer,
-	NO_IntegerInRange6_decode_uper,
-	NO_IntegerInRange6_encode_uper,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerInRange6_tags_1,
 	sizeof(asn_DEF_NO_IntegerInRange6_tags_1)
@@ -2717,95 +1477,10 @@ per_type_encoder_f CN_IntegerEnumerated1_encode_uper;
 
 /*** <<< CODE [CN-IntegerEnumerated1] >>> ***/
 
-int
-CN_IntegerEnumerated1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-CN_IntegerEnumerated1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-CN_IntegerEnumerated1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerEnumerated1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-CN_IntegerEnumerated1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerEnumerated1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-CN_IntegerEnumerated1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-CN_IntegerEnumerated1_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-CN_IntegerEnumerated1_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	CN_IntegerEnumerated1_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< STAT-DEFS [CN-IntegerEnumerated1] >>> ***/
 
@@ -2815,15 +1490,15 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerEnumerated1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerEnumerated1 = {
 	"CN-IntegerEnumerated1",
 	"CN-IntegerEnumerated1",
-	CN_IntegerEnumerated1_free,
-	CN_IntegerEnumerated1_print,
-	CN_IntegerEnumerated1_constraint,
-	CN_IntegerEnumerated1_decode_ber,
-	CN_IntegerEnumerated1_encode_der,
-	CN_IntegerEnumerated1_decode_xer,
-	CN_IntegerEnumerated1_encode_xer,
-	CN_IntegerEnumerated1_decode_uper,
-	CN_IntegerEnumerated1_encode_uper,
+	NativeInteger_free,
+	NativeInteger_print,
+	NativeInteger_constraint,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
+	NativeInteger_decode_uper,
+	NativeInteger_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerEnumerated1_tags_1,
 	sizeof(asn_DEF_CN_IntegerEnumerated1_tags_1)
@@ -2867,95 +1542,10 @@ per_type_encoder_f NO_IntegerEnumerated2_encode_uper;
 
 /*** <<< CODE [NO-IntegerEnumerated2] >>> ***/
 
-int
-NO_IntegerEnumerated2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using INTEGER,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_INTEGER.free_struct;
-	td->print_struct   = asn_DEF_INTEGER.print_struct;
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	td->ber_decoder    = asn_DEF_INTEGER.ber_decoder;
-	td->der_encoder    = asn_DEF_INTEGER.der_encoder;
-	td->xer_decoder    = asn_DEF_INTEGER.xer_decoder;
-	td->xer_encoder    = asn_DEF_INTEGER.xer_encoder;
-	td->uper_decoder   = asn_DEF_INTEGER.uper_decoder;
-	td->uper_encoder   = asn_DEF_INTEGER.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_INTEGER.per_constraints;
-	td->elements       = asn_DEF_INTEGER.elements;
-	td->elements_count = asn_DEF_INTEGER.elements_count;
-	td->specifics      = asn_DEF_INTEGER.specifics;
-}
-
-void
-NO_IntegerEnumerated2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_IntegerEnumerated2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerEnumerated2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_IntegerEnumerated2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerEnumerated2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_IntegerEnumerated2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_IntegerEnumerated2_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints, void **structure, asn_per_data_t *per_data) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	return td->uper_decoder(opt_codec_ctx, td, constraints, structure, per_data);
-}
-
-asn_enc_rval_t
-NO_IntegerEnumerated2_encode_uper(asn_TYPE_descriptor_t *td,
-		asn_per_constraints_t *constraints,
-		void *structure, asn_per_outp_t *per_out) {
-	NO_IntegerEnumerated2_1_inherit_TYPE_descriptor(td);
-	return td->uper_encoder(td, constraints, structure, per_out);
-}
-
 
 /*** <<< STAT-DEFS [NO-IntegerEnumerated2] >>> ***/
 
@@ -2965,15 +1555,15 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerEnumerated2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerEnumerated2 = {
 	"NO-IntegerEnumerated2",
 	"NO-IntegerEnumerated2",
-	NO_IntegerEnumerated2_free,
-	NO_IntegerEnumerated2_print,
-	NO_IntegerEnumerated2_constraint,
-	NO_IntegerEnumerated2_decode_ber,
-	NO_IntegerEnumerated2_encode_der,
-	NO_IntegerEnumerated2_decode_xer,
-	NO_IntegerEnumerated2_encode_xer,
-	NO_IntegerEnumerated2_decode_uper,
-	NO_IntegerEnumerated2_encode_uper,
+	INTEGER_free,
+	INTEGER_print,
+	INTEGER_constraint,
+	INTEGER_decode_ber,
+	INTEGER_encode_der,
+	INTEGER_decode_xer,
+	INTEGER_encode_xer,
+	INTEGER_decode_uper,
+	INTEGER_encode_uper,
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerEnumerated2_tags_1,
 	sizeof(asn_DEF_NO_IntegerEnumerated2_tags_1)

--- a/tests/91-cond-int-blessSize-OK.asn1.-Pfbless-SIZE
+++ b/tests/91-cond-int-blessSize-OK.asn1.-Pfbless-SIZE
@@ -45,68 +45,6 @@ OK_Integer1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_Integer1_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-OK_Integer1_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_Integer1_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_Integer1_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_Integer1_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_Integer1_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_Integer1_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_Integer1_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_Integer1_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_Integer1_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_Integer1_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_Integer1_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_Integer1_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [OK-Integer1] >>> ***/
 
@@ -116,13 +54,13 @@ static const ber_tlv_tag_t asn_DEF_OK_Integer1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_Integer1 = {
 	"OK-Integer1",
 	"OK-Integer1",
-	OK_Integer1_free,
-	OK_Integer1_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	OK_Integer1_constraint,
-	OK_Integer1_decode_ber,
-	OK_Integer1_encode_der,
-	OK_Integer1_decode_xer,
-	OK_Integer1_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_Integer1_tags_1,
@@ -183,68 +121,6 @@ OK_Integer2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_Integer2_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-OK_Integer2_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_Integer2_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_Integer2_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_Integer2_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_Integer2_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_Integer2_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_Integer2_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_Integer2_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_Integer2_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_Integer2_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_Integer2_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_Integer2_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [OK-Integer2] >>> ***/
 
@@ -254,13 +130,13 @@ static const ber_tlv_tag_t asn_DEF_OK_Integer2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_Integer2 = {
 	"OK-Integer2",
 	"OK-Integer2",
-	OK_Integer2_free,
-	OK_Integer2_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	OK_Integer2_constraint,
-	OK_Integer2_decode_ber,
-	OK_Integer2_encode_der,
-	OK_Integer2_decode_xer,
-	OK_Integer2_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_Integer2_tags_1,
@@ -321,68 +197,6 @@ OK_Integer3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_Integer3_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-OK_Integer3_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_Integer3_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_Integer3_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_Integer3_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_Integer3_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_Integer3_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_Integer3_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_Integer3_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_Integer3_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_Integer3_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_Integer3_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_Integer3_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [OK-Integer3] >>> ***/
 
@@ -392,13 +206,13 @@ static const ber_tlv_tag_t asn_DEF_OK_Integer3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_Integer3 = {
 	"OK-Integer3",
 	"OK-Integer3",
-	OK_Integer3_free,
-	OK_Integer3_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	OK_Integer3_constraint,
-	OK_Integer3_decode_ber,
-	OK_Integer3_encode_der,
-	OK_Integer3_decode_xer,
-	OK_Integer3_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_Integer3_tags_1,
@@ -459,68 +273,6 @@ OK_Integer4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-OK_Integer4_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-OK_Integer4_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	OK_Integer4_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-OK_Integer4_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_Integer4_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_Integer4_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	OK_Integer4_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-OK_Integer4_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_Integer4_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-OK_Integer4_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	OK_Integer4_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-OK_Integer4_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	OK_Integer4_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [OK-Integer4] >>> ***/
 
@@ -530,13 +282,13 @@ static const ber_tlv_tag_t asn_DEF_OK_Integer4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_Integer4 = {
 	"OK-Integer4",
 	"OK-Integer4",
-	OK_Integer4_free,
-	OK_Integer4_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	OK_Integer4_constraint,
-	OK_Integer4_decode_ber,
-	OK_Integer4_encode_der,
-	OK_Integer4_decode_xer,
-	OK_Integer4_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_Integer4_tags_1,
@@ -597,68 +349,6 @@ NO_Integer5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
  * This type is implemented using NativeInteger,
  * so here we adjust the DEF accordingly.
  */
-static void
-NO_Integer5_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_NativeInteger.free_struct;
-	td->print_struct   = asn_DEF_NativeInteger.print_struct;
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	td->ber_decoder    = asn_DEF_NativeInteger.ber_decoder;
-	td->der_encoder    = asn_DEF_NativeInteger.der_encoder;
-	td->xer_decoder    = asn_DEF_NativeInteger.xer_decoder;
-	td->xer_encoder    = asn_DEF_NativeInteger.xer_encoder;
-	td->uper_decoder   = asn_DEF_NativeInteger.uper_decoder;
-	td->uper_encoder   = asn_DEF_NativeInteger.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_NativeInteger.per_constraints;
-	td->elements       = asn_DEF_NativeInteger.elements;
-	td->elements_count = asn_DEF_NativeInteger.elements_count;
-	td->specifics      = asn_DEF_NativeInteger.specifics;
-}
-
-void
-NO_Integer5_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	NO_Integer5_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-NO_Integer5_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_Integer5_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_Integer5_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	NO_Integer5_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-NO_Integer5_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_Integer5_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-NO_Integer5_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	NO_Integer5_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-NO_Integer5_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	NO_Integer5_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [NO-Integer5] >>> ***/
 
@@ -668,13 +358,13 @@ static const ber_tlv_tag_t asn_DEF_NO_Integer5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_Integer5 = {
 	"NO-Integer5",
 	"NO-Integer5",
-	NO_Integer5_free,
-	NO_Integer5_print,
+	NativeInteger_free,
+	NativeInteger_print,
 	NO_Integer5_constraint,
-	NO_Integer5_decode_ber,
-	NO_Integer5_encode_der,
-	NO_Integer5_decode_xer,
-	NO_Integer5_encode_xer,
+	NativeInteger_decode_ber,
+	NativeInteger_encode_der,
+	NativeInteger_decode_xer,
+	NativeInteger_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_Integer5_tags_1,

--- a/tests/92-circular-loops-OK.asn1.-Pfindirect-choice
+++ b/tests/92-circular-loops-OK.asn1.-Pfindirect-choice
@@ -37,6 +37,8 @@ typedef struct Everything {
 /*** <<< FUNC-DECLS [Everything] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Everything;
+extern asn_SEQUENCE_specifics_t asn_SPC_Everything_specs_1;
+extern asn_TYPE_member_t asn_MBR_Everything_1[10];
 
 /*** <<< POST-INCLUDE [Everything] >>> ***/
 
@@ -46,7 +48,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Everything;
 
 /*** <<< STAT-DEFS [Everything] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Everything_1[] = {
+asn_TYPE_member_t asn_MBR_Everything_1[] = {
 	{ ATF_POINTER, 0, offsetof(struct Everything, ch1),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = +1,	/* EXPLICIT tag at current level */
@@ -153,7 +155,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Everything_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (8 << 2)), 8, 0, 0 }, /* tt */
     { (ASN_TAG_CLASS_CONTEXT | (9 << 2)), 9, 0, 0 } /* to */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Everything_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Everything_specs_1 = {
 	sizeof(struct Everything),
 	offsetof(struct Everything, _asn_ctx),
 	asn_MAP_Everything_tag2el_1,
@@ -224,6 +226,8 @@ typedef struct Choice1 {
 /*** <<< FUNC-DECLS [Choice1] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Choice1;
+extern asn_CHOICE_specifics_t asn_SPC_Choice1_specs_1;
+extern asn_TYPE_member_t asn_MBR_Choice1_1[2];
 
 /*** <<< POST-INCLUDE [Choice1] >>> ***/
 
@@ -231,7 +235,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Choice1;
 
 /*** <<< STAT-DEFS [Choice1] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Choice1_1[] = {
+asn_TYPE_member_t asn_MBR_Choice1_1[] = {
 	{ ATF_POINTER, 0, offsetof(struct Choice1, choice.something),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -255,7 +259,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Choice1_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* something */
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 } /* some2 */
 };
-static asn_CHOICE_specifics_t asn_SPC_Choice1_specs_1 = {
+asn_CHOICE_specifics_t asn_SPC_Choice1_specs_1 = {
 	sizeof(struct Choice1),
 	offsetof(struct Choice1, _asn_ctx),
 	offsetof(struct Choice1, present),
@@ -326,6 +330,8 @@ typedef struct Choice2 {
 /*** <<< FUNC-DECLS [Choice2] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Choice2;
+extern asn_CHOICE_specifics_t asn_SPC_Choice2_specs_1;
+extern asn_TYPE_member_t asn_MBR_Choice2_1[2];
 
 /*** <<< POST-INCLUDE [Choice2] >>> ***/
 
@@ -334,7 +340,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Choice2;
 
 /*** <<< STAT-DEFS [Choice2] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Choice2_1[] = {
+asn_TYPE_member_t asn_MBR_Choice2_1[] = {
 	{ ATF_POINTER, 0, offsetof(struct Choice2, choice.typeref),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -358,7 +364,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Choice2_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* typeref */
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 } /* some3 */
 };
-static asn_CHOICE_specifics_t asn_SPC_Choice2_specs_1 = {
+asn_CHOICE_specifics_t asn_SPC_Choice2_specs_1 = {
 	sizeof(struct Choice2),
 	offsetof(struct Choice2, _asn_ctx),
 	offsetof(struct Choice2, present),
@@ -439,6 +445,8 @@ typedef struct Choice3 {
 /*** <<< FUNC-DECLS [Choice3] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Choice3;
+extern asn_CHOICE_specifics_t asn_SPC_Choice3_specs_1;
+extern asn_TYPE_member_t asn_MBR_Choice3_1[3];
 
 /*** <<< POST-INCLUDE [Choice3] >>> ***/
 
@@ -544,7 +552,7 @@ asn_TYPE_descriptor_t asn_DEF_c_5 = {
 	&asn_SPC_c_specs_5	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_Choice3_1[] = {
+asn_TYPE_member_t asn_MBR_Choice3_1[] = {
 	{ ATF_POINTER, 0, offsetof(struct Choice3, choice.a),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = 0,
@@ -578,7 +586,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Choice3_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 }, /* b */
     { (ASN_TAG_CLASS_CONTEXT | (2 << 2)), 2, 0, 0 } /* c */
 };
-static asn_CHOICE_specifics_t asn_SPC_Choice3_specs_1 = {
+asn_CHOICE_specifics_t asn_SPC_Choice3_specs_1 = {
 	sizeof(struct Choice3),
 	offsetof(struct Choice3, _asn_ctx),
 	offsetof(struct Choice3, present),
@@ -652,6 +660,8 @@ typedef struct Set {
 /*** <<< FUNC-DECLS [Set] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Set;
+extern asn_SET_OF_specifics_t asn_SPC_Set_specs_1;
+extern asn_TYPE_member_t asn_MBR_Set_1[1];
 
 /*** <<< POST-INCLUDE [Set] >>> ***/
 
@@ -751,7 +761,7 @@ asn_TYPE_descriptor_t asn_DEF_Member_2 = {
 	&asn_SPC_Member_specs_2	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_Set_1[] = {
+asn_TYPE_member_t asn_MBR_Set_1[] = {
 	{ ATF_POINTER, 0, 0,
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
@@ -765,7 +775,7 @@ static asn_TYPE_member_t asn_MBR_Set_1[] = {
 static const ber_tlv_tag_t asn_DEF_Set_tags_1[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (17 << 2))
 };
-static asn_SET_OF_specifics_t asn_SPC_Set_specs_1 = {
+asn_SET_OF_specifics_t asn_SPC_Set_specs_1 = {
 	sizeof(struct Set),
 	offsetof(struct Set, _asn_ctx),
 	0,	/* XER encoding is XMLDelimitedItemList */
@@ -824,6 +834,8 @@ typedef struct Sequence {
 /*** <<< FUNC-DECLS [Sequence] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Sequence;
+extern asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1;
+extern asn_TYPE_member_t asn_MBR_Sequence_1[4];
 
 /*** <<< POST-INCLUDE [Sequence] >>> ***/
 
@@ -832,7 +844,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Sequence;
 
 /*** <<< STAT-DEFS [Sequence] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Sequence_1[] = {
+asn_TYPE_member_t asn_MBR_Sequence_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Sequence, a),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -879,7 +891,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Sequence_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (2 << 2)), 2, 0, 0 }, /* b */
     { (ASN_TAG_CLASS_CONTEXT | (3 << 2)), 3, 0, 0 } /* set */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1 = {
 	sizeof(struct Sequence),
 	offsetof(struct Sequence, _asn_ctx),
 	asn_MAP_Sequence_tag2el_1,
@@ -934,80 +946,10 @@ xer_type_encoder_f TypeRef_encode_xer;
 
 /*** <<< CODE [TypeRef] >>> ***/
 
-int
-TypeRef_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_Sequence.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using Sequence,
  * so here we adjust the DEF accordingly.
  */
-static void
-TypeRef_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Sequence.free_struct;
-	td->print_struct   = asn_DEF_Sequence.print_struct;
-	td->check_constraints = asn_DEF_Sequence.check_constraints;
-	td->ber_decoder    = asn_DEF_Sequence.ber_decoder;
-	td->der_encoder    = asn_DEF_Sequence.der_encoder;
-	td->xer_decoder    = asn_DEF_Sequence.xer_decoder;
-	td->xer_encoder    = asn_DEF_Sequence.xer_encoder;
-	td->uper_decoder   = asn_DEF_Sequence.uper_decoder;
-	td->uper_encoder   = asn_DEF_Sequence.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Sequence.per_constraints;
-	td->elements       = asn_DEF_Sequence.elements;
-	td->elements_count = asn_DEF_Sequence.elements_count;
-	td->specifics      = asn_DEF_Sequence.specifics;
-}
-
-void
-TypeRef_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	TypeRef_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-TypeRef_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	TypeRef_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-TypeRef_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	TypeRef_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-TypeRef_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	TypeRef_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-TypeRef_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	TypeRef_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-TypeRef_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	TypeRef_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [TypeRef] >>> ***/
 
@@ -1017,13 +959,13 @@ static const ber_tlv_tag_t asn_DEF_TypeRef_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_TypeRef = {
 	"TypeRef",
 	"TypeRef",
-	TypeRef_free,
-	TypeRef_print,
-	TypeRef_constraint,
-	TypeRef_decode_ber,
-	TypeRef_encode_der,
-	TypeRef_decode_xer,
-	TypeRef_encode_xer,
+	SEQUENCE_free,
+	SEQUENCE_print,
+	SEQUENCE_constraint,
+	SEQUENCE_decode_ber,
+	SEQUENCE_encode_der,
+	SEQUENCE_decode_xer,
+	SEQUENCE_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_TypeRef_tags_1,
@@ -1033,8 +975,9 @@ asn_TYPE_descriptor_t asn_DEF_TypeRef = {
 	sizeof(asn_DEF_TypeRef_tags_1)
 		/sizeof(asn_DEF_TypeRef_tags_1[0]), /* 1 */
 	0,	/* No PER visible constraints */
-	0, 0,	/* Defined elsewhere */
-	0	/* No specifics */
+	asn_MBR_Sequence_1,
+	4,	/* Elements count */
+	&asn_SPC_Sequence_specs_1	/* Additional specs */
 };
 
 
@@ -1064,6 +1007,8 @@ typedef struct Alpha {
 /*** <<< FUNC-DECLS [Alpha] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Alpha;
+extern asn_SEQUENCE_specifics_t asn_SPC_Alpha_specs_1;
+extern asn_TYPE_member_t asn_MBR_Alpha_1[2];
 
 /*** <<< POST-INCLUDE [Alpha] >>> ***/
 
@@ -1123,7 +1068,7 @@ asn_TYPE_descriptor_t asn_DEF_b_3 = {
 	&asn_SPC_b_specs_3	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_Alpha_1[] = {
+asn_TYPE_member_t asn_MBR_Alpha_1[] = {
 	{ ATF_POINTER, 0, offsetof(struct Alpha, a),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -1150,7 +1095,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Alpha_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* a */
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 } /* b */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Alpha_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Alpha_specs_1 = {
 	sizeof(struct Alpha),
 	offsetof(struct Alpha, _asn_ctx),
 	asn_MAP_Alpha_tag2el_1,
@@ -1206,6 +1151,8 @@ typedef struct Beta {
 /*** <<< FUNC-DECLS [Beta] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Beta;
+extern asn_SEQUENCE_specifics_t asn_SPC_Beta_specs_1;
+extern asn_TYPE_member_t asn_MBR_Beta_1[2];
 
 /*** <<< POST-INCLUDE [Beta] >>> ***/
 
@@ -1214,7 +1161,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Beta;
 
 /*** <<< STAT-DEFS [Beta] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Beta_1[] = {
+asn_TYPE_member_t asn_MBR_Beta_1[] = {
 	{ ATF_POINTER, 2, offsetof(struct Beta, b),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -1241,7 +1188,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Beta_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* b */
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 } /* g */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Beta_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Beta_specs_1 = {
 	sizeof(struct Beta),
 	offsetof(struct Beta, _asn_ctx),
 	asn_MAP_Beta_tag2el_1,
@@ -1299,6 +1246,8 @@ typedef struct Gamma {
 /*** <<< FUNC-DECLS [Gamma] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Gamma;
+extern asn_SEQUENCE_specifics_t asn_SPC_Gamma_specs_1;
+extern asn_TYPE_member_t asn_MBR_Gamma_1[3];
 
 /*** <<< POST-INCLUDE [Gamma] >>> ***/
 
@@ -1308,7 +1257,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Gamma;
 
 /*** <<< STAT-DEFS [Gamma] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Gamma_1[] = {
+asn_TYPE_member_t asn_MBR_Gamma_1[] = {
 	{ ATF_POINTER, 0, offsetof(struct Gamma, o),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -1345,7 +1294,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Gamma_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 }, /* a */
     { (ASN_TAG_CLASS_CONTEXT | (2 << 2)), 2, 0, 0 } /* b */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Gamma_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Gamma_specs_1 = {
 	sizeof(struct Gamma),
 	offsetof(struct Gamma, _asn_ctx),
 	asn_MAP_Gamma_tag2el_1,
@@ -1413,6 +1362,8 @@ typedef struct OneTwo {
 /*** <<< FUNC-DECLS [OneTwo] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_OneTwo;
+extern asn_SET_specifics_t asn_SPC_OneTwo_specs_1;
+extern asn_TYPE_member_t asn_MBR_OneTwo_1[1];
 
 /*** <<< POST-INCLUDE [OneTwo] >>> ***/
 
@@ -1420,7 +1371,7 @@ extern asn_TYPE_descriptor_t asn_DEF_OneTwo;
 
 /*** <<< STAT-DEFS [OneTwo] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_OneTwo_1[] = {
+asn_TYPE_member_t asn_MBR_OneTwo_1[] = {
 	{ ATF_POINTER, 0, offsetof(struct OneTwo, m12),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -1440,7 +1391,7 @@ static const asn_TYPE_tag2member_t asn_MAP_OneTwo_tag2el_1[] = {
 static const uint8_t asn_MAP_OneTwo_mmap_1[(1 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	(1 << 7)
 };
-static asn_SET_specifics_t asn_SPC_OneTwo_specs_1 = {
+asn_SET_specifics_t asn_SPC_OneTwo_specs_1 = {
 	sizeof(struct OneTwo),
 	offsetof(struct OneTwo, _asn_ctx),
 	offsetof(struct OneTwo, _presence_map),
@@ -1510,6 +1461,8 @@ typedef struct TwoThree {
 /*** <<< FUNC-DECLS [TwoThree] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_TwoThree;
+extern asn_SET_specifics_t asn_SPC_TwoThree_specs_1;
+extern asn_TYPE_member_t asn_MBR_TwoThree_1[1];
 
 /*** <<< POST-INCLUDE [TwoThree] >>> ***/
 
@@ -1517,7 +1470,7 @@ extern asn_TYPE_descriptor_t asn_DEF_TwoThree;
 
 /*** <<< STAT-DEFS [TwoThree] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_TwoThree_1[] = {
+asn_TYPE_member_t asn_MBR_TwoThree_1[] = {
 	{ ATF_POINTER, 0, offsetof(struct TwoThree, m23),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -1537,7 +1490,7 @@ static const asn_TYPE_tag2member_t asn_MAP_TwoThree_tag2el_1[] = {
 static const uint8_t asn_MAP_TwoThree_mmap_1[(1 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	(1 << 7)
 };
-static asn_SET_specifics_t asn_SPC_TwoThree_specs_1 = {
+asn_SET_specifics_t asn_SPC_TwoThree_specs_1 = {
 	sizeof(struct TwoThree),
 	offsetof(struct TwoThree, _asn_ctx),
 	offsetof(struct TwoThree, _presence_map),
@@ -1610,6 +1563,8 @@ typedef struct ThreeOne {
 /*** <<< FUNC-DECLS [ThreeOne] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_ThreeOne;
+extern asn_SET_specifics_t asn_SPC_ThreeOne_specs_1;
+extern asn_TYPE_member_t asn_MBR_ThreeOne_1[2];
 
 /*** <<< POST-INCLUDE [ThreeOne] >>> ***/
 
@@ -1618,7 +1573,7 @@ extern asn_TYPE_descriptor_t asn_DEF_ThreeOne;
 
 /*** <<< STAT-DEFS [ThreeOne] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_ThreeOne_1[] = {
+asn_TYPE_member_t asn_MBR_ThreeOne_1[] = {
 	{ ATF_POINTER, 0, offsetof(struct ThreeOne, m31),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -1648,7 +1603,7 @@ static const asn_TYPE_tag2member_t asn_MAP_ThreeOne_tag2el_1[] = {
 static const uint8_t asn_MAP_ThreeOne_mmap_1[(2 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	(1 << 7) | (1 << 6)
 };
-static asn_SET_specifics_t asn_SPC_ThreeOne_specs_1 = {
+asn_SET_specifics_t asn_SPC_ThreeOne_specs_1 = {
 	sizeof(struct ThreeOne),
 	offsetof(struct ThreeOne, _asn_ctx),
 	offsetof(struct ThreeOne, _presence_map),

--- a/tests/92-circular-loops-OK.asn1.-Pfwide-types
+++ b/tests/92-circular-loops-OK.asn1.-Pfwide-types
@@ -37,6 +37,8 @@ typedef struct Everything {
 /*** <<< FUNC-DECLS [Everything] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Everything;
+extern asn_SEQUENCE_specifics_t asn_SPC_Everything_specs_1;
+extern asn_TYPE_member_t asn_MBR_Everything_1[10];
 
 /*** <<< POST-INCLUDE [Everything] >>> ***/
 
@@ -46,7 +48,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Everything;
 
 /*** <<< STAT-DEFS [Everything] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Everything_1[] = {
+asn_TYPE_member_t asn_MBR_Everything_1[] = {
 	{ ATF_POINTER, 0, offsetof(struct Everything, ch1),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = +1,	/* EXPLICIT tag at current level */
@@ -153,7 +155,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Everything_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (8 << 2)), 8, 0, 0 }, /* tt */
     { (ASN_TAG_CLASS_CONTEXT | (9 << 2)), 9, 0, 0 } /* to */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Everything_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Everything_specs_1 = {
 	sizeof(struct Everything),
 	offsetof(struct Everything, _asn_ctx),
 	asn_MAP_Everything_tag2el_1,
@@ -224,6 +226,8 @@ typedef struct Choice1 {
 /*** <<< FUNC-DECLS [Choice1] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Choice1;
+extern asn_CHOICE_specifics_t asn_SPC_Choice1_specs_1;
+extern asn_TYPE_member_t asn_MBR_Choice1_1[2];
 
 /*** <<< POST-INCLUDE [Choice1] >>> ***/
 
@@ -231,7 +235,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Choice1;
 
 /*** <<< STAT-DEFS [Choice1] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Choice1_1[] = {
+asn_TYPE_member_t asn_MBR_Choice1_1[] = {
 	{ ATF_POINTER, 0, offsetof(struct Choice1, choice.something),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -255,7 +259,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Choice1_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* something */
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 } /* some2 */
 };
-static asn_CHOICE_specifics_t asn_SPC_Choice1_specs_1 = {
+asn_CHOICE_specifics_t asn_SPC_Choice1_specs_1 = {
 	sizeof(struct Choice1),
 	offsetof(struct Choice1, _asn_ctx),
 	offsetof(struct Choice1, present),
@@ -326,6 +330,8 @@ typedef struct Choice2 {
 /*** <<< FUNC-DECLS [Choice2] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Choice2;
+extern asn_CHOICE_specifics_t asn_SPC_Choice2_specs_1;
+extern asn_TYPE_member_t asn_MBR_Choice2_1[2];
 
 /*** <<< POST-INCLUDE [Choice2] >>> ***/
 
@@ -333,7 +339,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Choice2;
 
 /*** <<< STAT-DEFS [Choice2] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Choice2_1[] = {
+asn_TYPE_member_t asn_MBR_Choice2_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Choice2, choice.typeref),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -357,7 +363,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Choice2_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* typeref */
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 } /* some3 */
 };
-static asn_CHOICE_specifics_t asn_SPC_Choice2_specs_1 = {
+asn_CHOICE_specifics_t asn_SPC_Choice2_specs_1 = {
 	sizeof(struct Choice2),
 	offsetof(struct Choice2, _asn_ctx),
 	offsetof(struct Choice2, present),
@@ -438,6 +444,8 @@ typedef struct Choice3 {
 /*** <<< FUNC-DECLS [Choice3] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Choice3;
+extern asn_CHOICE_specifics_t asn_SPC_Choice3_specs_1;
+extern asn_TYPE_member_t asn_MBR_Choice3_1[3];
 
 /*** <<< POST-INCLUDE [Choice3] >>> ***/
 
@@ -543,7 +551,7 @@ asn_TYPE_descriptor_t asn_DEF_c_5 = {
 	&asn_SPC_c_specs_5	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_Choice3_1[] = {
+asn_TYPE_member_t asn_MBR_Choice3_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Choice3, choice.a),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = 0,
@@ -577,7 +585,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Choice3_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 }, /* b */
     { (ASN_TAG_CLASS_CONTEXT | (2 << 2)), 2, 0, 0 } /* c */
 };
-static asn_CHOICE_specifics_t asn_SPC_Choice3_specs_1 = {
+asn_CHOICE_specifics_t asn_SPC_Choice3_specs_1 = {
 	sizeof(struct Choice3),
 	offsetof(struct Choice3, _asn_ctx),
 	offsetof(struct Choice3, present),
@@ -651,6 +659,8 @@ typedef struct Set {
 /*** <<< FUNC-DECLS [Set] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Set;
+extern asn_SET_OF_specifics_t asn_SPC_Set_specs_1;
+extern asn_TYPE_member_t asn_MBR_Set_1[1];
 
 /*** <<< POST-INCLUDE [Set] >>> ***/
 
@@ -750,7 +760,7 @@ asn_TYPE_descriptor_t asn_DEF_Member_2 = {
 	&asn_SPC_Member_specs_2	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_Set_1[] = {
+asn_TYPE_member_t asn_MBR_Set_1[] = {
 	{ ATF_POINTER, 0, 0,
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
@@ -764,7 +774,7 @@ static asn_TYPE_member_t asn_MBR_Set_1[] = {
 static const ber_tlv_tag_t asn_DEF_Set_tags_1[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (17 << 2))
 };
-static asn_SET_OF_specifics_t asn_SPC_Set_specs_1 = {
+asn_SET_OF_specifics_t asn_SPC_Set_specs_1 = {
 	sizeof(struct Set),
 	offsetof(struct Set, _asn_ctx),
 	0,	/* XER encoding is XMLDelimitedItemList */
@@ -823,6 +833,8 @@ typedef struct Sequence {
 /*** <<< FUNC-DECLS [Sequence] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Sequence;
+extern asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1;
+extern asn_TYPE_member_t asn_MBR_Sequence_1[4];
 
 /*** <<< POST-INCLUDE [Sequence] >>> ***/
 
@@ -831,7 +843,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Sequence;
 
 /*** <<< STAT-DEFS [Sequence] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Sequence_1[] = {
+asn_TYPE_member_t asn_MBR_Sequence_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Sequence, a),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -878,7 +890,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Sequence_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (2 << 2)), 2, 0, 0 }, /* b */
     { (ASN_TAG_CLASS_CONTEXT | (3 << 2)), 3, 0, 0 } /* set */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1 = {
 	sizeof(struct Sequence),
 	offsetof(struct Sequence, _asn_ctx),
 	asn_MAP_Sequence_tag2el_1,
@@ -933,80 +945,10 @@ xer_type_encoder_f TypeRef_encode_xer;
 
 /*** <<< CODE [TypeRef] >>> ***/
 
-int
-TypeRef_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
-			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_Sequence.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
-}
-
 /*
  * This type is implemented using Sequence,
  * so here we adjust the DEF accordingly.
  */
-static void
-TypeRef_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
-	td->free_struct    = asn_DEF_Sequence.free_struct;
-	td->print_struct   = asn_DEF_Sequence.print_struct;
-	td->check_constraints = asn_DEF_Sequence.check_constraints;
-	td->ber_decoder    = asn_DEF_Sequence.ber_decoder;
-	td->der_encoder    = asn_DEF_Sequence.der_encoder;
-	td->xer_decoder    = asn_DEF_Sequence.xer_decoder;
-	td->xer_encoder    = asn_DEF_Sequence.xer_encoder;
-	td->uper_decoder   = asn_DEF_Sequence.uper_decoder;
-	td->uper_encoder   = asn_DEF_Sequence.uper_encoder;
-	if(!td->per_constraints)
-		td->per_constraints = asn_DEF_Sequence.per_constraints;
-	td->elements       = asn_DEF_Sequence.elements;
-	td->elements_count = asn_DEF_Sequence.elements_count;
-	td->specifics      = asn_DEF_Sequence.specifics;
-}
-
-void
-TypeRef_free(asn_TYPE_descriptor_t *td,
-		void *struct_ptr, int contents_only) {
-	TypeRef_1_inherit_TYPE_descriptor(td);
-	td->free_struct(td, struct_ptr, contents_only);
-}
-
-int
-TypeRef_print(asn_TYPE_descriptor_t *td, const void *struct_ptr,
-		int ilevel, asn_app_consume_bytes_f *cb, void *app_key) {
-	TypeRef_1_inherit_TYPE_descriptor(td);
-	return td->print_struct(td, struct_ptr, ilevel, cb, app_key);
-}
-
-asn_dec_rval_t
-TypeRef_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const void *bufptr, size_t size, int tag_mode) {
-	TypeRef_1_inherit_TYPE_descriptor(td);
-	return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
-}
-
-asn_enc_rval_t
-TypeRef_encode_der(asn_TYPE_descriptor_t *td,
-		void *structure, int tag_mode, ber_tlv_tag_t tag,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	TypeRef_1_inherit_TYPE_descriptor(td);
-	return td->der_encoder(td, structure, tag_mode, tag, cb, app_key);
-}
-
-asn_dec_rval_t
-TypeRef_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
-		void **structure, const char *opt_mname, const void *bufptr, size_t size) {
-	TypeRef_1_inherit_TYPE_descriptor(td);
-	return td->xer_decoder(opt_codec_ctx, td, structure, opt_mname, bufptr, size);
-}
-
-asn_enc_rval_t
-TypeRef_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
-		int ilevel, enum xer_encoder_flags_e flags,
-		asn_app_consume_bytes_f *cb, void *app_key) {
-	TypeRef_1_inherit_TYPE_descriptor(td);
-	return td->xer_encoder(td, structure, ilevel, flags, cb, app_key);
-}
-
 
 /*** <<< STAT-DEFS [TypeRef] >>> ***/
 
@@ -1016,13 +958,13 @@ static const ber_tlv_tag_t asn_DEF_TypeRef_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_TypeRef = {
 	"TypeRef",
 	"TypeRef",
-	TypeRef_free,
-	TypeRef_print,
-	TypeRef_constraint,
-	TypeRef_decode_ber,
-	TypeRef_encode_der,
-	TypeRef_decode_xer,
-	TypeRef_encode_xer,
+	SEQUENCE_free,
+	SEQUENCE_print,
+	SEQUENCE_constraint,
+	SEQUENCE_decode_ber,
+	SEQUENCE_encode_der,
+	SEQUENCE_decode_xer,
+	SEQUENCE_encode_xer,
 	0, 0,	/* No PER support, use "-gen-PER" to enable */
 	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_TypeRef_tags_1,
@@ -1032,8 +974,9 @@ asn_TYPE_descriptor_t asn_DEF_TypeRef = {
 	sizeof(asn_DEF_TypeRef_tags_1)
 		/sizeof(asn_DEF_TypeRef_tags_1[0]), /* 1 */
 	0,	/* No PER visible constraints */
-	0, 0,	/* Defined elsewhere */
-	0	/* No specifics */
+	asn_MBR_Sequence_1,
+	4,	/* Elements count */
+	&asn_SPC_Sequence_specs_1	/* Additional specs */
 };
 
 
@@ -1063,6 +1006,8 @@ typedef struct Alpha {
 /*** <<< FUNC-DECLS [Alpha] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Alpha;
+extern asn_SEQUENCE_specifics_t asn_SPC_Alpha_specs_1;
+extern asn_TYPE_member_t asn_MBR_Alpha_1[2];
 
 /*** <<< POST-INCLUDE [Alpha] >>> ***/
 
@@ -1122,7 +1067,7 @@ asn_TYPE_descriptor_t asn_DEF_b_3 = {
 	&asn_SPC_b_specs_3	/* Additional specs */
 };
 
-static asn_TYPE_member_t asn_MBR_Alpha_1[] = {
+asn_TYPE_member_t asn_MBR_Alpha_1[] = {
 	{ ATF_POINTER, 0, offsetof(struct Alpha, a),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -1149,7 +1094,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Alpha_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* a */
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 } /* b */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Alpha_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Alpha_specs_1 = {
 	sizeof(struct Alpha),
 	offsetof(struct Alpha, _asn_ctx),
 	asn_MAP_Alpha_tag2el_1,
@@ -1205,6 +1150,8 @@ typedef struct Beta {
 /*** <<< FUNC-DECLS [Beta] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Beta;
+extern asn_SEQUENCE_specifics_t asn_SPC_Beta_specs_1;
+extern asn_TYPE_member_t asn_MBR_Beta_1[2];
 
 /*** <<< POST-INCLUDE [Beta] >>> ***/
 
@@ -1213,7 +1160,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Beta;
 
 /*** <<< STAT-DEFS [Beta] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Beta_1[] = {
+asn_TYPE_member_t asn_MBR_Beta_1[] = {
 	{ ATF_POINTER, 2, offsetof(struct Beta, b),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -1240,7 +1187,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Beta_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* b */
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 } /* g */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Beta_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Beta_specs_1 = {
 	sizeof(struct Beta),
 	offsetof(struct Beta, _asn_ctx),
 	asn_MAP_Beta_tag2el_1,
@@ -1298,6 +1245,8 @@ typedef struct Gamma {
 /*** <<< FUNC-DECLS [Gamma] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Gamma;
+extern asn_SEQUENCE_specifics_t asn_SPC_Gamma_specs_1;
+extern asn_TYPE_member_t asn_MBR_Gamma_1[3];
 
 /*** <<< POST-INCLUDE [Gamma] >>> ***/
 
@@ -1307,7 +1256,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Gamma;
 
 /*** <<< STAT-DEFS [Gamma] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Gamma_1[] = {
+asn_TYPE_member_t asn_MBR_Gamma_1[] = {
 	{ ATF_POINTER, 0, offsetof(struct Gamma, o),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -1344,7 +1293,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Gamma_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 }, /* a */
     { (ASN_TAG_CLASS_CONTEXT | (2 << 2)), 2, 0, 0 } /* b */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Gamma_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Gamma_specs_1 = {
 	sizeof(struct Gamma),
 	offsetof(struct Gamma, _asn_ctx),
 	asn_MAP_Gamma_tag2el_1,
@@ -1412,6 +1361,8 @@ typedef struct OneTwo {
 /*** <<< FUNC-DECLS [OneTwo] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_OneTwo;
+extern asn_SET_specifics_t asn_SPC_OneTwo_specs_1;
+extern asn_TYPE_member_t asn_MBR_OneTwo_1[1];
 
 /*** <<< POST-INCLUDE [OneTwo] >>> ***/
 
@@ -1419,7 +1370,7 @@ extern asn_TYPE_descriptor_t asn_DEF_OneTwo;
 
 /*** <<< STAT-DEFS [OneTwo] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_OneTwo_1[] = {
+asn_TYPE_member_t asn_MBR_OneTwo_1[] = {
 	{ ATF_POINTER, 0, offsetof(struct OneTwo, m12),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -1439,7 +1390,7 @@ static const asn_TYPE_tag2member_t asn_MAP_OneTwo_tag2el_1[] = {
 static const uint8_t asn_MAP_OneTwo_mmap_1[(1 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	(1 << 7)
 };
-static asn_SET_specifics_t asn_SPC_OneTwo_specs_1 = {
+asn_SET_specifics_t asn_SPC_OneTwo_specs_1 = {
 	sizeof(struct OneTwo),
 	offsetof(struct OneTwo, _asn_ctx),
 	offsetof(struct OneTwo, _presence_map),
@@ -1509,6 +1460,8 @@ typedef struct TwoThree {
 /*** <<< FUNC-DECLS [TwoThree] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_TwoThree;
+extern asn_SET_specifics_t asn_SPC_TwoThree_specs_1;
+extern asn_TYPE_member_t asn_MBR_TwoThree_1[1];
 
 /*** <<< POST-INCLUDE [TwoThree] >>> ***/
 
@@ -1516,7 +1469,7 @@ extern asn_TYPE_descriptor_t asn_DEF_TwoThree;
 
 /*** <<< STAT-DEFS [TwoThree] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_TwoThree_1[] = {
+asn_TYPE_member_t asn_MBR_TwoThree_1[] = {
 	{ ATF_POINTER, 0, offsetof(struct TwoThree, m23),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -1536,7 +1489,7 @@ static const asn_TYPE_tag2member_t asn_MAP_TwoThree_tag2el_1[] = {
 static const uint8_t asn_MAP_TwoThree_mmap_1[(1 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	(1 << 7)
 };
-static asn_SET_specifics_t asn_SPC_TwoThree_specs_1 = {
+asn_SET_specifics_t asn_SPC_TwoThree_specs_1 = {
 	sizeof(struct TwoThree),
 	offsetof(struct TwoThree, _asn_ctx),
 	offsetof(struct TwoThree, _presence_map),
@@ -1609,6 +1562,8 @@ typedef struct ThreeOne {
 /*** <<< FUNC-DECLS [ThreeOne] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_ThreeOne;
+extern asn_SET_specifics_t asn_SPC_ThreeOne_specs_1;
+extern asn_TYPE_member_t asn_MBR_ThreeOne_1[2];
 
 /*** <<< POST-INCLUDE [ThreeOne] >>> ***/
 
@@ -1617,7 +1572,7 @@ extern asn_TYPE_descriptor_t asn_DEF_ThreeOne;
 
 /*** <<< STAT-DEFS [ThreeOne] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_ThreeOne_1[] = {
+asn_TYPE_member_t asn_MBR_ThreeOne_1[] = {
 	{ ATF_POINTER, 0, offsetof(struct ThreeOne, m31),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -1647,7 +1602,7 @@ static const asn_TYPE_tag2member_t asn_MAP_ThreeOne_tag2el_1[] = {
 static const uint8_t asn_MAP_ThreeOne_mmap_1[(2 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	(1 << 7) | (1 << 6)
 };
-static asn_SET_specifics_t asn_SPC_ThreeOne_specs_1 = {
+asn_SET_specifics_t asn_SPC_ThreeOne_specs_1 = {
 	sizeof(struct ThreeOne),
 	offsetof(struct ThreeOne, _asn_ctx),
 	offsetof(struct ThreeOne, _presence_map),

--- a/tests/93-asn1c-controls-OK.asn1.-Pfwide-types
+++ b/tests/93-asn1c-controls-OK.asn1.-Pfwide-types
@@ -17,10 +17,12 @@ typedef struct Sequence {
 /*** <<< FUNC-DECLS [Sequence] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_Sequence;
+extern asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1;
+extern asn_TYPE_member_t asn_MBR_Sequence_1[2];
 
 /*** <<< STAT-DEFS [Sequence] >>> ***/
 
-static asn_TYPE_member_t asn_MBR_Sequence_1[] = {
+asn_TYPE_member_t asn_MBR_Sequence_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Sequence, ainl),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
@@ -47,7 +49,7 @@ static const asn_TYPE_tag2member_t asn_MAP_Sequence_tag2el_1[] = {
     { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* ainl */
     { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 } /* aptr */
 };
-static asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1 = {
+asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1 = {
 	sizeof(struct Sequence),
 	offsetof(struct Sequence, _asn_ctx),
 	asn_MAP_Sequence_tag2el_1,
@@ -155,7 +157,8 @@ static const asn_TYPE_tag2member_t asn_MAP_Set_tag2el_1[] = {
 static const uint8_t asn_MAP_Set_mmap_1[(2 + (8 * sizeof(unsigned int)) - 1) / 8] = {
 	(1 << 7) | (1 << 6)
 };
-static asn_SET_specifics_t asn_SPC_Set_specs_1 = {
+static 
+asn_SET_specifics_t asn_SPC_Set_specs_1 = {
 	sizeof(struct Set),
 	offsetof(struct Set, _asn_ctx),
 	offsetof(struct Set, _presence_map),

--- a/tests/94-set-optionals-OK.asn1.-P
+++ b/tests/94-set-optionals-OK.asn1.-P
@@ -166,7 +166,8 @@ static const uint8_t asn_MAP_TestSet_mmap_1[(10 + (8 * sizeof(unsigned int)) - 1
 	(1 << 7) | (0 << 6) | (1 << 5) | (1 << 4) | (0 << 3) | (1 << 2) | (1 << 1) | (1 << 0),
 	(0 << 7) | (1 << 6)
 };
-static asn_SET_specifics_t asn_SPC_TestSet_specs_1 = {
+static 
+asn_SET_specifics_t asn_SPC_TestSet_specs_1 = {
 	sizeof(struct TestSet),
 	offsetof(struct TestSet, _asn_ctx),
 	offsetof(struct TestSet, _presence_map),


### PR DESCRIPTION
Taking 'FileCreationTimeStamp' of sample TAP3 as example, the corresponding ASN.1 expression of tap3.asn1 are :

```
FileCreationTimeStamp ::= [APPLICATION 108] DateTimeLong

DateTimeLong ::= SEQUENCE 
{
    localTimeStamp     LocalTimeStamp OPTIONAL, -- *m.m.
    utcTimeOffset      UtcTimeOffset  OPTIONAL
}
```

Part of generated FileCreationTimeStamp.c is : 

```
...
asn_dec_rval_t
FileCreationTimeStamp_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
        void **structure, const void *bufptr, size_t size, int tag_mode) {
    FileCreationTimeStamp_1_inherit_TYPE_descriptor(td);
    return td->ber_decoder(opt_codec_ctx, td, structure, bufptr, size, tag_mode);
}

static void
FileCreationTimeStamp_1_inherit_TYPE_descriptor(asn_TYPE_descriptor_t *td) {
    td->free_struct    = asn_DEF_DateTimeLong.free_struct;
    td->print_struct   = asn_DEF_DateTimeLong.print_struct;
    td->check_constraints = asn_DEF_DateTimeLong.check_constraints;
    td->ber_decoder    = asn_DEF_DateTimeLong.ber_decoder;
    td->der_encoder    = asn_DEF_DateTimeLong.der_encoder;
    td->xer_decoder    = asn_DEF_DateTimeLong.xer_decoder;
    td->xer_encoder    = asn_DEF_DateTimeLong.xer_encoder;
    td->uper_decoder   = asn_DEF_DateTimeLong.uper_decoder;
    td->uper_encoder   = asn_DEF_DateTimeLong.uper_encoder;
    if(!td->per_constraints)
        td->per_constraints = asn_DEF_DateTimeLong.per_constraints;
    td->elements       = asn_DEF_DateTimeLong.elements;
    td->elements_count = asn_DEF_DateTimeLong.elements_count;
    td->specifics      = asn_DEF_DateTimeLong.specifics;
}

asn_TYPE_descriptor_t asn_DEF_FileCreationTimeStamp = {
    "FileCreationTimeStamp",
    "FileCreationTimeStamp",
    FileCreationTimeStamp_free,
    FileCreationTimeStamp_print,
    FileCreationTimeStamp_constraint,
    FileCreationTimeStamp_decode_ber,
    FileCreationTimeStamp_encode_der,
    FileCreationTimeStamp_decode_xer,
    FileCreationTimeStamp_encode_xer,
    0, 0,   /* No PER support, use "-gen-PER" to enable */
    0,  /* Use generic outmost tag fetcher */
    asn_DEF_FileCreationTimeStamp_tags_1,
    sizeof(asn_DEF_FileCreationTimeStamp_tags_1)
        /sizeof(asn_DEF_FileCreationTimeStamp_tags_1[0]) - 1, /* 1 */
    asn_DEF_FileCreationTimeStamp_tags_1,   /* Same as above */
    sizeof(asn_DEF_FileCreationTimeStamp_tags_1)
        /sizeof(asn_DEF_FileCreationTimeStamp_tags_1[0]), /* 2 */
    0,  /* No PER visible constraints */
    0, 0,   /* Defined elsewhere */
    0   /* No specifics */
};
```

And part of generated DateTimeLong.c

```
asn_TYPE_descriptor_t asn_DEF_DateTimeLong = {
    "DateTimeLong",
    "DateTimeLong",
    SEQUENCE_free,
    SEQUENCE_print,
    SEQUENCE_constraint,
    SEQUENCE_decode_ber,
    SEQUENCE_encode_der,
    SEQUENCE_decode_xer,
    SEQUENCE_encode_xer,
    0, 0,   /* No PER support, use "-gen-PER" to enable */
    0,  /* Use generic outmost tag fetcher */
    asn_DEF_DateTimeLong_tags_1,
    sizeof(asn_DEF_DateTimeLong_tags_1)
        /sizeof(asn_DEF_DateTimeLong_tags_1[0]), /* 1 */
    asn_DEF_DateTimeLong_tags_1,    /* Same as above */
    sizeof(asn_DEF_DateTimeLong_tags_1)
        /sizeof(asn_DEF_DateTimeLong_tags_1[0]), /* 1 */
    0,  /* No PER visible constraints */
    asn_MBR_DateTimeLong_1,
    2,  /* Elements count */
    &asn_SPC_DateTimeLong_specs_1   /* Additional specs */
};
```

With eye-inspection, we can see when invoking ber_decoder of asn_DEF_FileCreationTimeStamp,
function SEQUENCE_decode_ber is called eventually. And the address of asn_SPC_DateTimeLong_specs_1 is assigned to asn_DEF_FileCreationTimeStamp's member variable 'specifics'. 

Moreover,  asn_MBR_DateTimeLong_1 is used for accessing child elements when proceeding the process of decoding each child element of DateTimeLong.

So after some tweak of asn1c_C.c and other files, we can eliminate the indirect access of codec function and generate the final data structure for asn_DEF_FileCreationTimeStamp directly. Thus we can remove the excessive helper functions which occupy a lot of code space.

New type descriptor in FileCreationTimeStamp.c 

```
asn_TYPE_descriptor_t asn_DEF_FileCreationTimeStamp = {
    "FileCreationTimeStamp",
    "FileCreationTimeStamp",
    SEQUENCE_free,
    SEQUENCE_print,
    FileCreationTimeStamp_constraint,
    SEQUENCE_decode_ber,
    SEQUENCE_encode_der,
    SEQUENCE_decode_xer,
    SEQUENCE_encode_xer,
    0, 0,   /* No PER support, use "-gen-PER" to enable */
    0,  /* Use generic outmost tag fetcher */
    asn_DEF_FileCreationTimeStamp_tags_1,
    sizeof(asn_DEF_FileCreationTimeStamp_tags_1)
        /sizeof(asn_DEF_FileCreationTimeStamp_tags_1[0]) - 1, /* 1 */
    asn_DEF_FileCreationTimeStamp_tags_1,   /* Same as above */
    sizeof(asn_DEF_FileCreationTimeStamp_tags_1)
        /sizeof(asn_DEF_FileCreationTimeStamp_tags_1[0]), /* 2 */
    0,  /* No PER visible constraints */
    asn_MBR_DateTimeLong_1,
    2,  /* Elements count */
    &asn_SPC_DateTimeLong_specs_1   /* Additional specs */
};
```

There are some more possible improvement to this pull request :
1. check_constraints function has not been manipulated as above due to, for some types, constraint checks are really needed.  For those check_constraints functions have similar content, it can be removed as well. For those check_constraints functions really do check, either leave it as current or change to a data driven function.
   We might need to modify asn1c_C.c and perhaps asn1c_constraint.c  to achieve these.
2. After codec functions are all mapped to primitive types, then we can extract them into a codec function array and use a type variable to access them. Then we can reduce excessive pointers to codec function to a single numeric (or enumerated) variable. This can further reduce code size.
3. After codec functions are extracted, it become easier for us to conditionally remove codec functions that we don't need. For example, if we only want PER coder and decoder, we can conditionally remove  XER/BER/DER codec. This is especially useful for RRC whose message are PER oriented.

Notice :
1. I have tested the pull request by 'make check' using examples under RRC, TAP3, LDAP. As for PKIX1 and MHEG5 and 'make distcheck', they failed the same place as 0.9.28. And ULP and MEGACO has not been tested yet due to no complete asn1 file and no test data available.
2. I am not quite acquainted with the internal of asn1c nor with ASN.1 specification. All modification are done by comparison and simple logic inference.  The modified code can work with minimum level but not in good quality in terms of code structure or flow. Any revise advice is welcomed.
