### PR TITLE
Fix segmentation fault in asn1c_make_identifier 

### DIFF
--- a/asn1c/tests/check-assembly.sh
+++ b/asn1c/tests/check-assembly.sh
@@ -17,7 +17,7 @@ abs_top_srcdir="${abs_top_srcdir:-$(pwd)/../../}"
 abs_top_builddir="${abs_top_builddir:-$(pwd)/../../}"
 
 if echo "$*" | grep -q -- -- ; then
-    TEST_DRIVER=$(echo "$*"  | sed -e 's/ -- .*/--/g')
+    TEST_DRIVER=$(echo "$*"  | sed -e 's/ -- .*/ -- /g')
     source_full=$(echo "$*"  | sed -e 's/.* //g')
 else
     TEST_DRIVER=""

--- a/libasn1compiler/asn1c_misc.c
+++ b/libasn1compiler/asn1c_misc.c
@@ -263,7 +263,7 @@ asn1c_type_name(arg_t *arg, asn1p_expr_t *expr, enum tnfmt _format) {
 	switch(_format) {
 	case TNF_UNMODIFIED:
 		return asn1c_make_identifier(AMI_MASK_ONLY_SPACES,
-			0, exprid ? exprid->Identifier : typename, 0);
+			0, exprid ? exprid->Identifier : typename, (char*)0);
 	case TNF_INCLUDE:
 		return asn1c_make_identifier(
 			AMI_MASK_ONLY_SPACES | AMI_NODELIMITER,
@@ -271,15 +271,15 @@ asn1c_type_name(arg_t *arg, asn1p_expr_t *expr, enum tnfmt _format) {
 				? "\"" : "<"),
 			exprid ? exprid->Identifier : typename,
 			((!stdname || (arg->flags & A1C_INCLUDES_QUOTED))
-				? ".h\"" : ".h>"), 0);
+				? ".h\"" : ".h>"), (char*)0);
 	case TNF_SAFE:
-		return asn1c_make_identifier(0, exprid, typename, 0);
+		return asn1c_make_identifier(0, exprid, typename, (char*)0);
 	case TNF_CTYPE:	/* C type */
 		return asn1c_make_identifier(0, exprid,
-				exprid?"t":typename, exprid?0:"t", 0);
+				exprid?"t":typename, exprid?0:"t", (char*)0);
 	case TNF_RSAFE:	/* Recursion-safe type */
 		return asn1c_make_identifier(AMI_CHECK_RESERVED, 0,
-			"struct", " ", typename, 0);
+			"struct", " ", typename, (char*)0);
 	}
 
 	assert(!"unreachable");


### PR DESCRIPTION
See http://stackoverflow.com/questions/25390720/va-arg-gives-something-strange-in-cygwin-x64

I've also fix execution of  asn1c tests. On RedHat Enterprise Linux 7 they were failing with 

```
 ../../config/test-driver: invalid option: '-C'
```
