### PR TITLE
Added two requirements to the INSTALL.md file

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,16 +1,21 @@
 
 ## Compiling From Sources
 
-### Configure
-Requirements:
+### Requirements
 
-    apt install autoconf libtool-bin
+**For Ubuntu 16.04**
+      apt install autoconf libtool-bin
+
+**For Fedora 24 and Centos 7.2**
+      yum install autoconf libtool automake make
+
+### Configure
+
 
 Configure with the default settings:
 
     test -f configure || autoreconf -iv
     ./configure
-    make
 
 Configure with non-standard settings:
 
@@ -36,7 +41,7 @@ Ensure asn1c is still behaving well after compiling on your platform:
 Install the compiler into a standard location:
 
     make install
-    # Use ./configure --prefix to override install location.
+    # Use ./configure --prefix /new/path to override install location.
 
 Display the `asn1c` manual page:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,10 +3,12 @@
 
 ### Requirements
 
-**For Ubuntu 16.04**
+For Ubuntu 16.04
+
       apt install autoconf libtool-bin
 
-**For Fedora 24 and Centos 7.2**
+For Fedora 24 and Centos 7.2
+
       yum install autoconf libtool automake make
 
 ### Configure

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,6 +2,9 @@
 ## Compiling From Sources
 
 ### Configure
+Requirements:
+
+    apt install autoconf libtool-bin
 
 Configure with the default settings:
 


### PR DESCRIPTION
not a biggie, but you get:

libasn1compiler/Makefile.am:8: error: Libtool library used but 'LIBTOOL' is undefined
libasn1compiler/Makefile.am:8:   The usual way to define 'LIBTOOL' is to add 'LT_INIT'
libasn1compiler/Makefile.am:8:   to 'configure.ac' and run 'aclocal' and 'autoconf' again.
libasn1compiler/Makefile.am:8:   If 'LT_INIT' is in 'configure.ac', make sure
libasn1compiler/Makefile.am:8:   its definition is in aclocal's search path.
libasn1fix/Makefile.am:6: error: Libtool library used but 'LIBTOOL' is undefined
libasn1fix/Makefile.am:6:   The usual way to define 'LIBTOOL' is to add 'LT_INIT'
libasn1fix/Makefile.am:6:   to 'configure.ac' and run 'aclocal' and 'autoconf' again.
libasn1fix/Makefile.am:6:   If 'LT_INIT' is in 'configure.ac', make sure
libasn1fix/Makefile.am:6:   its definition is in aclocal's search path.
libasn1parser/Makefile.am:6: error: Libtool library used but 'LIBTOOL' is undefined
libasn1parser/Makefile.am:6:   The usual way to define 'LIBTOOL' is to add 'LT_INIT'
libasn1parser/Makefile.am:6:   to 'configure.ac' and run 'aclocal' and 'autoconf' again.
libasn1parser/Makefile.am:6:   If 'LT_INIT' is in 'configure.ac', make sure
libasn1parser/Makefile.am:6:   its definition is in aclocal's search path.
libasn1print/Makefile.am:7: error: Libtool library used but 'LIBTOOL' is undefined
libasn1print/Makefile.am:7:   The usual way to define 'LIBTOOL' is to add 'LT_INIT'
libasn1print/Makefile.am:7:   to 'configure.ac' and run 'aclocal' and 'autoconf' again.
libasn1print/Makefile.am:7:   If 'LT_INIT' is in 'configure.ac', make sure
libasn1print/Makefile.am:7:   its definition is in aclocal's search path.
skeletons/Makefile.am:21: error: Libtool library used but 'LIBTOOL' is undefined
skeletons/Makefile.am:21:   The usual way to define 'LIBTOOL' is to add 'LT_INIT'
skeletons/Makefile.am:21:   to 'configure.ac' and run 'aclocal' and 'autoconf' again.
skeletons/Makefile.am:21:   If 'LT_INIT' is in 'configure.ac', make sure
skeletons/Makefile.am:21:   its definition is in aclocal's search path.
autoreconf: automake failed with exit status: 1

If you don't have libtool installed. So having this will save people a minute, esp as I could not simply rerun the test -f configure || autoreconf -iv thing but need to reset it somehow (or delete stuff manually and start over).
