### PR TITLE
Fix many memory leaks reported by valgrind

### DIFF
--- a/asn1c/asn1c.c
+++ b/asn1c/asn1c.c
@@ -330,6 +330,8 @@ main(int ac, char **av) {
         exit(EX_SOFTWARE);
     }
 
+    asn1p_delete(asn);
+
     return 0;
 }
 

--- a/asn1c/asn1c.c
+++ b/asn1c/asn1c.c
@@ -425,6 +425,11 @@ importStandardModules(asn1p_t *asn, const char *skeletons_dir) {
     closedir(dir);
 #endif
 
+#ifdef _WIN32
+    free(pattern);
+#endif
+    free(target_dir);
+
     return ret;
 }
 

--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -479,6 +479,8 @@ asn1c_lang_C_type_SEQUENCE_def(arg_t *arg) {
 
 	REDIR(OT_TYPE_DECLS);
 
+	if(tag2el) free(tag2el);
+
 	return 0;
 } /* _SEQUENCE_def() */
 
@@ -693,6 +695,9 @@ asn1c_lang_C_type_SET_def(arg_t *arg) {
 			ETD_HAS_SPECIFICS);
 
 	REDIR(OT_TYPE_DECLS);
+
+	if (tag2el) free(tag2el);
+	if (tag2el_cxer) free(tag2el_cxer);
 
 	return 0;
 } /* _SET_def() */
@@ -1027,6 +1032,8 @@ asn1c_lang_C_type_CHOICE_def(arg_t *arg) {
 			ETD_HAS_SPECIFICS);
 
 	REDIR(OT_TYPE_DECLS);
+
+	if (tag2el) free(tag2el);
 
 	return 0;
 } /* _CHOICE_def() */

