### PR TITLE
per encoding allow larger constraints

### DIFF
--- a/skeletons/per_support.h
+++ b/skeletons/per_support.h
@@ -24,8 +24,8 @@ typedef const struct asn_per_constraint_s {
 	} flags;
 	int  range_bits;		/* Full number of bits in the range */
 	int  effective_bits;		/* Effective bits */
-	long lower_bound;		/* "lb" value */
-	long upper_bound;		/* "ub" value */
+	long long lower_bound;		/* "lb" value */
+	long long upper_bound;		/* "ub" value */
 } asn_per_constraint_t;
 typedef const struct asn_per_constraints_s {
 	struct asn_per_constraint_s value;


### PR DESCRIPTION
Constraint values might be larger than what can be held in a 32bit integer. 
On example is TimestampIts defined by ETSI in http://forge.etsi.org/websvn/filedetails.php?repname=LIBS.LibIts&path=%2Ftrunk%2Fasn1%2FITS-Container%2FITS-Container.asn

