### PR TITLE
per encoding allow larger constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,18 @@ language: c
 compiler:
   - gcc
   - clang
+env:
+  - BUILD=x86_64-linux-gnu
+    CFLAGS=-m64 LDFLAGS=-m64
+  - BUILD=i686-linux-gnu
+    CFLAGS=-m32 LDFLAGS=-m32
+addons:
+  apt:
+    packages:
+    - gcc-multilib
 script:
     - autoreconf -iv
-    - ./configure --enable-Werror
+    - ./configure --enable-Werror --build=$BUILD
     - make -j8
     - make check
     - make distcheck

--- a/asn1c/tests/check-src/check-03.-fwide-types.c
+++ b/asn1c/tests/check-src/check-03.-fwide-types.c
@@ -28,7 +28,7 @@ check_xer(e_Enum2 eval, char *xer_string) {
 	asn_dec_rval_t rv;
 	char buf2[128];
 	Enum2_t *e = 0;
-	long val;
+	long long val;
 
 	rv = xer_decode(0, &asn_DEF_Enum2, (void **)&e,
 		xer_string, strlen(xer_string));

--- a/configure.ac
+++ b/configure.ac
@@ -81,8 +81,8 @@ AC_SUBST(TESTSUITE_CFLAGS)
 dnl Skeletons should be very compatible with most of the compilers, hence
 dnl very strict backward compatibility flags.
 SKELETONS_CFLAGS="${ADD_CFLAGS} ${SKELETONS_CFLAGS}"
-AX_CHECK_COMPILE_FLAG([-std=c89],
-    [SKELETONS_CFLAGS="$SKELETONS_CFLAGS -std=c89"])
+AX_CHECK_COMPILE_FLAG([-std=c99],
+    [SKELETONS_CFLAGS="$SKELETONS_CFLAGS -std=c99"])
 AX_CHECK_COMPILE_FLAG([-Wpedantic],
     [SKELETONS_CFLAGS="$SKELETONS_CFLAGS -Wpedantic"])
 AX_CHECK_COMPILE_FLAG([-Wno-duplicate-decl-specifier],

--- a/libasn1compiler/asn1c_constraint.c
+++ b/libasn1compiler/asn1c_constraint.c
@@ -106,10 +106,10 @@ asn1c_emit_constraint_checking_code(arg_t *arg) {
 				if(native_long_sign(r_value) >= 0) {
 					ulong_optimize = ulong_optimization(etype, r_size, r_value);
 					if(!ulong_optimize) {
-						OUT("unsigned long value;\n");
+						OUT("unsigned long long value;\n");
 					}
 				} else {
-					OUT("long value;\n");
+					OUT("long long value;\n");
 				}
 				break;
 			case ASN_BASIC_REAL:
@@ -613,9 +613,9 @@ emit_value_determination_code(arg_t *arg, asn1p_expr_type_e etype, asn1cnst_rang
 	case ASN_BASIC_INTEGER:
 	case ASN_BASIC_ENUMERATED:
 		if(asn1c_type_fits_long(arg, arg->expr) == FL_FITS_UNSIGN) {
-			OUT("value = *(const unsigned long *)sptr;\n");
+			OUT("value = *(const unsigned long long *)sptr;\n");
 		} else if(asn1c_type_fits_long(arg, arg->expr) != FL_NOTFIT) {
-			OUT("value = *(const long *)sptr;\n");
+			OUT("value = *(const long long *)sptr;\n");
 		} else {
 			/*
 			 * In some cases we can explore our knowledge of

--- a/libasn1compiler/asn1c_constraint.c
+++ b/libasn1compiler/asn1c_constraint.c
@@ -524,25 +524,15 @@ emit_range_comparison_code(arg_t *arg, asn1cnst_range_t *range, const char *varn
 		}
 
 		if(ignore_left) {
-			OUT("%s <= ", varname);
-			OINT(r->right.value);
-            OUT("LL");
+			OUT("%s <= %lldLL", varname, r->right.value);
 		} else if(ignore_right) {
-			OUT("%s >= ", varname);
-			OINT(r->left.value);
-            OUT("LL");
+			OUT("%s >= %lldLL", varname, r->left.value);
 		} else if(r->left.value == r->right.value) {
-			OUT("%s == ", varname);
-			OINT(r->right.value);
-            OUT("LL");
+			OUT("%s == %lldLL", varname, r->right.value);
 		} else {
-			OUT("%s >= ", varname);
-			OINT(r->left.value);
-            OUT("LL");
+			OUT("%s >= %lldLL", varname, r->left.value);
 			OUT(" && ");
-			OUT("%s <= ", varname);
-			OINT(r->right.value);
-            OUT("LL");
+			OUT("%s <= %lldLL", varname, r->right.value);
 		}
 		if(r != range) OUT(")");
 		generated_something = 1;

--- a/libasn1compiler/asn1c_constraint.c
+++ b/libasn1compiler/asn1c_constraint.c
@@ -526,18 +526,23 @@ emit_range_comparison_code(arg_t *arg, asn1cnst_range_t *range, const char *varn
 		if(ignore_left) {
 			OUT("%s <= ", varname);
 			OINT(r->right.value);
+            OUT("LL");
 		} else if(ignore_right) {
 			OUT("%s >= ", varname);
 			OINT(r->left.value);
+            OUT("LL");
 		} else if(r->left.value == r->right.value) {
 			OUT("%s == ", varname);
 			OINT(r->right.value);
+            OUT("LL");
 		} else {
 			OUT("%s >= ", varname);
 			OINT(r->left.value);
+            OUT("LL");
 			OUT(" && ");
 			OUT("%s <= ", varname);
 			OINT(r->right.value);
+            OUT("LL");
 		}
 		if(r != range) OUT(")");
 		generated_something = 1;

--- a/skeletons/ENUMERATED.c
+++ b/skeletons/ENUMERATED.c
@@ -61,7 +61,7 @@ asn_enc_rval_t
 ENUMERATED_encode_uper(asn_TYPE_descriptor_t *td,
 	asn_per_constraints_t *constraints, void *sptr, asn_per_outp_t *po) {
 	ENUMERATED_t *st = (ENUMERATED_t *)sptr;
-	long value;
+	long long value;
 
 	if(asn_INTEGER2long(st, &value))
 		ASN__ENCODE_FAILED;

--- a/skeletons/INTEGER.c
+++ b/skeletons/INTEGER.c
@@ -699,7 +699,7 @@ INTEGER_encode_uper(asn_TYPE_descriptor_t *td,
 				|| uval > (unsigned long long)ct->upper_bound)
 					inext = 1;
 			}
-			ASN_DEBUG("Value %lu (%02x/%d) lb %llu ub %llu %s",
+			ASN_DEBUG("Value %llu (%02x/%d) lb %llu ub %llu %s",
 				uval, st->buf[0], st->size,
 				ct->lower_bound, ct->upper_bound,
 				inext ? "ext" : "fix");

--- a/skeletons/INTEGER.c
+++ b/skeletons/INTEGER.c
@@ -111,13 +111,13 @@ INTEGER__dump(const asn_TYPE_descriptor_t *td, const INTEGER_t *st, asn_app_cons
 	char scratch[32];	/* Enough for 64-bit integer */
 	uint8_t *buf = st->buf;
 	uint8_t *buf_end = st->buf + st->size;
-	signed long value;
+	signed long long value;
 	ssize_t wrote = 0;
 	char *p;
 	int ret;
 
 	if(specs && specs->field_unsigned)
-		ret = asn_INTEGER2ulong(st, (unsigned long *)&value);
+		ret = asn_INTEGER2ulong(st, (unsigned long long *)&value);
 	else
 		ret = asn_INTEGER2long(st, &value);
 
@@ -134,7 +134,7 @@ INTEGER__dump(const asn_TYPE_descriptor_t *td, const INTEGER_t *st, asn_app_cons
 			scr = (char *)alloca(scrsize);
 			if(plainOrXER == 0)
 				ret = snprintf(scr, scrsize,
-					"%ld (%s)", value, el->enum_name);
+					"%lld (%s)", value, el->enum_name);
 			else
 				ret = snprintf(scr, scrsize,
 					"<%s/>", el->enum_name);
@@ -148,7 +148,7 @@ INTEGER__dump(const asn_TYPE_descriptor_t *td, const INTEGER_t *st, asn_app_cons
 			scr = scratch;
 			ret = snprintf(scr, scrsize,
 				(specs && specs->field_unsigned)
-				?"%lu":"%ld", value);
+				?"%lu":"%lld", value);
 		}
 		assert(ret > 0 && (size_t)ret < scrsize);
 		return (cb(scr, ret, app_key) < 0) ? -1 : ret;
@@ -270,16 +270,16 @@ INTEGER_map_enum2value(asn_INTEGER_specifics_t *specs, const char *lstart, const
 
 static int
 INTEGER__compar_value2enum(const void *kp, const void *am) {
-	long a = *(const long *)kp;
+	long long a = *(const long long *)kp;
 	const asn_INTEGER_enum_map_t *el = (const asn_INTEGER_enum_map_t *)am;
-	long b = el->nat_value;
+	long long b = el->nat_value;
 	if(a < b) return -1;
 	else if(a == b) return 0;
 	else return 1;
 }
 
 const asn_INTEGER_enum_map_t *
-INTEGER_map_value2enum(asn_INTEGER_specifics_t *specs, long value) {
+INTEGER_map_value2enum(asn_INTEGER_specifics_t *specs, long long value) {
 	int count = specs ? specs->map_count : 0;
 	if(!count) return 0;
 	return (asn_INTEGER_enum_map_t *)bsearch(&value, specs->value2enum,
@@ -307,7 +307,7 @@ INTEGER_st_prealloc(INTEGER_t *st, int min_size) {
 static enum xer_pbd_rval
 INTEGER__xer_body_decode(asn_TYPE_descriptor_t *td, void *sptr, const void *chunk_buf, size_t chunk_size) {
 	INTEGER_t *st = (INTEGER_t *)sptr;
-	long dec_value;
+	long long dec_value;
 	long hex_value = 0;
 	const char *lp;
 	const char *lstart = (const char *)chunk_buf;
@@ -600,25 +600,25 @@ INTEGER_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
 		/* #11.5.6 */
 		ASN_DEBUG("Integer with range %d bits", ct->range_bits);
 		if(ct->range_bits >= 0) {
-			if((size_t)ct->range_bits > 8 * sizeof(unsigned long))
+			if((size_t)ct->range_bits > 8 * sizeof(unsigned long long))
 				ASN__DECODE_FAILED;
 
 			if(specs && specs->field_unsigned) {
-				unsigned long uvalue;
+				unsigned long long uvalue;
 				if(uper_get_constrained_whole_number(pd,
 					&uvalue, ct->range_bits))
 					ASN__DECODE_STARVED;
-				ASN_DEBUG("Got value %lu + low %ld",
+				ASN_DEBUG("Got value %llu + low %lld",
 					uvalue, ct->lower_bound);
 				uvalue += ct->lower_bound;
 				if(asn_ulong2INTEGER(st, uvalue))
 					ASN__DECODE_FAILED;
 			} else {
-				unsigned long svalue;
+				unsigned long long svalue;
 				if(uper_get_constrained_whole_number(pd,
 					&svalue, ct->range_bits))
 					ASN__DECODE_STARVED;
-				ASN_DEBUG("Got value %ld + low %ld",
+				ASN_DEBUG("Got value %lld + low %lld",
 					svalue, ct->lower_bound);
 				svalue += ct->lower_bound;
 				if(asn_long2INTEGER(st, svalue))
@@ -655,7 +655,7 @@ INTEGER_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
 		/*
 		 * TODO: replace by in-place arithmetics.
 		 */
-		long value;
+		long long value;
 		if(asn_INTEGER2long(st, &value))
 			ASN__DECODE_FAILED;
 		if(asn_long2INTEGER(st, value + ct->lower_bound))
@@ -674,8 +674,8 @@ INTEGER_encode_uper(asn_TYPE_descriptor_t *td,
 	const uint8_t *buf;
 	const uint8_t *end;
 	asn_per_constraint_t *ct;
-	long value = 0;
-	unsigned long v = 0;
+	long long value = 0;
+	unsigned long long v = 0;
 
 	if(!st || st->size == 0) ASN__ENCODE_FAILED;
 
@@ -687,16 +687,16 @@ INTEGER_encode_uper(asn_TYPE_descriptor_t *td,
 	if(ct) {
 		int inext = 0;
 		if(specs && specs->field_unsigned) {
-			unsigned long uval;
+			unsigned long long uval;
 			if(asn_INTEGER2ulong(st, &uval))
 				ASN__ENCODE_FAILED;
 			/* Check proper range */
 			if(ct->flags & APC_SEMI_CONSTRAINED) {
-				if(uval < (unsigned long)ct->lower_bound)
+				if(uval < (unsigned long long)ct->lower_bound)
 					inext = 1;
 			} else if(ct->range_bits >= 0) {
-				if(uval < (unsigned long)ct->lower_bound
-				|| uval > (unsigned long)ct->upper_bound)
+				if(uval < (unsigned long long)ct->lower_bound
+				|| uval > (unsigned long long)ct->upper_bound)
 					inext = 1;
 			}
 			ASN_DEBUG("Value %lu (%02x/%d) lb %llu ub %llu %s",
@@ -716,7 +716,7 @@ INTEGER_encode_uper(asn_TYPE_descriptor_t *td,
 				|| value > ct->upper_bound)
 					inext = 1;
 			}
-			ASN_DEBUG("Value %ld (%02x/%d) lb %lld ub %lld %s",
+			ASN_DEBUG("Value %lld (%02x/%d) lb %lld ub %lld %s",
 				value, st->buf[0], st->size,
 				ct->lower_bound, ct->upper_bound,
 				inext ? "ext" : "fix");
@@ -734,7 +734,7 @@ INTEGER_encode_uper(asn_TYPE_descriptor_t *td,
 	/* X.691-11/2008, #13.2.2, test if constrained whole number */
 	if(ct && ct->range_bits >= 0) {
 		/* #11.5.6 -> #11.3 */
-		ASN_DEBUG("Encoding integer %ld (%lu) with range %d bits",
+		ASN_DEBUG("Encoding integer %lld (%llu) with range %d bits",
 			value, value - ct->lower_bound, ct->range_bits);
 		v = value - ct->lower_bound;
 		if(uper_put_constrained_whole_number_u(po, v, ct->range_bits))
@@ -743,7 +743,7 @@ INTEGER_encode_uper(asn_TYPE_descriptor_t *td,
 	}
 
 	if(ct && ct->lower_bound) {
-		ASN_DEBUG("Adjust lower bound to %ld", ct->lower_bound);
+		ASN_DEBUG("Adjust lower bound to %lld", ct->lower_bound);
 		/* TODO: adjust lower bound */
 		ASN__ENCODE_FAILED;
 	}
@@ -763,10 +763,10 @@ INTEGER_encode_uper(asn_TYPE_descriptor_t *td,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
 
 int
-asn_INTEGER2long(const INTEGER_t *iptr, long *lptr) {
+asn_INTEGER2long(const INTEGER_t *iptr, long long *lptr) {
 	uint8_t *b, *end;
 	size_t size;
-	long l;
+	long long l;
 
 	/* Sanity checking */
 	if(!iptr || !iptr->buf || !lptr) {
@@ -779,7 +779,7 @@ asn_INTEGER2long(const INTEGER_t *iptr, long *lptr) {
 	size = iptr->size;
 	end = b + size;	/* Where to stop */
 
-	if(size > sizeof(long)) {
+	if(size > sizeof(long long)) {
 		uint8_t *end1 = end - 1;
 		/*
 		 * Slightly more advanced processing,
@@ -797,7 +797,7 @@ asn_INTEGER2long(const INTEGER_t *iptr, long *lptr) {
 		}
 
 		size = end - b;
-		if(size > sizeof(long)) {
+		if(size > sizeof(long long)) {
 			/* Still cannot fit the long */
 			errno = ERANGE;
 			return -1;
@@ -823,9 +823,9 @@ asn_INTEGER2long(const INTEGER_t *iptr, long *lptr) {
 }
 
 int
-asn_INTEGER2ulong(const INTEGER_t *iptr, unsigned long *lptr) {
+asn_INTEGER2ulong(const INTEGER_t *iptr, unsigned long long *lptr) {
 	uint8_t *b, *end;
-	unsigned long l;
+	unsigned long long l;
 	size_t size;
 
 	if(!iptr || !iptr->buf || !lptr) {
@@ -838,7 +838,7 @@ asn_INTEGER2ulong(const INTEGER_t *iptr, unsigned long *lptr) {
 	end = b + size;
 
 	/* If all extra leading bytes are zeroes, ignore them */
-	for(; size > sizeof(unsigned long); b++, size--) {
+	for(; size > sizeof(unsigned long long); b++, size--) {
 		if(*b) {
 			/* Value won't fit unsigned long */
 			errno = ERANGE;
@@ -855,13 +855,13 @@ asn_INTEGER2ulong(const INTEGER_t *iptr, unsigned long *lptr) {
 }
 
 int
-asn_ulong2INTEGER(INTEGER_t *st, unsigned long value) {
+asn_ulong2INTEGER(INTEGER_t *st, unsigned long long value) {
 	uint8_t *buf;
 	uint8_t *end;
 	uint8_t *b;
 	int shr;
 
-	if(value <= LONG_MAX)
+	if(value <= LLONG_MAX)
 		return asn_long2INTEGER(st, value);
 
 	buf = (uint8_t *)MALLOC(1 + sizeof(value));
@@ -869,7 +869,7 @@ asn_ulong2INTEGER(INTEGER_t *st, unsigned long value) {
 
 	end = buf + (sizeof(value) + 1);
 	buf[0] = 0;
-	for(b = buf + 1, shr = (sizeof(long)-1)*8; b < end; shr -= 8, b++)
+	for(b = buf + 1, shr = (sizeof(long long)-1)*8; b < end; shr -= 8, b++)
 		*b = (uint8_t)(value >> shr);
 
 	if(st->buf) FREEMEM(st->buf);
@@ -880,7 +880,7 @@ asn_ulong2INTEGER(INTEGER_t *st, unsigned long value) {
 }
 
 int
-asn_long2INTEGER(INTEGER_t *st, long value) {
+asn_long2INTEGER(INTEGER_t *st, long long value) {
 	uint8_t *buf, *bp;
 	uint8_t *p;
 	uint8_t *pstart;
@@ -938,7 +938,7 @@ asn_long2INTEGER(INTEGER_t *st, long value) {
  * This function is going to be DEPRECATED soon.
  */
 enum asn_strtol_result_e
-asn_strtol(const char *str, const char *end, long *lp) {
+asn_strtol(const char *str, const char *end, long long *lp) {
     const char *endp = end;
 
     switch(asn_strtol_lim(str, &endp, lp)) {
@@ -964,12 +964,12 @@ asn_strtol(const char *str, const char *end, long *lp) {
  * WARNING: This behavior is different from the standard strtol(3).
  */
 enum asn_strtol_result_e
-asn_strtol_lim(const char *str, const char **end, long *lp) {
+asn_strtol_lim(const char *str, const char **end, long long *lp) {
 	int sign = 1;
-	long l;
+	long long l;
 
-	const long upper_boundary = LONG_MAX / 10;
-	long last_digit_max = LONG_MAX % 10;
+	const long long upper_boundary = LLONG_MAX / 10;
+	long long last_digit_max = LLONG_MAX % 10;
 
 	if(str >= *end) return ASN_STRTOL_ERROR_INVAL;
 

--- a/skeletons/INTEGER.c
+++ b/skeletons/INTEGER.c
@@ -148,7 +148,7 @@ INTEGER__dump(const asn_TYPE_descriptor_t *td, const INTEGER_t *st, asn_app_cons
 			scr = scratch;
 			ret = snprintf(scr, scrsize,
 				(specs && specs->field_unsigned)
-				?"%lu":"%lld", value);
+				?"%llu":"%lld", value);
 		}
 		assert(ret > 0 && (size_t)ret < scrsize);
 		return (cb(scr, ret, app_key) < 0) ? -1 : ret;

--- a/skeletons/INTEGER.c
+++ b/skeletons/INTEGER.c
@@ -699,7 +699,7 @@ INTEGER_encode_uper(asn_TYPE_descriptor_t *td,
 				|| uval > (unsigned long)ct->upper_bound)
 					inext = 1;
 			}
-			ASN_DEBUG("Value %lu (%02x/%d) lb %lu ub %lu %s",
+			ASN_DEBUG("Value %lu (%02x/%d) lb %llu ub %llu %s",
 				uval, st->buf[0], st->size,
 				ct->lower_bound, ct->upper_bound,
 				inext ? "ext" : "fix");
@@ -716,7 +716,7 @@ INTEGER_encode_uper(asn_TYPE_descriptor_t *td,
 				|| value > ct->upper_bound)
 					inext = 1;
 			}
-			ASN_DEBUG("Value %ld (%02x/%d) lb %ld ub %ld %s",
+			ASN_DEBUG("Value %ld (%02x/%d) lb %lld ub %lld %s",
 				value, st->buf[0], st->size,
 				ct->lower_bound, ct->upper_bound,
 				inext ? "ext" : "fix");

--- a/skeletons/INTEGER.h
+++ b/skeletons/INTEGER.h
@@ -52,10 +52,10 @@ per_type_encoder_f INTEGER_encode_uper;
  * -1/ERANGE: Value encoded is out of range for long representation
  * -1/ENOMEM: Memory allocation failed (in asn_long2INTEGER()).
  */
-int asn_INTEGER2long(const INTEGER_t *i, long *l);
-int asn_INTEGER2ulong(const INTEGER_t *i, unsigned long *l);
-int asn_long2INTEGER(INTEGER_t *i, long l);
-int asn_ulong2INTEGER(INTEGER_t *i, unsigned long l);
+int asn_INTEGER2long(const INTEGER_t *i, long long *l);
+int asn_INTEGER2ulong(const INTEGER_t *i, unsigned long long *l);
+int asn_long2INTEGER(INTEGER_t *i, long long l);
+int asn_ulong2INTEGER(INTEGER_t *i, unsigned long long l);
 
 /* A a reified version of strtol(3) with nicer error reporting. */
 enum asn_strtol_result_e {
@@ -65,15 +65,15 @@ enum asn_strtol_result_e {
     ASN_STRTOL_OK          =  0,  /* Conversion succeded, number ends at (*end) */
     ASN_STRTOL_EXTRA_DATA  =  1   /* Conversion succeded, but the string has extra stuff */
 };
-enum asn_strtol_result_e asn_strtol_lim(const char *str, const char **end, long *l);
+enum asn_strtol_result_e asn_strtol_lim(const char *str, const char **end, long long *l);
 
 /* The asn_strtol is going to be DEPRECATED soon */
-enum asn_strtol_result_e asn_strtol(const char *str, const char *end, long *l);
+enum asn_strtol_result_e asn_strtol(const char *str, const char *end, long long *l);
 
 /*
  * Convert the integer value into the corresponding enumeration map entry.
  */
-const asn_INTEGER_enum_map_t *INTEGER_map_value2enum(asn_INTEGER_specifics_t *specs, long value);
+const asn_INTEGER_enum_map_t *INTEGER_map_value2enum(asn_INTEGER_specifics_t *specs, long long value);
 
 #ifdef __cplusplus
 }

--- a/skeletons/NativeInteger.c
+++ b/skeletons/NativeInteger.c
@@ -259,7 +259,7 @@ NativeInteger_decode_uper(asn_codec_ctx_t *opt_codec_ctx,
 			: asn_INTEGER2long(&tmpint, native))
 			rval.code = RC_FAIL;
 		else
-			ASN_DEBUG("NativeInteger %s got value %ld",
+			ASN_DEBUG("NativeInteger %s got value %lld",
 				td->name, *native);
 	}
 	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_INTEGER, &tmpint);

--- a/skeletons/NativeInteger.c
+++ b/skeletons/NativeInteger.c
@@ -100,14 +100,14 @@ NativeInteger_decode_ber(asn_codec_ctx_t *opt_codec_ctx,
 			const void *constbuf;
 			void *nonconstbuf;
 		} unconst_buf;
-		long l;
+		long long l;
 
 		unconst_buf.constbuf = buf_ptr;
 		tmp.buf = (uint8_t *)unconst_buf.nonconstbuf;
 		tmp.size = length;
 
 		if((specs&&specs->field_unsigned)
-			? asn_INTEGER2ulong(&tmp, (unsigned long *)&l) /* sic */
+			? asn_INTEGER2ulong(&tmp, (unsigned long long *)&l) /* sic */
 			: asn_INTEGER2long(&tmp, &l)) {
 			rval.code = RC_FAIL;
 			rval.consumed = 0;
@@ -185,9 +185,9 @@ NativeInteger_decode_xer(asn_codec_ctx_t *opt_codec_ctx,
 	rval = INTEGER_decode_xer(opt_codec_ctx, td, &st_ptr, 
 		opt_mname, buf_ptr, size);
 	if(rval.code == RC_OK) {
-		long l;
+		long long l;
 		if((specs&&specs->field_unsigned)
-			? asn_INTEGER2ulong(&st, (unsigned long *)&l) /* sic */
+			? asn_INTEGER2ulong(&st, (unsigned long long *)&l) /* sic */
 			: asn_INTEGER2long(&st, &l)) {
 			rval.code = RC_FAIL;
 			rval.consumed = 0;
@@ -238,7 +238,7 @@ NativeInteger_decode_uper(asn_codec_ctx_t *opt_codec_ctx,
 
 	asn_INTEGER_specifics_t *specs=(asn_INTEGER_specifics_t *)td->specifics;
 	asn_dec_rval_t rval;
-	long *native = (long *)*sptr;
+	long long *native = (long long*)*sptr;
 	INTEGER_t tmpint;
 	void *tmpintptr = &tmpint;
 
@@ -246,7 +246,7 @@ NativeInteger_decode_uper(asn_codec_ctx_t *opt_codec_ctx,
 	ASN_DEBUG("Decoding NativeInteger %s (UPER)", td->name);
 
 	if(!native) {
-		native = (long *)(*sptr = CALLOC(1, sizeof(*native)));
+		native = (long long *)(*sptr = CALLOC(1, sizeof(*native)));
 		if(!native) ASN__DECODE_FAILED;
 	}
 
@@ -255,7 +255,7 @@ NativeInteger_decode_uper(asn_codec_ctx_t *opt_codec_ctx,
 				   &tmpintptr, pd);
 	if(rval.code == RC_OK) {
 		if((specs&&specs->field_unsigned)
-			? asn_INTEGER2ulong(&tmpint, (unsigned long *)native)
+			? asn_INTEGER2ulong(&tmpint, (unsigned long long *)native)
 			: asn_INTEGER2long(&tmpint, native))
 			rval.code = RC_FAIL;
 		else

--- a/skeletons/NativeInteger.c
+++ b/skeletons/NativeInteger.c
@@ -283,7 +283,7 @@ NativeInteger_encode_uper(asn_TYPE_descriptor_t *td,
 
 	memset(&tmpint, 0, sizeof(tmpint));
 	if((specs&&specs->field_unsigned)
-		? asn_ulong2INTEGER(&tmpint, native)
+		? asn_ulong2INTEGER(&tmpint, (unsigned long)native)
 		: asn_long2INTEGER(&tmpint, native))
 		ASN__ENCODE_FAILED;
 	er = INTEGER_encode_uper(td, constraints, &tmpint, po);

--- a/skeletons/OBJECT_IDENTIFIER.c
+++ b/skeletons/OBJECT_IDENTIFIER.c
@@ -666,7 +666,7 @@ OBJECT_IDENTIFIER_parse_arcs(const char *oid_text, ssize_t oid_txt_length,
 
 #define	_OID_CAPTURE_ARC(oid_text, oid_end)		do {	\
 	const char *endp = oid_end;				\
-	long value;						\
+	long long value;						\
 	switch(asn_strtol_lim(oid_text, &endp, &value)) {	\
 	case ASN_STRTOL_EXTRA_DATA:				\
 	case ASN_STRTOL_OK:					\

--- a/skeletons/OCTET_STRING.c
+++ b/skeletons/OCTET_STRING.c
@@ -1392,7 +1392,7 @@ OCTET_STRING_decode_uper(asn_codec_ctx_t *opt_codec_ctx,
 		if(!st) RETURN(RC_FAIL);
 	}
 
-	ASN_DEBUG("PER Decoding %s size %ld .. %ld bits %d",
+	ASN_DEBUG("PER Decoding %s size %lld .. %lld bits %d",
 		csiz->flags & APC_EXTENSIBLE ? "extensible" : "non-extensible",
 		csiz->lower_bound, csiz->upper_bound, csiz->effective_bits);
 
@@ -1423,14 +1423,14 @@ OCTET_STRING_decode_uper(asn_codec_ctx_t *opt_codec_ctx,
 	if(csiz->effective_bits == 0) {
 		int ret;
 		if(bpc) {
-			ASN_DEBUG("Encoding OCTET STRING size %ld",
+			ASN_DEBUG("Encoding OCTET STRING size %lld",
 				csiz->upper_bound);
 			ret = OCTET_STRING_per_get_characters(pd, st->buf,
 				csiz->upper_bound, bpc, unit_bits,
 				cval->lower_bound, cval->upper_bound, pc);
 			if(ret > 0) RETURN(RC_FAIL);
 		} else {
-			ASN_DEBUG("Encoding BIT STRING size %ld",
+			ASN_DEBUG("Encoding BIT STRING size %lld",
 				csiz->upper_bound);
 			ret = per_get_many_bits(pd, st->buf, 0,
 					    unit_bits * csiz->upper_bound);
@@ -1566,7 +1566,7 @@ OCTET_STRING_encode_uper(asn_TYPE_descriptor_t *td,
 	}
 
 	ASN_DEBUG("Encoding %s into %d units of %d bits"
-		" (%ld..%ld, effective %d)%s",
+		" (%lld..%lld, effective %d)%s",
 		td->name, sizeinunits, unit_bits,
 		csiz->lower_bound, csiz->upper_bound,
 		csiz->effective_bits, ct_extensible ? " EXT" : "");
@@ -1598,7 +1598,7 @@ OCTET_STRING_encode_uper(asn_TYPE_descriptor_t *td,
 	/* X.691, #16.6: short fixed length encoding (up to 2 octets) */
 	/* X.691, #16.7: long fixed length encoding (up to 64K octets) */
 	if(csiz->effective_bits >= 0) {
-		ASN_DEBUG("Encoding %d bytes (%ld), length in %d bits",
+		ASN_DEBUG("Encoding %d bytes (%lld), length in %d bits",
 				st->size, sizeinunits - csiz->lower_bound,
 				csiz->effective_bits);
 		ret = per_put_few_bits(po, sizeinunits - csiz->lower_bound,

--- a/skeletons/asn_system.h
+++ b/skeletons/asn_system.h
@@ -21,7 +21,7 @@
 #include <stdlib.h>	/* For *alloc(3) */
 #include <string.h>	/* For memcpy(3) */
 #include <sys/types.h>	/* For size_t */
-#include <limits.h>	/* For LONG_MAX */
+#include <limits.h>	/* For LLONG_MAX and ULLONG_MAX*/
 #include <stdarg.h>	/* For va_start */
 #include <stddef.h>	/* for offsetof and ptrdiff_t */
 

--- a/skeletons/constr_SEQUENCE_OF.c
+++ b/skeletons/constr_SEQUENCE_OF.c
@@ -164,7 +164,7 @@ SEQUENCE_OF_encode_uper(asn_TYPE_descriptor_t *td,
 	if(ct) {
 		int not_in_root = (list->count < ct->lower_bound
 				|| list->count > ct->upper_bound);
-		ASN_DEBUG("lb %ld ub %ld %s",
+		ASN_DEBUG("lb %lld ub %lld %s",
 			ct->lower_bound, ct->upper_bound,
 			ct->flags & APC_EXTENSIBLE ? "ext" : "fix");
 		if(ct->flags & APC_EXTENSIBLE) {

--- a/skeletons/constr_SET_OF.c
+++ b/skeletons/constr_SET_OF.c
@@ -902,7 +902,7 @@ SET_OF_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
 	if(ct && ct->effective_bits >= 0) {
 		/* X.691, #19.5: No length determinant */
 		nelems = per_get_few_bits(pd, ct->effective_bits);
-		ASN_DEBUG("Preparing to fetch %ld+%ld elements from %s",
+		ASN_DEBUG("Preparing to fetch %ld+%lld elements from %s",
 			(long)nelems, ct->lower_bound, td->name);
 		if(nelems < 0)  ASN__DECODE_STARVED;
 		nelems += ct->lower_bound;

--- a/skeletons/per_support.c
+++ b/skeletons/per_support.c
@@ -265,9 +265,9 @@ uper_put_nsnnwn(asn_per_outp_t *po, int n) {
 
 
 /* X.691-2008/11, #11.5.6 -> #11.3 */
-int uper_get_constrained_whole_number(asn_per_data_t *pd, unsigned long *out_value, int nbits) {
-	unsigned long lhalf;    /* Lower half of the number*/
-	long half;
+int uper_get_constrained_whole_number(asn_per_data_t *pd, unsigned long long *out_value, int nbits) {
+	unsigned long long lhalf;    /* Lower half of the number*/
+	long long half;
 
 	if(nbits <= 31) {
 		half = per_get_few_bits(pd, nbits);
@@ -285,27 +285,27 @@ int uper_get_constrained_whole_number(asn_per_data_t *pd, unsigned long *out_val
 	if(uper_get_constrained_whole_number(pd, &lhalf, nbits - 31))
 		return -1;
 
-	*out_value = ((unsigned long)half << (nbits - 31)) | lhalf;
+	*out_value = ((unsigned long long)half << (nbits - 31)) | lhalf;
 	return 0;
 }
 
 
 /* X.691-2008/11, #11.5.6 -> #11.3 */
-int uper_put_constrained_whole_number_s(asn_per_outp_t *po, long v, int nbits) {
+int uper_put_constrained_whole_number_s(asn_per_outp_t *po, long long v, int nbits) {
 	/*
 	 * Assume signed number can be safely coerced into
 	 * unsigned of the same range.
 	 * The following testing code will likely be optimized out
 	 * by compiler if it is true.
 	 */
-	unsigned long uvalue1 = ULONG_MAX;
-	         long svalue  = uvalue1;
-	unsigned long uvalue2 = svalue;
+	unsigned long long uvalue1 = ULLONG_MAX;
+	         long long svalue  = uvalue1;
+	unsigned long long uvalue2 = svalue;
 	assert(uvalue1 == uvalue2);
 	return uper_put_constrained_whole_number_u(po, v, nbits);
 }
 
-int uper_put_constrained_whole_number_u(asn_per_outp_t *po, unsigned long v, int nbits) {
+int uper_put_constrained_whole_number_u(asn_per_outp_t *po, unsigned long long v, int nbits) {
 	if(nbits <= 31) {
 		return per_put_few_bits(po, v, nbits);
 	} else {

--- a/skeletons/per_support.h
+++ b/skeletons/per_support.h
@@ -24,8 +24,8 @@ typedef const struct asn_per_constraint_s {
 	} flags;
 	int  range_bits;		/* Full number of bits in the range */
 	int  effective_bits;		/* Effective bits */
-	long lower_bound;		/* "lb" value */
-	long upper_bound;		/* "ub" value */
+	long long lower_bound;		/* "lb" value */
+	long long upper_bound;		/* "ub" value */
 } asn_per_constraint_t;
 typedef const struct asn_per_constraints_s {
 	struct asn_per_constraint_s value;

--- a/skeletons/per_support.h
+++ b/skeletons/per_support.h
@@ -82,7 +82,7 @@ ssize_t uper_get_nslength(asn_per_data_t *pd);
 ssize_t uper_get_nsnnwn(asn_per_data_t *pd);
 
 /* X.691-2008/11, #11.5.6 */
-int uper_get_constrained_whole_number(asn_per_data_t *pd, unsigned long *v, int nbits);
+int uper_get_constrained_whole_number(asn_per_data_t *pd, unsigned long long *v, int nbits);
 
 /* Non-thread-safe debugging function, don't use it */
 char *per_data_string(asn_per_data_t *pd);
@@ -107,8 +107,8 @@ int per_put_few_bits(asn_per_outp_t *per_data, uint32_t bits, int obits);
 int per_put_many_bits(asn_per_outp_t *po, const uint8_t *src, int put_nbits);
 
 /* X.691-2008/11, #11.5 */
-int uper_put_constrained_whole_number_s(asn_per_outp_t *po, long v, int nbits);
-int uper_put_constrained_whole_number_u(asn_per_outp_t *po, unsigned long v, int nbits);
+int uper_put_constrained_whole_number_s(asn_per_outp_t *po, long long v, int nbits);
+int uper_put_constrained_whole_number_u(asn_per_outp_t *po, unsigned long long v, int nbits);
 
 /*
  * Put the length "n" to the Unaligned PER stream.

--- a/skeletons/tests/check-INTEGER.c
+++ b/skeletons/tests/check-INTEGER.c
@@ -14,13 +14,13 @@ static int _print2buf(const void *buf, size_t size, void *key) {
 }
 
 static void
-check(uint8_t *buf, int size, long check_long, int check_ret) {
+check(uint8_t *buf, int size, long long check_long, int check_ret) {
 	char scratch[128];
 	char verify[32];
 	INTEGER_t val;
 	uint8_t *buf_end = buf + size;
 	int ret;
-	long rlong = 123;
+	long long rlong = 123;
 
 	assert(buf);
 	assert(size >= 0);
@@ -36,15 +36,15 @@ check(uint8_t *buf, int size, long check_long, int check_ret) {
 	printf("]: ");
 
 	ret = asn_INTEGER2long(&val, &rlong);
-	printf(" (%ld, %d) vs (%ld, %d)\n",
+	printf(" (%lld, %d) vs (%lld, %d)\n",
 		rlong, ret, check_long, check_ret);
 	assert(ret == check_ret);
-	printf("%ld %ld\n", rlong, check_long);
+	printf("%lld %lld\n", rlong, check_long);
 	assert(rlong == check_long);
 
 	if(check_ret == 0) {
 		INTEGER_t val2;
-		long rlong2;
+		long long rlong2;
 		val2.buf = 0;
 		val2.size = 0;
 		ret = asn_long2INTEGER(&val2, rlong);
@@ -60,7 +60,7 @@ check(uint8_t *buf, int size, long check_long, int check_ret) {
 	ret = INTEGER_print(&asn_DEF_INTEGER, &val, 0, _print2buf, scratch);
 	assert(shared_scratch_start < scratch + sizeof(scratch));
 	assert(ret == 0);
-	ret = snprintf(verify, sizeof(verify), "%ld", check_long);
+	ret = snprintf(verify, sizeof(verify), "%lld", check_long);
 	assert(ret < 0 || (size_t)ret < sizeof(verify));
 	ret = strcmp(scratch, verify);
 	printf("         [%s] vs [%s]: %d%s\n",
@@ -75,13 +75,13 @@ check(uint8_t *buf, int size, long check_long, int check_ret) {
 }
 
 static void
-check_unsigned(uint8_t *buf, int size, unsigned long check_long, int check_ret) {
+check_unsigned(uint8_t *buf, int size, unsigned long long  check_long, int check_ret) {
 	char scratch[128];
 	char verify[32];
 	INTEGER_t val;
 	uint8_t *buf_end = buf + size;
 	int ret;
-	unsigned long rlong = 123;
+	unsigned long long rlong = 123;
 
 	assert(buf);
 	assert(size >= 0);
@@ -97,14 +97,14 @@ check_unsigned(uint8_t *buf, int size, unsigned long check_long, int check_ret) 
 	printf("]: ");
 
 	ret = asn_INTEGER2ulong(&val, &rlong);
-	printf(" (%lu, %d) vs (%lu, %d)\n",
+	printf(" (%llu, %d) vs (%llu, %d)\n",
 		rlong, ret, check_long, check_ret);
 	assert(ret == check_ret);
 	assert(rlong == check_long);
 
 	if(check_ret == 0) {
 		INTEGER_t val2;
-		unsigned long rlong2;
+		unsigned long long rlong2;
 		val2.buf = 0;
 		val2.size = 0;
 		ret = asn_ulong2INTEGER(&val2, rlong);
@@ -127,7 +127,7 @@ check_unsigned(uint8_t *buf, int size, unsigned long check_long, int check_ret) 
 	ret = INTEGER_print(&asn_DEF_INTEGER, &val, 0, _print2buf, scratch);
 	assert(shared_scratch_start < scratch + sizeof(scratch));
 	assert(ret == 0);
-	ret = snprintf(verify, sizeof(verify), "%lu", check_long);
+	ret = snprintf(verify, sizeof(verify), "%llu", check_long);
 	assert(ret < sizeof(verify));
 	ret = strcmp(scratch, verify);
 	printf("         [%s] vs [%s]: %d%s\n",
@@ -145,7 +145,7 @@ static void
 check_xer(int tofail, char *xmldata, long orig_value) {
 	INTEGER_t *st = 0;
 	asn_dec_rval_t rc;
-	long value;
+	long long value;
 	int ret;
 
 	printf("[%s] vs %ld: ", xmldata, orig_value);
@@ -162,7 +162,7 @@ check_xer(int tofail, char *xmldata, long orig_value) {
 	ret = asn_INTEGER2long(st, &value);
 	assert(ret == 0);
 
-	printf("\t%ld\n", value);
+	printf("\t%lld\n", value);
 
 	assert(value == orig_value);
 

--- a/skeletons/tests/check-INTEGER.c
+++ b/skeletons/tests/check-INTEGER.c
@@ -142,7 +142,7 @@ check_unsigned(uint8_t *buf, int size, unsigned long long  check_long, int check
 }
 
 static void
-check_xer(int tofail, char *xmldata, long orig_value) {
+check_xer(int tofail, char *xmldata, long long orig_value) {
 	INTEGER_t *st = 0;
 	asn_dec_rval_t rc;
 	long long value;
@@ -249,19 +249,27 @@ main() {
 	check_xer(0, "<INTEGER>-2147483648</INTEGER>", -2147483647-1);
 	check_xer(0, "<INTEGER>+2147483647</INTEGER>", 2147483647);
 	check_xer(0, "<INTEGER>2147483647</INTEGER>", 2147483647);
+
 	if(sizeof(long) == 4) {
-		check_xer( 0, "<INTEGER>-2147483648</INTEGER>", -2147483648);
-		check_xer(-1, "<INTEGER>-2147483649</INTEGER>", 0);
-		check_xer(-1, "<INTEGER>2147483648</INTEGER>", 0);
-		check_xer(-1, "<INTEGER>2147483649</INTEGER>", 0);
-		check_xer(-1, "<INTEGER>3147483649</INTEGER>", 0);
-		check_xer(-1, "<INTEGER>4147483649</INTEGER>", 0);
-		check_xer(-1, "<INTEGER>5147483649</INTEGER>", 0); /* special */
-		check_xer(-1, "<INTEGER>9147483649</INTEGER>", 0);
-		check_xer(-1, "<INTEGER>9999999999</INTEGER>", 0);
-		check_xer(-1, "<INTEGER>-5147483649</INTEGER>", 0);/* special */
-		check_xer(-1, "<INTEGER>-9147483649</INTEGER>", 0);
-		check_xer(-1, "<INTEGER>-9999999999</INTEGER>", 0);
+		check_xer(0, "<INTEGER>2147483648</INTEGER>", 2147483648);
+		check_xer(0, "<INTEGER>2147483649</INTEGER>", 2147483649);
+		check_xer(0, "<INTEGER>3147483649</INTEGER>", 3147483649);
+		check_xer(0, "<INTEGER>4147483649</INTEGER>", 4147483649);
+		check_xer(0, "<INTEGER>5147483649</INTEGER>", 5147483649);
+		check_xer(0, "<INTEGER>9147483649</INTEGER>", 9147483649);
+		check_xer(0, "<INTEGER>9999999999</INTEGER>", 9999999999);
+		check_xer(0, "<INTEGER>9223372036854775807</INTEGER>", 9223372036854775807);
+		check_xer(-1, "<INTEGER>9223372036854775808</INTEGER>", 0);
+		check_xer(-1, "<INTEGER>10223372036854775807</INTEGER>", 0);
+		check_xer(-1, "<INTEGER>50223372036854775807</INTEGER>", 0);
+		check_xer(-1, "<INTEGER>100223372036854775807</INTEGER>", 0);
+		check_xer(-1, "<INTEGER>500223372036854775807</INTEGER>", 0);
+		check_xer(0, "<INTEGER>-9223372036854775808</INTEGER>", -9223372036854775807-1);
+		check_xer(-1, "<INTEGER>-9223372036854775809</INTEGER>", 0);
+		check_xer(-1, "<INTEGER>-10223372036854775807</INTEGER>", 0);
+		check_xer(-1, "<INTEGER>-50223372036854775807</INTEGER>", 0);
+		check_xer(-1, "<INTEGER>-100223372036854775807</INTEGER>", 0);
+		check_xer(-1, "<INTEGER>-500223372036854775807</INTEGER>", 0);
 	}
 	if(sizeof(long) == 8) {
 		check_xer(0, "<INTEGER>2147483648</INTEGER>", 2147483648);

--- a/skeletons/tests/check-OIDs.c
+++ b/skeletons/tests/check-OIDs.c
@@ -416,13 +416,16 @@ main() {
 	check_parse("1.2000000000.3", 3);
 	check_parse("1.2147483647.3", 3);
 	if(sizeof(long) == 4) {
-		check_parse("1.2147483648.3", -1);	/* overflow on ILP32 */
-		check_parse("1.2147483649.3", -1);	/* overflow on ILP32 */
-		check_parse("1.3000000000.3", -1);
-		check_parse("1.4000000000.3", -1);
-		check_parse("1.5000000000.3", -1);
-		check_parse("1.6000000000.3", -1);
-		check_parse("1.9000000000.3", -1);
+		check_parse("1.2147483648.3", 3);
+		check_parse("1.9223372036854775807.3", 3);
+		check_parse("1.9223372036854775808.3", -1);
+//		check_parse("1.2147483648.3", 3);	/* overflow on ILP32 */
+//		check_parse("1.2147483649.3", 3);	/* overflow on ILP32 */
+//		check_parse("1.3000000000.3", -1);
+//		check_parse("1.4000000000.3", -1);
+//		check_parse("1.5000000000.3", -1);
+//		check_parse("1.6000000000.3", -1);
+//		check_parse("1.9000000000.3", -1);
 	} else if(sizeof(long) == 8) {
 		check_parse("1.2147483648.3", 3);
 		check_parse("1.9223372036854775807.3", 3);

--- a/skeletons/tests/check-PER-INTEGER.c
+++ b/skeletons/tests/check-PER-INTEGER.c
@@ -104,11 +104,11 @@ check_per_encode_constrained(int lineno, int unsigned_, long value, long lbound,
 					(void **)&reconstructed_st, &pd);
 	assert(dec_rval.code == RC_OK);
 	if(unsigned_) {
-		unsigned long reconstructed_value = 0;
+		unsigned long long reconstructed_value = 0;
 		asn_INTEGER2ulong(reconstructed_st, &reconstructed_value);
 		assert(reconstructed_value == (unsigned long)value);
 	} else {
-		long reconstructed_value = 0;
+		long long reconstructed_value = 0;
 		asn_INTEGER2long(reconstructed_st, &reconstructed_value);
 		assert(reconstructed_value == value);
 	}

--- a/skeletons/tests/check-REAL.c
+++ b/skeletons/tests/check-REAL.c
@@ -192,7 +192,7 @@ check_ber_buffer_twoway(double d, const char *sample, const char *canonical_samp
 	ret = asn_double2REAL(&rn, d);
 	assert(ret == 0);
 	if((size_t)rn.size != outsize) {
-		printf("Encoded %f into %d expected %ld\n",
+		printf("Encoded %f into %d expected %zu\n",
 			d, (int)rn.size, outsize);
 		assert((size_t)rn.size == outsize);
 	}

--- a/tests/106-param-constr-OK.asn1.-P
+++ b/tests/106-param-constr-OK.asn1.-P
@@ -24,7 +24,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Narrow_15P0;
 static int
 memb_narrow1_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -33,9 +33,9 @@ memb_narrow1_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= 1 && value <= 5)) {
+	if((value >= 1LL && value <= 5LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -49,7 +49,7 @@ memb_narrow1_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 static int
 memb_narrow2_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -58,9 +58,9 @@ memb_narrow2_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= 2 && value <= 5)) {
+	if((value >= 2LL && value <= 5LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -74,7 +74,7 @@ memb_narrow2_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 static int
 memb_narrow3_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -83,9 +83,9 @@ memb_narrow3_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= 3 && value <= 5)) {
+	if((value >= 3LL && value <= 5LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {

--- a/tests/108-param-constr-3-OK.asn1.-Pfwide-types
+++ b/tests/108-param-constr-3-OK.asn1.-Pfwide-types
@@ -24,7 +24,7 @@ int
 MinMax_16P0_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -40,7 +40,7 @@ MinMax_16P0_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value >= 3)) {
+	if((value >= 3LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -172,7 +172,7 @@ int
 ThreePlus_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const MinMax_16P0_t *st = (const MinMax_16P0_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -188,7 +188,7 @@ ThreePlus_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value >= 3)) {
+	if((value >= 3LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {

--- a/tests/119-per-strings-OK.asn1.-Pgen-PER
+++ b/tests/119-per-strings-OK.asn1.-Pgen-PER
@@ -80,7 +80,7 @@ static int check_permitted_alphabet_5(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 90)) return -1;
+		if(!(cv >= 65LL && cv <= 90LL)) return -1;
 	}
 	return 0;
 }
@@ -93,7 +93,7 @@ static int check_permitted_alphabet_6(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 90)) return -1;
+		if(!(cv >= 65LL && cv <= 90LL)) return -1;
 	}
 	return 0;
 }
@@ -132,7 +132,7 @@ static int check_permitted_alphabet_9(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 90)) return -1;
+		if(!(cv >= 65LL && cv <= 90LL)) return -1;
 	}
 	return 0;
 }
@@ -145,7 +145,7 @@ static int check_permitted_alphabet_10(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 90)) return -1;
+		if(!(cv >= 65LL && cv <= 90LL)) return -1;
 	}
 	return 0;
 }
@@ -184,7 +184,7 @@ static int check_permitted_alphabet_13(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 90)) return -1;
+		if(!(cv >= 65LL && cv <= 90LL)) return -1;
 	}
 	return 0;
 }
@@ -223,7 +223,7 @@ static int check_permitted_alphabet_16(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 53 && cv <= 57)) return -1;
+		if(!(cv >= 53LL && cv <= 57LL)) return -1;
 	}
 	return 0;
 }
@@ -236,7 +236,7 @@ static int check_permitted_alphabet_17(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 53 && cv <= 57)) return -1;
+		if(!(cv >= 53LL && cv <= 57LL)) return -1;
 	}
 	return 0;
 }
@@ -299,7 +299,7 @@ static int check_permitted_alphabet_23(const void *sptr) {
 	for(; ch < end; ch += 2) {
 		uint16_t cv = (ch[0] << 8)
 				| ch[1];
-		if(!(cv >= 65 && cv <= 90)) return -1;
+		if(!(cv >= 65LL && cv <= 90LL)) return -1;
 	}
 	return 0;
 }
@@ -314,7 +314,7 @@ static int check_permitted_alphabet_24(const void *sptr) {
 	for(; ch < end; ch += 2) {
 		uint16_t cv = (ch[0] << 8)
 				| ch[1];
-		if(!(cv <= 65533)) return -1;
+		if(!(cv <= 65533LL)) return -1;
 	}
 	return 0;
 }
@@ -329,7 +329,7 @@ static int check_permitted_alphabet_25(const void *sptr) {
 	for(; ch < end; ch += 2) {
 		uint16_t cv = (ch[0] << 8)
 				| ch[1];
-		if(!(cv >= 65 && cv <= 90)) return -1;
+		if(!(cv >= 65LL && cv <= 90LL)) return -1;
 	}
 	return 0;
 }
@@ -375,7 +375,7 @@ static int check_permitted_alphabet_28(const void *sptr) {
 				| (ch[1] << 16)
 				| (ch[2] << 8)
 				|  ch[3];
-		if(!(cv >= 65 && cv <= 90)) return -1;
+		if(!(cv >= 65LL && cv <= 90LL)) return -1;
 	}
 	return 0;
 }
@@ -409,7 +409,7 @@ static int check_permitted_alphabet_30(const void *sptr) {
 				| (ch[1] << 16)
 				| (ch[2] << 8)
 				|  ch[3];
-		if(!(cv >= 65 && cv <= 90)) return -1;
+		if(!(cv >= 65LL && cv <= 90LL)) return -1;
 	}
 	return 0;
 }
@@ -773,7 +773,7 @@ memb_ut_c_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((size == 6)) {
+	if((size == 6LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -805,7 +805,7 @@ memb_ut_ce_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((size == 6)) {
+	if((size == 6LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -879,7 +879,7 @@ memb_bm_cs_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	size = st->size >> 1;	/* 2 byte per character */
 	
-	if((size == 6)
+	if((size == 6LL)
 		 && !check_permitted_alphabet_24(st)) {
 		/* Constraint check succeeded */
 		return 0;
@@ -988,7 +988,7 @@ memb_us_cs_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	size = st->size >> 2;	/* 4 byte per character */
 	
-	if((size == 6)
+	if((size == 6LL)
 		 && !check_permitted_alphabet_29(st)) {
 		/* Constraint check succeeded */
 		return 0;

--- a/tests/127-per-long-OK.asn1.-Pgen-PER
+++ b/tests/127-per-long-OK.asn1.-Pgen-PER
@@ -266,7 +266,7 @@ memb_full32range_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	value = *(const long long *)sptr;
 	
-	if((value >= (-2147483647L - 1)LL && value <= 2147483647LL)) {
+	if((value >= -2147483648LL && value <= 2147483647LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {

--- a/tests/127-per-long-OK.asn1.-Pgen-PER
+++ b/tests/127-per-long-OK.asn1.-Pgen-PER
@@ -124,7 +124,7 @@ unsigned32_4_encode_uper(asn_TYPE_descriptor_t *td,
 static int
 unsplit32_5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	unsigned long value;
+	unsigned long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -133,9 +133,9 @@ unsplit32_5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const unsigned long *)sptr;
+	value = *(const unsigned long long *)sptr;
 	
-	if(((value >= 5 && value <= 500) || (value >= 600 && value <= 4294967290))) {
+	if(((value >= 5LL && value <= 500LL) || (value >= 600LL && value <= 4294967290LL))) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -230,7 +230,7 @@ unsplit32_5_encode_uper(asn_TYPE_descriptor_t *td,
 static int
 memb_small32range_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -239,9 +239,9 @@ memb_small32range_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= -2000000000 && value <= 2000000000)) {
+	if((value >= -2000000000LL && value <= 2000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -255,7 +255,7 @@ memb_small32range_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 static int
 memb_full32range_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -264,9 +264,9 @@ memb_full32range_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= (-2147483647L - 1) && value <= 2147483647)) {
+	if((value >= (-2147483647L - 1)LL && value <= 2147483647LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -296,7 +296,7 @@ memb_unsigned32_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 static int
 memb_unsplit32_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	unsigned long value;
+	unsigned long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -305,9 +305,9 @@ memb_unsplit32_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const unsigned long *)sptr;
+	value = *(const unsigned long long *)sptr;
 	
-	if(((value >= 5 && value <= 500) || (value >= 600 && value <= 4294967290))) {
+	if(((value >= 5LL && value <= 500LL) || (value >= 600LL && value <= 4294967290LL))) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {

--- a/tests/134-per-long-OK.asn1.-Pgen-PER
+++ b/tests/134-per-long-OK.asn1.-Pgen-PER
@@ -26,7 +26,7 @@ static int
 memb_unsigned33_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -42,7 +42,7 @@ memb_unsigned33_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value >= 0 && value <= 5000000000)) {
+	if((value >= 0LL && value <= 5000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -57,7 +57,7 @@ static int
 memb_unsigned42_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -73,7 +73,7 @@ memb_unsigned42_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value >= 0 && value <= 3153600000000)) {
+	if((value >= 0LL && value <= 3153600000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -88,7 +88,7 @@ static int
 memb_signed33_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -104,7 +104,7 @@ memb_signed33_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value >= -4000000000 && value <= 4000000000)) {
+	if((value >= -4000000000LL && value <= 4000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -119,7 +119,7 @@ static int
 memb_signed33ext_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -135,7 +135,7 @@ memb_signed33ext_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value >= -4000000000 && value <= 4000000000)) {
+	if((value >= -4000000000LL && value <= 4000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {

--- a/tests/19-param-OK.asn1.-Pfwide-types
+++ b/tests/19-param-OK.asn1.-Pfwide-types
@@ -51,7 +51,7 @@ memb_signature_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		size = 0;
 	}
 	
-	if((size <= 256)) {
+	if((size <= 256LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {

--- a/tests/42-real-life-OK.asn1.-PR
+++ b/tests/42-real-life-OK.asn1.-PR
@@ -54,7 +54,7 @@ memb_varsets_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 	/* Determine the number of elements */
 	size = _A_CSEQUENCE_FROM_VOID(sptr)->count;
 	
-	if((size >= 1)) {
+	if((size >= 1LL)) {
 		/* Perform validation of the inner elements */
 		return td->check_constraints(td, sptr, ctfailcb, app_key);
 	} else {
@@ -411,7 +411,7 @@ memb_vset_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 	/* Determine the number of elements */
 	size = _A_CSET_FROM_VOID(sptr)->count;
 	
-	if((size >= 1)) {
+	if((size >= 1LL)) {
 		/* Perform validation of the inner elements */
 		return td->check_constraints(td, sptr, ctfailcb, app_key);
 	} else {

--- a/tests/50-constraint-OK.asn1.-Pfwide-types
+++ b/tests/50-constraint-OK.asn1.-Pfwide-types
@@ -149,7 +149,7 @@ int
 Int2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const Int1_t *st = (const Int1_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -161,7 +161,7 @@ Int2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	/* Check if the sign bit is present */
 	value = st->buf ? ((st->buf[0] & 0x80) ? -1 : 1) : 0;
 	
-	if((value >= 0)) {
+	if((value >= 0LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -293,7 +293,7 @@ int
 Int3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const Int2_t *st = (const Int2_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -309,7 +309,7 @@ Int3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value >= 0 && value <= 10)) {
+	if((value >= 0LL && value <= 10LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -441,7 +441,7 @@ int
 Int4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const Int3_t *st = (const Int3_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -457,7 +457,7 @@ Int4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value >= 1 && value <= 10)) {
+	if((value >= 1LL && value <= 10LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -589,7 +589,7 @@ int
 Int5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const Int4_t *st = (const Int4_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -605,7 +605,7 @@ Int5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value == 5)) {
+	if((value == 5LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -737,7 +737,7 @@ int
 ExtensibleExtensions_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -753,7 +753,7 @@ ExtensibleExtensions_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value >= 1 && value <= 256)) {
+	if((value >= 1LL && value <= 256LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1014,7 +1014,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv <= 127)) return -1;
+		if(!(cv <= 127LL)) return -1;
 	}
 	return 0;
 }
@@ -1037,7 +1037,7 @@ Str2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	size = st->size;
 	
-	if(((size <= 20) || (size >= 25 && size <= 30))
+	if(((size <= 20LL) || (size >= 25LL && size <= 30LL))
 		 && !check_permitted_alphabet_1(st)) {
 		/* Constraint check succeeded */
 		return 0;
@@ -1208,7 +1208,7 @@ Str3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	size = st->size;
 	
-	if(((size >= 10 && size <= 20) || (size >= 25 && size <= 27))
+	if(((size >= 10LL && size <= 20LL) || (size >= 25LL && size <= 27LL))
 		 && !check_permitted_alphabet_1(st)) {
 		/* Constraint check succeeded */
 		return 0;
@@ -1345,7 +1345,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv <= 127)) return -1;
+		if(!(cv <= 127LL)) return -1;
 	}
 	return 0;
 }
@@ -1502,7 +1502,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 70)) return -1;
+		if(!(cv >= 65LL && cv <= 70LL)) return -1;
 	}
 	return 0;
 }
@@ -1659,7 +1659,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 69 && cv <= 70)) return -1;
+		if(!(cv >= 69LL && cv <= 70LL)) return -1;
 	}
 	return 0;
 }
@@ -1816,7 +1816,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 70)) return -1;
+		if(!(cv >= 65LL && cv <= 70LL)) return -1;
 	}
 	return 0;
 }
@@ -1973,7 +1973,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 66)) return -1;
+		if(!(cv >= 65LL && cv <= 66LL)) return -1;
 	}
 	return 0;
 }
@@ -2130,7 +2130,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 66)) return -1;
+		if(!(cv >= 65LL && cv <= 66LL)) return -1;
 	}
 	return 0;
 }
@@ -2287,7 +2287,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 68)) return -1;
+		if(!(cv >= 65LL && cv <= 68LL)) return -1;
 	}
 	return 0;
 }
@@ -2310,7 +2310,7 @@ SIZE_but_not_FROM_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	size = st->size;
 	
-	if((size >= 1 && size <= 4)
+	if((size >= 1LL && size <= 4LL)
 		 && !check_permitted_alphabet_1(st)) {
 		/* Constraint check succeeded */
 		return 0;
@@ -2447,7 +2447,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 68)) return -1;
+		if(!(cv >= 65LL && cv <= 68LL)) return -1;
 	}
 	return 0;
 }
@@ -2470,7 +2470,7 @@ SIZE_and_FROM_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	size = st->size;
 	
-	if((size >= 1 && size <= 4)
+	if((size >= 1LL && size <= 4LL)
 		 && !check_permitted_alphabet_1(st)) {
 		/* Constraint check succeeded */
 		return 0;
@@ -2607,7 +2607,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 70)) return -1;
+		if(!(cv >= 65LL && cv <= 70LL)) return -1;
 	}
 	return 0;
 }
@@ -2957,7 +2957,7 @@ Utf8_3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((size >= 1 && size <= 2)
+	if((size >= 1LL && size <= 2LL)
 		 && !check_permitted_alphabet_1(st)) {
 		/* Constraint check succeeded */
 		return 0;
@@ -3107,7 +3107,7 @@ Utf8_2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((size >= 1 && size <= 2)) {
+	if((size >= 1LL && size <= 2LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -3403,7 +3403,7 @@ VisibleIdentifier_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	size = st->size;
 	
-	if((size >= 1 && size <= 32)
+	if((size >= 1LL && size <= 32LL)
 		 && !check_permitted_alphabet_1(st)) {
 		/* Constraint check succeeded */
 		return 0;
@@ -3636,7 +3636,7 @@ static int
 memb_int1_c_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const Int1_t *st = (const Int1_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -3652,7 +3652,7 @@ memb_int1_c_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value >= -2)) {
+	if((value >= -2LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -3667,7 +3667,7 @@ static int
 memb_int4_c_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const Int4_t *st = (const Int4_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -3683,7 +3683,7 @@ memb_int4_c_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value >= 5 && value <= 7)) {
+	if((value >= 5LL && value <= 7LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -3698,7 +3698,7 @@ static int
 memb_int5_c_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const Int5_t *st = (const Int5_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -3714,7 +3714,7 @@ memb_int5_c_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value == 5)) {
+	if((value == 5LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -4177,7 +4177,7 @@ xer_type_encoder_f Enum1_encode_xer;
 int
 Enum1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -4186,9 +4186,9 @@ Enum1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value == 0)) {
+	if((value == 0LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -4376,7 +4376,7 @@ Identifier_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	size = st->size;
 	
-	if((size >= 1 && size <= 32)
+	if((size >= 1LL && size <= 32LL)
 		 && !check_permitted_alphabet_1(st)) {
 		/* Constraint check succeeded */
 		return 0;

--- a/tests/50-constraint-OK.asn1.-Pgen-PER
+++ b/tests/50-constraint-OK.asn1.-Pgen-PER
@@ -168,7 +168,7 @@ per_type_encoder_f Int2_encode_uper;
 int
 Int2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -177,9 +177,9 @@ Int2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= 0)) {
+	if((value >= 0LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -336,7 +336,7 @@ per_type_encoder_f Int3_encode_uper;
 int
 Int3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -345,9 +345,9 @@ Int3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= 0 && value <= 10)) {
+	if((value >= 0LL && value <= 10LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -504,7 +504,7 @@ per_type_encoder_f Int4_encode_uper;
 int
 Int4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -513,9 +513,9 @@ Int4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= 1 && value <= 10)) {
+	if((value >= 1LL && value <= 10LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -672,7 +672,7 @@ per_type_encoder_f Int5_encode_uper;
 int
 Int5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -681,9 +681,9 @@ Int5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value == 5)) {
+	if((value == 5LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -840,7 +840,7 @@ per_type_encoder_f ExtensibleExtensions_encode_uper;
 int
 ExtensibleExtensions_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -849,9 +849,9 @@ ExtensibleExtensions_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= 1 && value <= 256)) {
+	if((value >= 1LL && value <= 256LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1156,7 +1156,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv <= 127)) return -1;
+		if(!(cv <= 127LL)) return -1;
 	}
 	return 0;
 }
@@ -1179,7 +1179,7 @@ Str2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	size = st->size;
 	
-	if(((size <= 20) || (size >= 25 && size <= 30))
+	if(((size <= 20LL) || (size >= 25LL && size <= 30LL))
 		 && !check_permitted_alphabet_1(st)) {
 		/* Constraint check succeeded */
 		return 0;
@@ -1379,7 +1379,7 @@ Str3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	size = st->size;
 	
-	if(((size >= 10 && size <= 20) || (size >= 25 && size <= 27))
+	if(((size >= 10LL && size <= 20LL) || (size >= 25LL && size <= 27LL))
 		 && !check_permitted_alphabet_1(st)) {
 		/* Constraint check succeeded */
 		return 0;
@@ -1553,7 +1553,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv <= 127)) return -1;
+		if(!(cv <= 127LL)) return -1;
 	}
 	return 0;
 }
@@ -1736,7 +1736,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 70)) return -1;
+		if(!(cv >= 65LL && cv <= 70LL)) return -1;
 	}
 	return 0;
 }
@@ -1919,7 +1919,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 69 && cv <= 70)) return -1;
+		if(!(cv >= 69LL && cv <= 70LL)) return -1;
 	}
 	return 0;
 }
@@ -2102,7 +2102,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 70)) return -1;
+		if(!(cv >= 65LL && cv <= 70LL)) return -1;
 	}
 	return 0;
 }
@@ -2285,7 +2285,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 66)) return -1;
+		if(!(cv >= 65LL && cv <= 66LL)) return -1;
 	}
 	return 0;
 }
@@ -2468,7 +2468,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 66)) return -1;
+		if(!(cv >= 65LL && cv <= 66LL)) return -1;
 	}
 	return 0;
 }
@@ -2651,7 +2651,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 68)) return -1;
+		if(!(cv >= 65LL && cv <= 68LL)) return -1;
 	}
 	return 0;
 }
@@ -2674,7 +2674,7 @@ SIZE_but_not_FROM_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	size = st->size;
 	
-	if((size >= 1 && size <= 4)
+	if((size >= 1LL && size <= 4LL)
 		 && !check_permitted_alphabet_1(st)) {
 		/* Constraint check succeeded */
 		return 0;
@@ -2837,7 +2837,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 68)) return -1;
+		if(!(cv >= 65LL && cv <= 68LL)) return -1;
 	}
 	return 0;
 }
@@ -2860,7 +2860,7 @@ SIZE_and_FROM_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	size = st->size;
 	
-	if((size >= 1 && size <= 4)
+	if((size >= 1LL && size <= 4LL)
 		 && !check_permitted_alphabet_1(st)) {
 		/* Constraint check succeeded */
 		return 0;
@@ -3023,7 +3023,7 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 70)) return -1;
+		if(!(cv >= 65LL && cv <= 70LL)) return -1;
 	}
 	return 0;
 }
@@ -3425,7 +3425,7 @@ Utf8_3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((size >= 1 && size <= 2)
+	if((size >= 1LL && size <= 2LL)
 		 && !check_permitted_alphabet_1(st)) {
 		/* Constraint check succeeded */
 		return 0;
@@ -3601,7 +3601,7 @@ Utf8_2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((size >= 1 && size <= 2)) {
+	if((size >= 1LL && size <= 2LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -3948,7 +3948,7 @@ VisibleIdentifier_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	size = st->size;
 	
-	if((size >= 1 && size <= 32)
+	if((size >= 1LL && size <= 32LL)
 		 && !check_permitted_alphabet_1(st)) {
 		/* Constraint check succeeded */
 		return 0;
@@ -4211,7 +4211,7 @@ enum_c_6_encode_uper(asn_TYPE_descriptor_t *td,
 static int
 memb_int1_c_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -4220,9 +4220,9 @@ memb_int1_c_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= -2)) {
+	if((value >= -2LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -4236,7 +4236,7 @@ memb_int1_c_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 static int
 memb_int4_c_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -4245,9 +4245,9 @@ memb_int4_c_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= 5 && value <= 7)) {
+	if((value >= 5LL && value <= 7LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -4261,7 +4261,7 @@ memb_int4_c_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 static int
 memb_int5_c_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -4270,9 +4270,9 @@ memb_int5_c_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value == 5)) {
+	if((value == 5LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -4797,7 +4797,7 @@ per_type_encoder_f Enum1_encode_uper;
 int
 Enum1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -4806,9 +4806,9 @@ Enum1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value == 0)) {
+	if((value == 0LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -5029,7 +5029,7 @@ Identifier_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	size = st->size;
 	
-	if((size >= 1 && size <= 32)
+	if((size >= 1LL && size <= 32LL)
 		 && !check_permitted_alphabet_1(st)) {
 		/* Constraint check succeeded */
 		return 0;

--- a/tests/69-reserved-words-OK.asn1.-Pfwide-types
+++ b/tests/69-reserved-words-OK.asn1.-Pfwide-types
@@ -61,7 +61,7 @@ memb_char_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	size = st->size;
 	
-	if((size == 1)) {
+	if((size == 1LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {

--- a/tests/72-same-names-OK.asn1.-Pfwide-types
+++ b/tests/72-same-names-OK.asn1.-Pfwide-types
@@ -429,7 +429,7 @@ memb_a_constraint_3(asn_TYPE_descriptor_t *td, const void *sptr,
 		size = 0;
 	}
 	
-	if((size == 2)) {
+	if((size == 2LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -460,7 +460,7 @@ memb_a_constraint_8(asn_TYPE_descriptor_t *td, const void *sptr,
 		size = 0;
 	}
 	
-	if((size == 2)) {
+	if((size == 2LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {

--- a/tests/73-circular-OK.asn1.-Pfwide-types
+++ b/tests/73-circular-OK.asn1.-Pfwide-types
@@ -473,7 +473,7 @@ static int check_permitted_alphabet_6(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 65 && cv <= 90)) return -1;
+		if(!(cv >= 65LL && cv <= 90LL)) return -1;
 	}
 	return 0;
 }
@@ -486,7 +486,7 @@ static int check_permitted_alphabet_7(const void *sptr) {
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
-		if(!(cv >= 97 && cv <= 122)) return -1;
+		if(!(cv >= 97LL && cv <= 122LL)) return -1;
 	}
 	return 0;
 }

--- a/tests/84-param-tags-OK.asn1.-Pfwide-types
+++ b/tests/84-param-tags-OK.asn1.-Pfwide-types
@@ -30,7 +30,7 @@ extern asn_TYPE_descriptor_t asn_DEF_TestType_16P1;
 static int
 memb_common_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -39,9 +39,9 @@ memb_common_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= 1 && value <= 10)) {
+	if((value >= 1LL && value <= 10LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -312,7 +312,7 @@ extern asn_TYPE_descriptor_t asn_DEF_AutoType_34P1;
 static int
 memb_common_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -321,9 +321,9 @@ memb_common_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value == 0)) {
+	if((value == 0LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -348,7 +348,7 @@ memb_common_constraint_3(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	value = (*(const long *)sptr) ? 1 : 0;
 	
-	if((value <= 0)) {
+	if((value <= 0LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {

--- a/tests/90-cond-int-type-OK.asn1.-P
+++ b/tests/90-cond-int-type-OK.asn1.-P
@@ -1750,7 +1750,7 @@ OK_IntegerInRange3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	value = *(const long long *)sptr;
 	
-	if((value >= (-2147483647L - 1)LL && value <= 2147483647LL)) {
+	if((value >= -2147483648LL && value <= 2147483647LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1892,7 +1892,7 @@ OK_IntegerInRange4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	value = *(const long long *)sptr;
 	
-	if(((value == (-2147483647L - 1)LL) || (value == 2147483647LL))) {
+	if(((value == -2147483648LL) || (value == 2147483647LL))) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -2034,7 +2034,7 @@ OK_IntegerInRange5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	value = *(const long long *)sptr;
 	
-	if(((value == (-2147483647L - 1)LL) || (value == 2147483647LL))) {
+	if(((value == -2147483648LL) || (value == 2147483647LL))) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {

--- a/tests/90-cond-int-type-OK.asn1.-P
+++ b/tests/90-cond-int-type-OK.asn1.-P
@@ -286,7 +286,7 @@ xer_type_encoder_f CN_IntegerMinLow_encode_xer;
 int
 CN_IntegerMinLow_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -295,9 +295,9 @@ CN_IntegerMinLow_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value <= 1)) {
+	if((value <= 1LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -429,7 +429,7 @@ int
 NO_IntegerMinHigh_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -445,7 +445,7 @@ NO_IntegerMinHigh_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value <= 3000000000)) {
+	if((value <= 3000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -576,7 +576,7 @@ xer_type_encoder_f NO_IntegerLowHigh_encode_xer;
 int
 NO_IntegerLowHigh_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	unsigned long value;
+	unsigned long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -585,9 +585,9 @@ NO_IntegerLowHigh_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const unsigned long *)sptr;
+	value = *(const unsigned long long *)sptr;
 	
-	if((value >= 1 && value <= 3000000000)) {
+	if((value >= 1LL && value <= 3000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -723,7 +723,7 @@ xer_type_encoder_f CN_IntegerLowMax_encode_xer;
 int
 CN_IntegerLowMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -732,9 +732,9 @@ CN_IntegerLowMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= 1)) {
+	if((value >= 1LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -866,7 +866,7 @@ int
 NO_IntegerHighMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -882,7 +882,7 @@ NO_IntegerHighMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value >= 3000000000)) {
+	if((value >= 3000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1014,7 +1014,7 @@ int
 NO_IntegerLowestMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1030,7 +1030,7 @@ NO_IntegerLowestMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value >= -3000000000)) {
+	if((value >= -3000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1161,7 +1161,7 @@ xer_type_encoder_f NO_IntegerOutRange_encode_xer;
 int
 NO_IntegerOutRange_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	unsigned long value;
+	unsigned long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1170,9 +1170,9 @@ NO_IntegerOutRange_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const unsigned long *)sptr;
+	value = *(const unsigned long long *)sptr;
 	
-	if((value >= 3000000000 && value <= 3000000001)) {
+	if((value >= 3000000000LL && value <= 3000000001LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1308,7 +1308,7 @@ xer_type_encoder_f NO_IntegerOutValue_encode_xer;
 int
 NO_IntegerOutValue_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	unsigned long value;
+	unsigned long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1317,9 +1317,9 @@ NO_IntegerOutValue_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const unsigned long *)sptr;
+	value = *(const unsigned long long *)sptr;
 	
-	if((value == 3000000000)) {
+	if((value == 3000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1455,7 +1455,7 @@ xer_type_encoder_f OK_IntegerInRange1_encode_xer;
 int
 OK_IntegerInRange1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1464,9 +1464,9 @@ OK_IntegerInRange1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= -100 && value <= 100)) {
+	if((value >= -100LL && value <= 100LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1597,7 +1597,7 @@ xer_type_encoder_f OK_IntegerInRange2_encode_xer;
 int
 OK_IntegerInRange2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1606,9 +1606,9 @@ OK_IntegerInRange2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if(((value == -100) || (value == 100))) {
+	if(((value == -100LL) || (value == 100LL))) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1739,7 +1739,7 @@ xer_type_encoder_f OK_IntegerInRange3_encode_xer;
 int
 OK_IntegerInRange3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1748,9 +1748,9 @@ OK_IntegerInRange3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= (-2147483647L - 1) && value <= 2147483647)) {
+	if((value >= (-2147483647L - 1)LL && value <= 2147483647LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1881,7 +1881,7 @@ xer_type_encoder_f OK_IntegerInRange4_encode_xer;
 int
 OK_IntegerInRange4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1890,9 +1890,9 @@ OK_IntegerInRange4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if(((value == (-2147483647L - 1)) || (value == 2147483647))) {
+	if(((value == (-2147483647L - 1)LL) || (value == 2147483647LL))) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -2023,7 +2023,7 @@ xer_type_encoder_f OK_IntegerInRange5_encode_xer;
 int
 OK_IntegerInRange5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -2032,9 +2032,9 @@ OK_IntegerInRange5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if(((value == (-2147483647L - 1)) || (value == 2147483647))) {
+	if(((value == (-2147483647L - 1)LL) || (value == 2147483647LL))) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {

--- a/tests/90-cond-int-type-OK.asn1.-Pfwide-types
+++ b/tests/90-cond-int-type-OK.asn1.-Pfwide-types
@@ -288,7 +288,7 @@ int
 CN_IntegerMinLow_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -304,7 +304,7 @@ CN_IntegerMinLow_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value <= 1)) {
+	if((value <= 1LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -436,7 +436,7 @@ int
 NO_IntegerMinHigh_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -452,7 +452,7 @@ NO_IntegerMinHigh_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value <= 3000000000)) {
+	if((value <= 3000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -583,7 +583,7 @@ xer_type_encoder_f NO_IntegerLowHigh_encode_xer;
 int
 NO_IntegerLowHigh_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	unsigned long value;
+	unsigned long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -592,9 +592,9 @@ NO_IntegerLowHigh_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const unsigned long *)sptr;
+	value = *(const unsigned long long *)sptr;
 	
-	if((value >= 1 && value <= 3000000000)) {
+	if((value >= 1LL && value <= 3000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -731,7 +731,7 @@ int
 CN_IntegerLowMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -747,7 +747,7 @@ CN_IntegerLowMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value >= 1)) {
+	if((value >= 1LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -879,7 +879,7 @@ int
 NO_IntegerHighMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -895,7 +895,7 @@ NO_IntegerHighMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value >= 3000000000)) {
+	if((value >= 3000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1027,7 +1027,7 @@ int
 NO_IntegerLowestMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1043,7 +1043,7 @@ NO_IntegerLowestMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value >= -3000000000)) {
+	if((value >= -3000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1174,7 +1174,7 @@ xer_type_encoder_f NO_IntegerOutRange_encode_xer;
 int
 NO_IntegerOutRange_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	unsigned long value;
+	unsigned long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1183,9 +1183,9 @@ NO_IntegerOutRange_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const unsigned long *)sptr;
+	value = *(const unsigned long long *)sptr;
 	
-	if((value >= 3000000000 && value <= 3000000001)) {
+	if((value >= 3000000000LL && value <= 3000000001LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1321,7 +1321,7 @@ xer_type_encoder_f NO_IntegerOutValue_encode_xer;
 int
 NO_IntegerOutValue_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	unsigned long value;
+	unsigned long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1330,9 +1330,9 @@ NO_IntegerOutValue_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const unsigned long *)sptr;
+	value = *(const unsigned long long *)sptr;
 	
-	if((value == 3000000000)) {
+	if((value == 3000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1468,7 +1468,7 @@ xer_type_encoder_f OK_IntegerInRange1_encode_xer;
 int
 OK_IntegerInRange1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1477,9 +1477,9 @@ OK_IntegerInRange1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= -100 && value <= 100)) {
+	if((value >= -100LL && value <= 100LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1610,7 +1610,7 @@ xer_type_encoder_f OK_IntegerInRange2_encode_xer;
 int
 OK_IntegerInRange2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1619,9 +1619,9 @@ OK_IntegerInRange2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if(((value == -100) || (value == 100))) {
+	if(((value == -100LL) || (value == 100LL))) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1752,7 +1752,7 @@ xer_type_encoder_f OK_IntegerInRange3_encode_xer;
 int
 OK_IntegerInRange3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1761,9 +1761,9 @@ OK_IntegerInRange3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= (-2147483647L - 1) && value <= 2147483647)) {
+	if((value >= (-2147483647L - 1)LL && value <= 2147483647LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1894,7 +1894,7 @@ xer_type_encoder_f OK_IntegerInRange4_encode_xer;
 int
 OK_IntegerInRange4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1903,9 +1903,9 @@ OK_IntegerInRange4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if(((value == (-2147483647L - 1)) || (value == 2147483647))) {
+	if(((value == (-2147483647L - 1)LL) || (value == 2147483647LL))) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -2037,7 +2037,7 @@ int
 OK_IntegerInRange5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -2053,7 +2053,7 @@ OK_IntegerInRange5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if(((value == (-2147483647L - 1)) || (value == 2147483647))) {
+	if(((value == (-2147483647L - 1)LL) || (value == 2147483647LL))) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {

--- a/tests/90-cond-int-type-OK.asn1.-Pfwide-types
+++ b/tests/90-cond-int-type-OK.asn1.-Pfwide-types
@@ -1763,7 +1763,7 @@ OK_IntegerInRange3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	value = *(const long long *)sptr;
 	
-	if((value >= (-2147483647L - 1)LL && value <= 2147483647LL)) {
+	if((value >= -2147483648LL && value <= 2147483647LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1905,7 +1905,7 @@ OK_IntegerInRange4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	value = *(const long long *)sptr;
 	
-	if(((value == (-2147483647L - 1)LL) || (value == 2147483647LL))) {
+	if(((value == -2147483648LL) || (value == 2147483647LL))) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -2053,7 +2053,7 @@ OK_IntegerInRange5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if(((value == (-2147483647L - 1)LL) || (value == 2147483647LL))) {
+	if(((value == -2147483648LL) || (value == 2147483647LL))) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {

--- a/tests/90-cond-int-type-OK.asn1.-Pgen-PER
+++ b/tests/90-cond-int-type-OK.asn1.-Pgen-PER
@@ -332,7 +332,7 @@ per_type_encoder_f CN_IntegerMinLow_encode_uper;
 int
 CN_IntegerMinLow_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -341,9 +341,9 @@ CN_IntegerMinLow_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value <= 1)) {
+	if((value <= 1LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -501,7 +501,7 @@ int
 NO_IntegerMinHigh_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -517,7 +517,7 @@ NO_IntegerMinHigh_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value <= 3000000000)) {
+	if((value <= 3000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -674,7 +674,7 @@ per_type_encoder_f NO_IntegerLowHigh_encode_uper;
 int
 NO_IntegerLowHigh_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	unsigned long value;
+	unsigned long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -683,9 +683,9 @@ NO_IntegerLowHigh_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const unsigned long *)sptr;
+	value = *(const unsigned long long *)sptr;
 	
-	if((value >= 1 && value <= 3000000000)) {
+	if((value >= 1LL && value <= 3000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -847,7 +847,7 @@ per_type_encoder_f CN_IntegerLowMax_encode_uper;
 int
 CN_IntegerLowMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -856,9 +856,9 @@ CN_IntegerLowMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= 1)) {
+	if((value >= 1LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1016,7 +1016,7 @@ int
 NO_IntegerHighMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1032,7 +1032,7 @@ NO_IntegerHighMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value >= 3000000000)) {
+	if((value >= 3000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1190,7 +1190,7 @@ int
 NO_IntegerLowestMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1206,7 +1206,7 @@ NO_IntegerLowestMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	if((value >= -3000000000)) {
+	if((value >= -3000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1363,7 +1363,7 @@ per_type_encoder_f NO_IntegerOutRange_encode_uper;
 int
 NO_IntegerOutRange_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	unsigned long value;
+	unsigned long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1372,9 +1372,9 @@ NO_IntegerOutRange_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const unsigned long *)sptr;
+	value = *(const unsigned long long *)sptr;
 	
-	if((value >= 3000000000 && value <= 3000000001)) {
+	if((value >= 3000000000LL && value <= 3000000001LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1536,7 +1536,7 @@ per_type_encoder_f NO_IntegerOutValue_encode_uper;
 int
 NO_IntegerOutValue_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	unsigned long value;
+	unsigned long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1545,9 +1545,9 @@ NO_IntegerOutValue_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const unsigned long *)sptr;
+	value = *(const unsigned long long *)sptr;
 	
-	if((value == 3000000000)) {
+	if((value == 3000000000LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1709,7 +1709,7 @@ per_type_encoder_f OK_IntegerInRange1_encode_uper;
 int
 OK_IntegerInRange1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1718,9 +1718,9 @@ OK_IntegerInRange1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= -100 && value <= 100)) {
+	if((value >= -100LL && value <= 100LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -1877,7 +1877,7 @@ per_type_encoder_f OK_IntegerInRange2_encode_uper;
 int
 OK_IntegerInRange2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -1886,9 +1886,9 @@ OK_IntegerInRange2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if(((value == -100) || (value == 100))) {
+	if(((value == -100LL) || (value == 100LL))) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -2045,7 +2045,7 @@ per_type_encoder_f OK_IntegerInRange3_encode_uper;
 int
 OK_IntegerInRange3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -2054,9 +2054,9 @@ OK_IntegerInRange3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if((value >= (-2147483647L - 1) && value <= 2147483647)) {
+	if((value >= (-2147483647L - 1)LL && value <= 2147483647LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -2213,7 +2213,7 @@ per_type_encoder_f OK_IntegerInRange4_encode_uper;
 int
 OK_IntegerInRange4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -2222,9 +2222,9 @@ OK_IntegerInRange4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if(((value == (-2147483647L - 1)) || (value == 2147483647))) {
+	if(((value == (-2147483647L - 1)LL) || (value == 2147483647LL))) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -2381,7 +2381,7 @@ per_type_encoder_f OK_IntegerInRange5_encode_uper;
 int
 OK_IntegerInRange5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
-	long value;
+	long long value;
 	
 	if(!sptr) {
 		ASN__CTFAIL(app_key, td, sptr,
@@ -2390,9 +2390,9 @@ OK_IntegerInRange5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 		return -1;
 	}
 	
-	value = *(const long *)sptr;
+	value = *(const long long *)sptr;
 	
-	if(((value == (-2147483647L - 1)) || (value == 2147483647))) {
+	if(((value == (-2147483647L - 1)LL) || (value == 2147483647LL))) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {

--- a/tests/90-cond-int-type-OK.asn1.-Pgen-PER
+++ b/tests/90-cond-int-type-OK.asn1.-Pgen-PER
@@ -2056,7 +2056,7 @@ OK_IntegerInRange3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	value = *(const long long *)sptr;
 	
-	if((value >= (-2147483647L - 1)LL && value <= 2147483647LL)) {
+	if((value >= -2147483648LL && value <= 2147483647LL)) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -2224,7 +2224,7 @@ OK_IntegerInRange4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	value = *(const long long *)sptr;
 	
-	if(((value == (-2147483647L - 1)LL) || (value == 2147483647LL))) {
+	if(((value == -2147483648LL) || (value == 2147483647LL))) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {
@@ -2392,7 +2392,7 @@ OK_IntegerInRange5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	value = *(const long long *)sptr;
 	
-	if(((value == (-2147483647L - 1)LL) || (value == 2147483647LL))) {
+	if(((value == -2147483648LL) || (value == 2147483647LL))) {
 		/* Constraint check succeeded */
 		return 0;
 	} else {


### PR DESCRIPTION
Constraint values might be larger than what can be held in a 32bit integer.
One example is TimestampIts defined by ETSI in http://forge.etsi.org/websvn/filedetails.php?repname=LIBS.LibIts&path=%2Ftrunk%2Fasn1%2FITS-Container%2FITS-Container.asn