### PR TITLE
Fix some memory leakage found till now

### DIFF
--- a/libasn1compiler/asn1c_constraint.c
+++ b/libasn1compiler/asn1c_constraint.c
@@ -267,6 +267,7 @@ asn1c_emit_constraint_tables(arg_t *arg, int got_size) {
 		 */
 		assert(range->el_count == 0);
 		/* The full range is specified. Ignore it. */
+		asn1constraint_range_free(range);
 		return 0;
 	}
 

--- a/libasn1fix/asn1fix_constr.c
+++ b/libasn1fix/asn1fix_constr.c
@@ -60,7 +60,7 @@ asn1f_pull_components_of(arg_t *arg) {
 		coft = asn1p_expr_clone(terminal, 1 /* Skip extensions */);
 		if(!coft) return -1;	/* ENOMEM */
 
-		if(0) {
+		if(1) {
 			asn1p_expr_free(memb);	/* Don't need it anymore*/
 		} else {
 			/* Actual removal clashes with constraints... skip. */

--- a/libasn1fix/asn1fix_cws.c
+++ b/libasn1fix/asn1fix_cws.c
@@ -206,12 +206,14 @@ _asn1f_assign_cell_value(arg_t *arg, struct asn1p_ioc_row_s *row, struct asn1p_i
 		ref = asn1p_ref_new(arg->expr->_lineno);
 		asn1p_ref_add_component(ref, p, RLT_UNKNOWN);
 		assert(ref);
-	
+
 		expr = asn1f_lookup_symbol(arg, arg->mod, arg->expr->rhs_pspecs, ref);
 		if(!expr) {
 			FATAL("Cannot find %s referenced by %s at line %d",
 				p, arg->expr->Identifier,
 				arg->expr->_lineno);
+			asn1p_ref_free(ref);
+			free(p);
 			return -1;
 		}
 	}

--- a/libasn1fix/asn1fix_misc.c
+++ b/libasn1fix/asn1fix_misc.c
@@ -26,7 +26,7 @@ asn1f_printable_value(asn1p_value_t *v) {
         size_t tmp_len = (len);                     \
         if(tmp_len >= managedptr_len) {             \
             free(managedptr);                       \
-            managedptr = malloc(tmp_len + 1);       \
+            managedptr = calloc(1, tmp_len + 1);    \
             if(managedptr) {                        \
                 managedptr_len = tmp_len;           \
             } else {                                \

--- a/libasn1parser/asn1p_expr.c
+++ b/libasn1parser/asn1p_expr.c
@@ -222,8 +222,8 @@ void
 asn1p_expr_add_many(asn1p_expr_t *to, asn1p_expr_t *from_what) {
 	asn1p_expr_t *expr;
 	TQ_FOR(expr, &(from_what->members), next) {
-        expr->parent_expr = to;
-    }
+		expr->parent_expr = to;
+	}
 	TQ_CONCAT(&(to->members), &(from_what->members), next);
 }
 
@@ -257,9 +257,25 @@ asn1p_expr_free(asn1p_expr_t *expr) {
 		asn1p_constraint_free(expr->constraints);
 		asn1p_constraint_free(expr->combined_constraints);
 		asn1p_paramlist_free(expr->lhs_params);
+		asn1p_expr_free(expr->rhs_pspecs);
 		asn1p_value_free(expr->value);
 		asn1p_value_free(expr->marker.default_value);
 		asn1p_wsyntx_free(expr->with_syntax);
+		if(expr->specializations.pspec) {
+			int pspec;
+			for(pspec = 0; pspec < expr->specializations.pspecs_count; pspec++) {
+				asn1p_expr_free(expr->specializations.pspec[pspec].rhs_pspecs);
+				asn1p_expr_free(expr->specializations.pspec[pspec].my_clone);
+			}
+			free(expr->specializations.pspec);
+		}
+		if(expr->object_class_matrix.row) {
+			int row;
+			for(row = 0; row < expr->object_class_matrix.rows; row++) {
+				asn1p_ioc_row_delete(expr->object_class_matrix.row[row]);
+			}
+			free(expr->object_class_matrix.row);
+		}
 
 		if(expr->data && expr->data_free)
 			expr->data_free(expr->data);

--- a/libasn1parser/asn1p_l.l
+++ b/libasn1parser/asn1p_l.l
@@ -209,7 +209,7 @@ WSP	[\t\r\v\f\n ]
 
 '[0-9A-F \t\r\v\f\n]+'H {
 		/* " \t\r\n" weren't allowed in ASN.1:1990. */
-		asn1p_lval.tv_str = yytext;
+		asn1p_lval.tv_str = strdup(yytext);
 		return TOK_hstring;
 	}
 

--- a/libasn1parser/asn1p_module.c
+++ b/libasn1parser/asn1p_module.c
@@ -26,11 +26,18 @@ void
 asn1p_module_free(asn1p_module_t *mod) {
 	if(mod) {
 		asn1p_expr_t *expr;
+		asn1p_xports_t *xports;
 
 		free(mod->ModuleName);
 		free(mod->source_file_name);
 
 		asn1p_oid_free(mod->module_oid);
+
+		while((xports = TQ_REMOVE(&(mod->exports), xp_next)))
+			asn1p_xports_free(xports);
+
+		while((xports = TQ_REMOVE(&(mod->imports), xp_next)))
+			asn1p_xports_free(xports);
 
 		while((expr = TQ_REMOVE(&(mod->members), next)))
 			asn1p_expr_free(expr);

--- a/libasn1parser/asn1p_xports.c
+++ b/libasn1parser/asn1p_xports.c
@@ -25,8 +25,14 @@ asn1p_xports_new() {
 void
 asn1p_xports_free(asn1p_xports_t *xp) {
 	if(xp) {
+		asn1p_expr_t *expr;
+
 		free(xp->fromModuleName);
 		asn1p_oid_free(xp->identifier.oid);
+
+		while((expr = TQ_REMOVE(&(xp->members), next)))
+			asn1p_expr_free(expr);
+
 		free(xp);
 	}
 }

--- a/libasn1parser/asn1p_y.c
+++ b/libasn1parser/asn1p_y.c
@@ -2449,6 +2449,10 @@ yyreduce:
 		AL_IMPORT((yyval.a_module), exports, (yyvsp[(1) - (3)].a_module), xp_next);
 		AL_IMPORT((yyval.a_module), imports, (yyvsp[(2) - (3)].a_module), xp_next);
 		AL_IMPORT((yyval.a_module), members, (yyvsp[(3) - (3)].a_module), next);
+
+		asn1p_module_free((yyvsp[(1) - (3)].a_module));
+		asn1p_module_free((yyvsp[(2) - (3)].a_module));
+		asn1p_module_free((yyvsp[(3) - (3)].a_module));
 	}
     break;
 
@@ -2469,6 +2473,8 @@ yyreduce:
 			break;
 		}
 		AL_IMPORT((yyval.a_module), members, (yyvsp[(2) - (2)].a_module), next);
+
+		asn1p_module_free((yyvsp[(2) - (2)].a_module));
 	}
     break;
 
@@ -2925,7 +2931,7 @@ yyreduce:
     {
 		(yyval.a_expr) = NEW_EXPR();
 		checkmem((yyval.a_expr));
-		(yyval.a_expr)->Identifier = "?";
+		(yyval.a_expr)->Identifier = strdup("?");
 		(yyval.a_expr)->expr_type = A1TC_REFERENCE;
 		(yyval.a_expr)->meta_type = AMT_VALUE;
 		(yyval.a_expr)->value = (yyvsp[(1) - (1)].a_value);
@@ -2989,6 +2995,7 @@ yyreduce:
     {
         (yyval.a_expr) = (yyvsp[(1) - (5)].a_expr);
 		asn1p_expr_add_many((yyval.a_expr), (yyvsp[(4) - (5)].a_expr));
+		asn1p_expr_free((yyvsp[(4) - (5)].a_expr));
 	}
     break;
 
@@ -3324,6 +3331,8 @@ yyreduce:
 		} else {
 			if((yyval.a_expr)->constraints) {
 				assert(!(yyvsp[(2) - (3)].a_expr));
+				/* Check this : optConstraints is not used ?! */
+				asn1p_constraint_free((yyvsp[(3) - (3)].a_constr));
 			} else {
 				(yyval.a_expr)->constraints = (yyvsp[(3) - (3)].a_constr);
 			}
@@ -4412,6 +4421,7 @@ yyreduce:
 		(yyval.a_constr) = asn1p_constraint_new(yylineno);
 		(yyval.a_constr)->type = ACT_CT_CTNG;
 		(yyval.a_constr)->value = asn1p_value_fromtype((yyvsp[(2) - (2)].a_expr));
+		asn1p_expr_free((yyvsp[(2) - (2)].a_expr));
 	}
     break;
 

--- a/libasn1parser/asn1parser.c
+++ b/libasn1parser/asn1parser.c
@@ -53,8 +53,10 @@ asn1p_parse_buffer(const char *buffer, int size /* = -1 */, enum asn1p_flags fla
 
 	if(ret == 0) {
 		assert(a);
-		if(_asn1p_fix_modules(a, "-"))
+		if(_asn1p_fix_modules(a, "-")) {
+			asn1p_delete(a);
 			return NULL;	/* FIXME: destroy (a) */
+		}
 	} else if(a) {
 		asn1p_delete(a);
 		a = NULL;
@@ -110,8 +112,10 @@ asn1p_parse_file(const char *filename, enum asn1p_flags flags) {
 
 	if(ret == 0) {
 		assert(a);
-		if(_asn1p_fix_modules(a, filename))
+		if(_asn1p_fix_modules(a, filename)) {
+			asn1p_delete(a);
 			return NULL;	/* FIXME: destroy (a) */
+		}
 	} else if(a) {
 		asn1p_delete(a);
 		a = NULL;

--- a/libasn1parser/asn1parser.h
+++ b/libasn1parser/asn1parser.h
@@ -70,5 +70,6 @@ asn1p_t	*asn1p_parse_buffer(const char *buffer, int size /* = -1 */,
 	enum asn1p_flags);
 
 int asn1p_atoi(const char *ptr, asn1c_integer_t *r_value);
+int asn1p_lex_destroy();
 
 #endif	/* ASN1PARSER_H */


### PR DESCRIPTION
Memory allocated in asn1p_l.c and asn1p_y.c are freed.

Remaining two leaked memory blocks are allocated inside function asn1f_printable_value() and asn1c_make_identifier() hold by static variables. Please refer to [Valgrind log.](https://gist.github.com/brchiu/d0ef9f32e373095a9703712aa2b4e9c9)

asn.1 modules under `examples` directories and some more asn.1, ex. LTE-RRC, S1AP, RANAP, DSRC, NBAP are used for verification.

When the parser ends with unexpected token or grammar error, memory allocated by `asn1_module_new()`.... etc are not able freed because `asn1p_parse()` does not return a valid `asn1p_t *` pointer to caller. Perhaps adding a suitable hook to call `asn1p_free()` inside parser is needed.

Of course, there might still be un-found leakages exist in other asn,1 syntax cases.