### PR TITLE
Update 112-param-class-OK.asn1

### DIFF
--- a/tests/112-param-class-OK.asn1
+++ b/tests/112-param-class-OK.asn1
@@ -14,7 +14,7 @@ BEGIN
 	PCLASS {Type, INTEGER:value, INTEGER:ValueSet} ::= CLASS {
 		&valueField1	Type,
 		&valueField2	INTEGER DEFAULT value,
-		&valueField3	INTEGER (ValueSet),
+		&valueField3	INTEGER (value),
 		&ValueSetField	INTEGER DEFAULT {ValueSet}
 	} WITH SYNTAX {
 		&valueField1, &valueField2, &valueField3, &ValueSetField }


### PR DESCRIPTION
IMO, &valueField3 is a fixed-type value of type INTEGER, and thus it cannot have INTEGER:ValueSet as value.