--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -813,6 +813,8 @@ asn1c_lang_C_type_SEx_OF_def(arg_t *arg, int seq_of) {
 		arg->embed++;
 		emit_member_table(arg, v);
 		arg->embed--;
+		free(v->Identifier);
+		v->Identifier = (char *)NULL;
 	INDENT(-1);
 	OUT("};\n");
 

--- a/libasn1compiler/asn1c_constraint.c
+++ b/libasn1compiler/asn1c_constraint.c
@@ -35,6 +35,7 @@ asn1c_emit_constraint_checking_code(arg_t *arg) {
 	int alphabet_table_compiled;
 	int produce_st = 0;
 	int ulong_optimize = 0;
+	int ret = 0;
 
 	ct = expr->combined_constraints;
 	if(ct == NULL)
@@ -158,7 +159,7 @@ asn1c_emit_constraint_checking_code(arg_t *arg) {
 		OUT("\n");
 		OUT("/* Constraint check succeeded */\n");
 		OUT("return 0;\n");
-		return 0;
+		goto end;
 	}
 
 	/*
@@ -197,7 +198,8 @@ asn1c_emit_constraint_checking_code(arg_t *arg) {
 			INDENTED(OUT("/* Nothing is here. See below */\n"));
 			OUT("}\n");
 			OUT("\n");
-			return 1;
+			ret = 1;
+			goto end;
 		}
 	INDENT(-1);
 	OUT(") {\n");
@@ -222,7 +224,11 @@ asn1c_emit_constraint_checking_code(arg_t *arg) {
 		INDENT(-1);
 	OUT("}\n");
 
-	return 0;
+end:
+	if (r_value) asn1constraint_range_free(r_value);
+	if (r_size) asn1constraint_range_free(r_size);
+
+	return ret;
 }
 
 static int

--- a/libasn1compiler/asn1c_fdeps.h
+++ b/libasn1compiler/asn1c_fdeps.h
@@ -25,5 +25,6 @@ int asn1c_activate_dependency(asn1c_fdeps_t *deps, asn1c_fdeps_t *cur,
 	const char *data);
 
 asn1c_fdeps_t *asn1c_deps_makelist(asn1c_fdeps_t *deps);
+void asn1c_deps_freelist(asn1c_fdeps_t *deps);
 
 #endif	/* ASN1C_FDEPS_H */

--- a/libasn1compiler/asn1c_save.c
+++ b/libasn1compiler/asn1c_save.c
@@ -149,6 +149,9 @@ asn1c_save_compiled_output(arg_t *arg, const char *datadir,
 			safe_fprintf(mkf, "ASN_%s_%s+=%s\n",
 				what_class, what_kind, fname);
 		}
+
+		asn1c_deps_freelist(deps);
+		asn1c_deps_freelist(dlist);
 	}
 
 	if(need_to_generate_pdu_collection(arg)) {

--- a/libasn1parser/asn1p_expr.c
+++ b/libasn1parser/asn1p_expr.c
@@ -22,6 +22,7 @@ asn1p_expr_new(int _lineno, asn1p_module_t *mod) {
 		expr->spec_index = -1;
 		expr->module = mod;
 		expr->_lineno = _lineno;
+		expr->ref_cnt = 0;
 	}
 
 	return expr;
@@ -234,6 +235,12 @@ void
 asn1p_expr_free(asn1p_expr_t *expr) {
 	if(expr) {
 		asn1p_expr_t *tm;
+
+		if (expr->ref_cnt) {
+			/* Decrease reference count only */
+			expr->ref_cnt--;
+			return;
+		}
 
 		/* Remove all children */
 		while((tm = TQ_REMOVE(&(expr->members), next))) {

--- a/libasn1parser/asn1p_expr.h
+++ b/libasn1parser/asn1p_expr.h
@@ -216,6 +216,7 @@ typedef struct asn1p_expr_s {
 		asn1p_value_t *default_value;	/* For EM_DEFAULT case */
 	} marker;
 	int unique;	/* UNIQUE */
+	int ref_cnt;	/* reference count */
 
 	/*
 	 * Whether automatic tagging may be applied for subtypes.

--- a/libasn1parser/asn1p_module.c
+++ b/libasn1parser/asn1p_module.c
@@ -28,6 +28,7 @@ asn1p_module_free(asn1p_module_t *mod) {
 		asn1p_expr_t *expr;
 
 		free(mod->ModuleName);
+		free(mod->source_file_name);
 
 		asn1p_oid_free(mod->module_oid);
 

--- a/libasn1parser/asn1p_oid.c
+++ b/libasn1parser/asn1p_oid.c
@@ -52,6 +52,7 @@ asn1p_oid_free(asn1p_oid_t *oid) {
 			while(oid->arcs_count--) {
 				free(oid->arcs[oid->arcs_count].name);
 			}
+			free(oid->arcs);
 		}
 		free(oid);
 	}

--- a/libasn1parser/asn1p_value.c
+++ b/libasn1parser/asn1p_value.c
@@ -138,6 +138,7 @@ asn1p_value_fromtype(asn1p_expr_t *expr) {
 	if(v) {
 		v->value.v_type = expr;
 		v->type = ATV_TYPE;
+		expr->ref_cnt++;
 	}
 	return v;
 }
@@ -258,6 +259,7 @@ asn1p_value_free(asn1p_value_t *v) {
 			asn1p_value_free(v->value.choice_identifier.value);
 			break;
 		}
+		memset(v, 0, sizeof(*v));
 		free(v);
 	}
 }


### PR DESCRIPTION
Using Valgrind to check memory leakage during compiling rrc-7.1.0.asn1 :

```
==32511== LEAK SUMMARY:
==32511==    definitely lost: 664,203 bytes in 6,379 blocks
==32511==    indirectly lost: 107,661,853 bytes in 2,273,838 blocks
==32511==      possibly lost: 256 bytes in 4 blocks
==32511==    still reachable: 86,691 bytes in 98 blocks
==32511==         suppressed: 0 bytes in 0 blocks
==32511== 
==32511== ERROR SUMMARY: 148 errors from 148 contexts (suppressed: 0 from 0)
==32511== ERROR SUMMARY: 148 errors from 148 contexts (suppressed: 0 from 0)
```

Many of them are fixed with this pull request, but there exist several leaks I am not able to solve. 
[Detail of remaining leaks when compiling rrc-7.1.0.asn1](https://gist.github.com/brchiu/589126422c98e568fab676ddfe0ea45a)

```
==32093== LEAK SUMMARY:
==32093==    definitely lost: 259,209 bytes in 2,478 blocks
==32093==    indirectly lost: 168,787 bytes in 1,321 blocks
==32093==      possibly lost: 0 bytes in 0 blocks
==32093==    still reachable: 82,185 bytes in 6 blocks
==32093==         suppressed: 0 bytes in 0 blocks
==32093== 
==32093== ERROR SUMMARY: 8 errors from 8 contexts (suppressed: 0 from 0)
==32093== ERROR SUMMARY: 8 errors from 8 contexts (suppressed: 0 from 0)
```
