### PR TITLE
Add (void) when st is unused

### DIFF
--- a/libasn1compiler/asn1c_constraint.c
+++ b/libasn1compiler/asn1c_constraint.c
@@ -195,6 +195,9 @@ asn1c_emit_constraint_checking_code(arg_t *arg) {
 			OUT("1 /* No applicable constraints whatsoever */");
 			OUT(") {\n");
 			INDENT(-1);
+			if(produce_st) {
+				INDENTED(OUT("(void)st; /* Unused variable */\n"));
+			}
 			INDENTED(OUT("/* Nothing is here. See below */\n"));
 			OUT("}\n");
 			OUT("\n");

--- a/tests/125-bitstring-constraint-OK.asn1.-P
+++ b/tests/125-bitstring-constraint-OK.asn1.-P
@@ -42,6 +42,7 @@ T_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	
 	if(1 /* No applicable constraints whatsoever */) {
+		(void)st; /* Unused variable */
 		/* Nothing is here. See below */
 	}
 	

--- a/tests/90-cond-int-type-OK.asn1.-Pfwide-types
+++ b/tests/90-cond-int-type-OK.asn1.-Pfwide-types
@@ -159,6 +159,7 @@ CN_IntegerMinMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	
 	
 	if(1 /* No applicable constraints whatsoever */) {
+		(void)st; /* Unused variable */
 		/* Nothing is here. See below */
 	}
 	


### PR DESCRIPTION
This is to get rid of the GCC warning:
"warning: unused variable ‘st’ [-Wunused-variable]"