### PR TITLE
Use wide types to decode x509 certificate in examples, solves #47

### DIFF
--- a/examples/sample.source.PKIX1/Makefile
+++ b/examples/sample.source.PKIX1/Makefile
@@ -375,7 +375,7 @@ Certificate.c: ../sample.makefile.regen ../rfc3280-*.asn1
 	make
 
 regen-makefile:
-	ASN1CMDOPTS="" \
+	ASN1CMDOPTS="-fwide-types" \
 	ASN1MODULES="../rfc3280-*.asn1" \
 	ASN1PDU=Certificate \
 	PROGNAME=x509dump \


### PR DESCRIPTION
Certificate serial number in `examples/sample.source.PKIX1/sample-Certificate-1.der` as in almost all real-world certificates is large number that cannot fit into native integer type, so original `x509dump` fails with this certificate. Using `-fwide-types` option for `asn1c` solves this problem and given certificate is successfully parsed.
