### PR TITLE
Add const to strings in skeletons/

### DIFF
--- a/skeletons/BIT_STRING.c
+++ b/skeletons/BIT_STRING.c
@@ -67,7 +67,7 @@ BIT_STRING_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	return 0;
 }
 
-static char *_bit_pattern[16] = {
+static const char *_bit_pattern[16] = {
 	"0000", "0001", "0010", "0011", "0100", "0101", "0110", "0111",
 	"1000", "1001", "1010", "1011", "1100", "1101", "1110", "1111"
 };

--- a/skeletons/ber_tlv_tag.c
+++ b/skeletons/ber_tlv_tag.c
@@ -74,7 +74,7 @@ ber_tlv_tag_fwrite(ber_tlv_tag_t tag, FILE *f) {
 
 ssize_t
 ber_tlv_tag_snprint(ber_tlv_tag_t tag, char *buf, size_t size) {
-	char *type = 0;
+	const char *type = 0;
 	int ret;
 
 	switch(tag & 0x3) {


### PR DESCRIPTION
This removes the GCC warning:
"warning: initialization discards ‘const’ qualifier from pointer
target type [-Wdiscarded-qualifiers]"
from BIT_STRING.c and ber_tlv_tag.c.