### PR TITLE
Skip last comma when there are no extensions

### DIFF
--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -938,6 +938,7 @@ asn1c_lang_C_type_CHOICE(arg_t *arg) {
 		OUT("_PR_NOTHING,\t/* No components present */\n");
 		TQ_FOR(v, &(expr->members), next) {
 			if(skipComma) skipComma = 0;
+			else if (v->expr_type == A1TC_EXTENSIBLE && !TQ_NEXT(v, next)) OUT("\n");
 			else OUT(",\n");
 			if(v->expr_type == A1TC_EXTENSIBLE) {
 				OUT("/* Extensions may appear below */\n");

--- a/tests/42-real-life-OK.asn1.-PR
+++ b/tests/42-real-life-OK.asn1.-PR
@@ -353,7 +353,7 @@ asn_TYPE_descriptor_t asn_DEF_VariablePartSet = {
 typedef enum VariablePart_PR {
 	VariablePart_PR_NOTHING,	/* No components present */
 	VariablePart_PR_vset,
-	VariablePart_PR_vrange,
+	VariablePart_PR_vrange
 	/* Extensions may appear below */
 	
 } VariablePart_PR;

--- a/tests/47-set-ext-OK.asn1.-Pfwide-types
+++ b/tests/47-set-ext-OK.asn1.-Pfwide-types
@@ -196,7 +196,7 @@ asn_TYPE_descriptor_t asn_DEF_T2 = {
 
 typedef enum T3_PR {
 	T3_PR_NOTHING,	/* No components present */
-	T3_PR_i,
+	T3_PR_i
 	/* Extensions may appear below */
 	
 } T3_PR;
@@ -279,7 +279,7 @@ asn_TYPE_descriptor_t asn_DEF_T3 = {
 
 typedef enum T4_PR {
 	T4_PR_NOTHING,	/* No components present */
-	T4_PR_i,
+	T4_PR_i
 	/* Extensions may appear below */
 	
 } T4_PR;

--- a/tests/70-xer-test-OK.asn1.-Pfwide-types
+++ b/tests/70-xer-test-OK.asn1.-Pfwide-types
@@ -36,7 +36,7 @@ typedef enum PDU_PR {
 	PDU_PR_namedSetOfEnums,
 	PDU_PR_seqOfZuka,
 	PDU_PR_setOfChoice,
-	PDU_PR_namedSetOfChoice,
+	PDU_PR_namedSetOfChoice
 	/* Extensions may appear below */
 	
 } PDU_PR;


### PR DESCRIPTION
This is to get rid of the GCC warning:
"warning: comma at end of enumerator list [-Wpedantic]"