### PR TITLE
Fix duplicate 'const' warnings

### DIFF
--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -203,7 +203,7 @@ asn1c_lang_C_type_common_INTEGER(arg_t *arg) {
 			OUT("\t/* This list is extensible */\n");
 		OUT("};\n");
 
-		OUT("static const asn_INTEGER_specifics_t asn_SPC_%s_specs_%d = {\n",
+		OUT("static asn_INTEGER_specifics_t asn_SPC_%s_specs_%d = {\n",
 			MKID(expr), expr->_type_unique_index);
 		INDENT(+1);
 		OUT("asn_MAP_%s_value2enum_%d,\t"
@@ -235,7 +235,7 @@ asn1c_lang_C_type_common_INTEGER(arg_t *arg) {
 	if(expr->expr_type == ASN_BASIC_INTEGER
 	&& asn1c_type_fits_long(arg, expr) == FL_FITS_UNSIGN) {
 		REDIR(OT_STAT_DEFS);
-		OUT("static const asn_INTEGER_specifics_t asn_SPC_%s_specs_%d = {\n",
+		OUT("static asn_INTEGER_specifics_t asn_SPC_%s_specs_%d = {\n",
 			MKID(expr), expr->_type_unique_index);
 		INDENT(+1);
 		OUT("0,\t");

--- a/tests/03-enum-OK.asn1.-Pfwide-types
+++ b/tests/03-enum-OK.asn1.-Pfwide-types
@@ -123,7 +123,7 @@ static const unsigned int asn_MAP_Enum1_enum2value_1[] = {
 	0	/* red(0) */
 	/* This list is extensible */
 };
-static const asn_INTEGER_specifics_t asn_SPC_Enum1_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_Enum1_specs_1 = {
 	asn_MAP_Enum1_value2enum_1,	/* "tag" => N; sorted by tag */
 	asn_MAP_Enum1_enum2value_1,	/* N => "tag"; sorted by N */
 	4,	/* Number of elements in the maps */
@@ -292,7 +292,7 @@ static const unsigned int asn_MAP_Enum2_enum2value_1[] = {
 	0	/* red(0) */
 	/* This list is extensible */
 };
-static const asn_INTEGER_specifics_t asn_SPC_Enum2_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_Enum2_specs_1 = {
 	asn_MAP_Enum2_value2enum_1,	/* "tag" => N; sorted by tag */
 	asn_MAP_Enum2_enum2value_1,	/* N => "tag"; sorted by N */
 	7,	/* Number of elements in the maps */
@@ -449,7 +449,7 @@ static const unsigned int asn_MAP_Enum3_enum2value_1[] = {
 	1	/* c(1) */
 	/* This list is extensible */
 };
-static const asn_INTEGER_specifics_t asn_SPC_Enum3_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_Enum3_specs_1 = {
 	asn_MAP_Enum3_value2enum_1,	/* "tag" => N; sorted by tag */
 	asn_MAP_Enum3_enum2value_1,	/* N => "tag"; sorted by N */
 	3,	/* Number of elements in the maps */
@@ -609,7 +609,7 @@ static const unsigned int asn_MAP_Enum4_enum2value_1[] = {
 	3	/* d(4) */
 	/* This list is extensible */
 };
-static const asn_INTEGER_specifics_t asn_SPC_Enum4_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_Enum4_specs_1 = {
 	asn_MAP_Enum4_value2enum_1,	/* "tag" => N; sorted by tag */
 	asn_MAP_Enum4_enum2value_1,	/* N => "tag"; sorted by N */
 	4,	/* Number of elements in the maps */
@@ -766,7 +766,7 @@ static const unsigned int asn_MAP_Enum5_enum2value_1[] = {
 	1	/* z(25) */
 	/* This list is extensible */
 };
-static const asn_INTEGER_specifics_t asn_SPC_Enum5_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_Enum5_specs_1 = {
 	asn_MAP_Enum5_value2enum_1,	/* "tag" => N; sorted by tag */
 	asn_MAP_Enum5_enum2value_1,	/* N => "tag"; sorted by N */
 	3,	/* Number of elements in the maps */

--- a/tests/110-param-3-OK.asn1.-Pfwide-types
+++ b/tests/110-param-3-OK.asn1.-Pfwide-types
@@ -218,7 +218,7 @@ static const unsigned int asn_MAP_field_enum2value_7[] = {
 	1,	/* green(4) */
 	0	/* red(3) */
 };
-static const asn_INTEGER_specifics_t asn_SPC_field_specs_7 = {
+static asn_INTEGER_specifics_t asn_SPC_field_specs_7 = {
 	asn_MAP_field_value2enum_7,	/* "tag" => N; sorted by tag */
 	asn_MAP_field_enum2value_7,	/* N => "tag"; sorted by N */
 	3,	/* Number of elements in the maps */

--- a/tests/127-per-long-OK.asn1.-Pgen-PER
+++ b/tests/127-per-long-OK.asn1.-Pgen-PER
@@ -354,7 +354,7 @@ static asn_per_constraints_t asn_PER_memb_unsplit32_constr_5 GCC_NOTUSED = {
 
 /*** <<< STAT-DEFS [T] >>> ***/
 
-static const asn_INTEGER_specifics_t asn_SPC_unsigned32_specs_4 = {
+static asn_INTEGER_specifics_t asn_SPC_unsigned32_specs_4 = {
 	0,	0,	0,	0,	0,
 	0,	/* Native long size */
 	1	/* Unsigned representation */
@@ -388,7 +388,7 @@ asn_TYPE_descriptor_t asn_DEF_unsigned32_4 = {
 	&asn_SPC_unsigned32_specs_4	/* Additional specs */
 };
 
-static const asn_INTEGER_specifics_t asn_SPC_unsplit32_specs_5 = {
+static asn_INTEGER_specifics_t asn_SPC_unsplit32_specs_5 = {
 	0,	0,	0,	0,	0,
 	0,	/* Native long size */
 	1	/* Unsigned representation */

--- a/tests/42-real-life-OK.asn1.-PR
+++ b/tests/42-real-life-OK.asn1.-PR
@@ -732,7 +732,7 @@ static const unsigned int asn_MAP_accept_as_enum2value_2[] = {
 	2	/* unsafe(2) */
 	/* This list is extensible */
 };
-static const asn_INTEGER_specifics_t asn_SPC_accept_as_specs_2 = {
+static asn_INTEGER_specifics_t asn_SPC_accept_as_specs_2 = {
 	asn_MAP_accept_as_value2enum_2,	/* "tag" => N; sorted by tag */
 	asn_MAP_accept_as_enum2value_2,	/* N => "tag"; sorted by N */
 	3,	/* Number of elements in the maps */

--- a/tests/50-constraint-OK.asn1.-Pfwide-types
+++ b/tests/50-constraint-OK.asn1.-Pfwide-types
@@ -3778,7 +3778,7 @@ static const unsigned int asn_MAP_enum_c_enum2value_6[] = {
 	1	/* two(2) */
 	/* This list is extensible */
 };
-static const asn_INTEGER_specifics_t asn_SPC_enum_c_specs_6 = {
+static asn_INTEGER_specifics_t asn_SPC_enum_c_specs_6 = {
 	asn_MAP_enum_c_value2enum_6,	/* "tag" => N; sorted by tag */
 	asn_MAP_enum_c_enum2value_6,	/* N => "tag"; sorted by N */
 	3,	/* Number of elements in the maps */
@@ -4110,7 +4110,7 @@ static const unsigned int asn_MAP_Enum0_enum2value_1[] = {
 	0,	/* one(0) */
 	1	/* two(1) */
 };
-static const asn_INTEGER_specifics_t asn_SPC_Enum0_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_Enum0_specs_1 = {
 	asn_MAP_Enum0_value2enum_1,	/* "tag" => N; sorted by tag */
 	asn_MAP_Enum0_enum2value_1,	/* N => "tag"; sorted by N */
 	2,	/* Number of elements in the maps */
@@ -4276,7 +4276,7 @@ static const unsigned int asn_MAP_Enum1_enum2value_1[] = {
 	0,	/* one(0) */
 	1	/* two(1) */
 };
-static const asn_INTEGER_specifics_t asn_SPC_Enum1_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_Enum1_specs_1 = {
 	asn_MAP_Enum1_value2enum_1,	/* "tag" => N; sorted by tag */
 	asn_MAP_Enum1_enum2value_1,	/* N => "tag"; sorted by N */
 	2,	/* Number of elements in the maps */

--- a/tests/50-constraint-OK.asn1.-Pgen-PER
+++ b/tests/50-constraint-OK.asn1.-Pgen-PER
@@ -4357,7 +4357,7 @@ static const unsigned int asn_MAP_enum_c_enum2value_6[] = {
 	1	/* two(2) */
 	/* This list is extensible */
 };
-static const asn_INTEGER_specifics_t asn_SPC_enum_c_specs_6 = {
+static asn_INTEGER_specifics_t asn_SPC_enum_c_specs_6 = {
 	asn_MAP_enum_c_value2enum_6,	/* "tag" => N; sorted by tag */
 	asn_MAP_enum_c_enum2value_6,	/* N => "tag"; sorted by N */
 	3,	/* Number of elements in the maps */
@@ -4727,7 +4727,7 @@ static const unsigned int asn_MAP_Enum0_enum2value_1[] = {
 	0,	/* one(0) */
 	1	/* two(1) */
 };
-static const asn_INTEGER_specifics_t asn_SPC_Enum0_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_Enum0_specs_1 = {
 	asn_MAP_Enum0_value2enum_1,	/* "tag" => N; sorted by tag */
 	asn_MAP_Enum0_enum2value_1,	/* N => "tag"; sorted by N */
 	2,	/* Number of elements in the maps */
@@ -4919,7 +4919,7 @@ static const unsigned int asn_MAP_Enum1_enum2value_1[] = {
 	0,	/* one(0) */
 	1	/* two(1) */
 };
-static const asn_INTEGER_specifics_t asn_SPC_Enum1_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_Enum1_specs_1 = {
 	asn_MAP_Enum1_value2enum_1,	/* "tag" => N; sorted by tag */
 	asn_MAP_Enum1_enum2value_1,	/* N => "tag"; sorted by N */
 	2,	/* Number of elements in the maps */

--- a/tests/66-ref-simple-OK.asn1.-Pfwide-types
+++ b/tests/66-ref-simple-OK.asn1.-Pfwide-types
@@ -180,7 +180,7 @@ static const unsigned int asn_MAP_SimpleType_enum2value_1[] = {
 	2,	/* three(2) */
 	1	/* two(1) */
 };
-static const asn_INTEGER_specifics_t asn_SPC_SimpleType_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_SimpleType_specs_1 = {
 	asn_MAP_SimpleType_value2enum_1,	/* "tag" => N; sorted by tag */
 	asn_MAP_SimpleType_enum2value_1,	/* N => "tag"; sorted by N */
 	3,	/* Number of elements in the maps */

--- a/tests/70-xer-test-OK.asn1.-Pfwide-types
+++ b/tests/70-xer-test-OK.asn1.-Pfwide-types
@@ -612,7 +612,7 @@ static const unsigned int asn_MAP_enum_enum2value_4[] = {
 	1,	/* a(1) */
 	0	/* b(0) */
 };
-static const asn_INTEGER_specifics_t asn_SPC_enum_specs_4 = {
+static asn_INTEGER_specifics_t asn_SPC_enum_specs_4 = {
 	asn_MAP_enum_value2enum_4,	/* "tag" => N; sorted by tag */
 	asn_MAP_enum_enum2value_4,	/* N => "tag"; sorted by N */
 	2,	/* Number of elements in the maps */
@@ -1145,7 +1145,7 @@ static const unsigned int asn_MAP_Member_enum2value_2[] = {
 	0,	/* one(0) */
 	1	/* oneMore(1) */
 };
-static const asn_INTEGER_specifics_t asn_SPC_Member_specs_2 = {
+static asn_INTEGER_specifics_t asn_SPC_Member_specs_2 = {
 	asn_MAP_Member_value2enum_2,	/* "tag" => N; sorted by tag */
 	asn_MAP_Member_enum2value_2,	/* N => "tag"; sorted by N */
 	2,	/* Number of elements in the maps */
@@ -1469,7 +1469,7 @@ static const unsigned int asn_MAP_name_enum2value_2[] = {
 	0,	/* one(0) */
 	1	/* oneMore(1) */
 };
-static const asn_INTEGER_specifics_t asn_SPC_name_specs_2 = {
+static asn_INTEGER_specifics_t asn_SPC_name_specs_2 = {
 	asn_MAP_name_value2enum_2,	/* "tag" => N; sorted by tag */
 	asn_MAP_name_enum2value_2,	/* N => "tag"; sorted by N */
 	2,	/* Number of elements in the maps */

--- a/tests/73-circular-OK.asn1.-Pfwide-types
+++ b/tests/73-circular-OK.asn1.-Pfwide-types
@@ -818,7 +818,7 @@ static const unsigned int asn_MAP_EnumType_enum2value_1[] = {
 	0,	/* one(0) */
 	1	/* two(1) */
 };
-static const asn_INTEGER_specifics_t asn_SPC_EnumType_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_EnumType_specs_1 = {
 	asn_MAP_EnumType_value2enum_1,	/* "tag" => N; sorted by tag */
 	asn_MAP_EnumType_enum2value_1,	/* N => "tag"; sorted by N */
 	2,	/* Number of elements in the maps */

--- a/tests/90-cond-int-type-OK.asn1.-P
+++ b/tests/90-cond-int-type-OK.asn1.-P
@@ -667,7 +667,7 @@ NO_IntegerLowHigh_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
 
 /*** <<< STAT-DEFS [NO-IntegerLowHigh] >>> ***/
 
-static const asn_INTEGER_specifics_t asn_SPC_NO_IntegerLowHigh_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_NO_IntegerLowHigh_specs_1 = {
 	0,	0,	0,	0,	0,
 	0,	/* Native long size */
 	1	/* Unsigned representation */
@@ -1252,7 +1252,7 @@ NO_IntegerOutRange_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
 
 /*** <<< STAT-DEFS [NO-IntegerOutRange] >>> ***/
 
-static const asn_INTEGER_specifics_t asn_SPC_NO_IntegerOutRange_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_NO_IntegerOutRange_specs_1 = {
 	0,	0,	0,	0,	0,
 	0,	/* Native long size */
 	1	/* Unsigned representation */
@@ -1399,7 +1399,7 @@ NO_IntegerOutValue_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
 
 /*** <<< STAT-DEFS [NO-IntegerOutValue] >>> ***/
 
-static const asn_INTEGER_specifics_t asn_SPC_NO_IntegerOutValue_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_NO_IntegerOutValue_specs_1 = {
 	0,	0,	0,	0,	0,
 	0,	/* Native long size */
 	1	/* Unsigned representation */
@@ -2247,7 +2247,7 @@ NO_IntegerInRange6_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
 
 /*** <<< STAT-DEFS [NO-IntegerInRange6] >>> ***/
 
-static const asn_INTEGER_specifics_t asn_SPC_NO_IntegerInRange6_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_NO_IntegerInRange6_specs_1 = {
 	0,	0,	0,	0,	0,
 	0,	/* Native long size */
 	1	/* Unsigned representation */

--- a/tests/90-cond-int-type-OK.asn1.-Pfwide-types
+++ b/tests/90-cond-int-type-OK.asn1.-Pfwide-types
@@ -674,7 +674,7 @@ NO_IntegerLowHigh_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
 
 /*** <<< STAT-DEFS [NO-IntegerLowHigh] >>> ***/
 
-static const asn_INTEGER_specifics_t asn_SPC_NO_IntegerLowHigh_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_NO_IntegerLowHigh_specs_1 = {
 	0,	0,	0,	0,	0,
 	0,	/* Native long size */
 	1	/* Unsigned representation */
@@ -1265,7 +1265,7 @@ NO_IntegerOutRange_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
 
 /*** <<< STAT-DEFS [NO-IntegerOutRange] >>> ***/
 
-static const asn_INTEGER_specifics_t asn_SPC_NO_IntegerOutRange_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_NO_IntegerOutRange_specs_1 = {
 	0,	0,	0,	0,	0,
 	0,	/* Native long size */
 	1	/* Unsigned representation */
@@ -1412,7 +1412,7 @@ NO_IntegerOutValue_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
 
 /*** <<< STAT-DEFS [NO-IntegerOutValue] >>> ***/
 
-static const asn_INTEGER_specifics_t asn_SPC_NO_IntegerOutValue_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_NO_IntegerOutValue_specs_1 = {
 	0,	0,	0,	0,	0,
 	0,	/* Native long size */
 	1	/* Unsigned representation */
@@ -2266,7 +2266,7 @@ NO_IntegerInRange6_encode_xer(asn_TYPE_descriptor_t *td, void *structure,
 
 /*** <<< STAT-DEFS [NO-IntegerInRange6] >>> ***/
 
-static const asn_INTEGER_specifics_t asn_SPC_NO_IntegerInRange6_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_NO_IntegerInRange6_specs_1 = {
 	0,	0,	0,	0,	0,
 	0,	/* Native long size */
 	1	/* Unsigned representation */

--- a/tests/90-cond-int-type-OK.asn1.-Pgen-PER
+++ b/tests/90-cond-int-type-OK.asn1.-Pgen-PER
@@ -788,7 +788,7 @@ static asn_per_constraints_t asn_PER_type_NO_IntegerLowHigh_constr_1 GCC_NOTUSED
 
 /*** <<< STAT-DEFS [NO-IntegerLowHigh] >>> ***/
 
-static const asn_INTEGER_specifics_t asn_SPC_NO_IntegerLowHigh_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_NO_IntegerLowHigh_specs_1 = {
 	0,	0,	0,	0,	0,
 	0,	/* Native long size */
 	1	/* Unsigned representation */
@@ -1477,7 +1477,7 @@ static asn_per_constraints_t asn_PER_type_NO_IntegerOutRange_constr_1 GCC_NOTUSE
 
 /*** <<< STAT-DEFS [NO-IntegerOutRange] >>> ***/
 
-static const asn_INTEGER_specifics_t asn_SPC_NO_IntegerOutRange_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_NO_IntegerOutRange_specs_1 = {
 	0,	0,	0,	0,	0,
 	0,	/* Native long size */
 	1	/* Unsigned representation */
@@ -1650,7 +1650,7 @@ static asn_per_constraints_t asn_PER_type_NO_IntegerOutValue_constr_1 GCC_NOTUSE
 
 /*** <<< STAT-DEFS [NO-IntegerOutValue] >>> ***/
 
-static const asn_INTEGER_specifics_t asn_SPC_NO_IntegerOutValue_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_NO_IntegerOutValue_specs_1 = {
 	0,	0,	0,	0,	0,
 	0,	/* Native long size */
 	1	/* Unsigned representation */
@@ -2654,7 +2654,7 @@ static asn_per_constraints_t asn_PER_type_NO_IntegerInRange6_constr_1 GCC_NOTUSE
 
 /*** <<< STAT-DEFS [NO-IntegerInRange6] >>> ***/
 
-static const asn_INTEGER_specifics_t asn_SPC_NO_IntegerInRange6_specs_1 = {
+static asn_INTEGER_specifics_t asn_SPC_NO_IntegerInRange6_specs_1 = {
 	0,	0,	0,	0,	0,
 	0,	/* Native long size */
 	1	/* Unsigned representation */


### PR DESCRIPTION
Since the typedef of asn_INTEGER_specifics_t also contains a const the
compiler complained about:
"warning: duplicate ‘const’ [-Wpedantic]"