### PR TITLE
Fix issue 144

### DIFF
--- a/examples/sample.makefile.regen
+++ b/examples/sample.makefile.regen
@@ -38,7 +38,7 @@ if test ! -f Makefile.am.sample ; then
 	exit 1
 fi
 
-EXTRA_CFLAGS="-DJUNKTEST"
+EXTRA_CFLAGS="-DJUNKTEST -D_DEFAULT_SOURCE ${CFLAGS}"
 test -f config.h && EXTRA_CFLAGS="-DHAVE_CONFIG_H ${EXTRA_CFLAGS}"
 test -n "$TITLE" && EXTRA_CFLAGS="-DASN_CONVERTER_TITLE=\"$TITLE\" ${EXTRA_CFLAGS}"
 
@@ -62,6 +62,7 @@ set +x
 	echo "	ASN1MODULES=\"${ASN1MODULES}\" \\"
 	echo "	ASN1PDU=${ASN1PDU} \\"
 	echo "	PROGNAME=${PROGNAME} \\"
+	echo "	CFLAGS=\"${CFLAGS}\" \\"
 	echo "	$0"
 	echo
 	echo 'check: ${TARGET} check-ber check-xer check-per'

--- a/examples/sample.source.LDAP3/Makefile
+++ b/examples/sample.source.LDAP3/Makefile
@@ -163,7 +163,7 @@ libsomething_la_SOURCES=$(ASN_MODULE_SOURCES) $(ASN_MODULE_HEADERS)
 # This file may be used as an input for make(3)
 # Remove the lines below to convert it into a pure .am file
 TARGET = ldap3dump
-CFLAGS += -DASN_CONVERTER_TITLE="Lightweight Directory Access Protocol V3 decoder" -DHAVE_CONFIG_H -DJUNKTEST -DPDU=LDAPMessage -I.
+CFLAGS += -DASN_CONVERTER_TITLE="Lightweight Directory Access Protocol V3 decoder" -DHAVE_CONFIG_H -DJUNKTEST -D_DEFAULT_SOURCE  -DPDU=LDAPMessage -I.
 OBJS=${ASN_MODULE_SOURCES:.c=.o} ${ASN_CONVERTER_SOURCES:.c=.o}
 
 all: LDAPMessage.c $(TARGET)
@@ -198,6 +198,7 @@ regen-makefile:
 	ASN1MODULES="../rfc4511-Lightweight-Directory-Access-Protocol-V3.asn1" \
 	ASN1PDU=LDAPMessage \
 	PROGNAME=ldap3dump \
+	CFLAGS="" \
 	../sample.makefile.regen
 
 check: ${TARGET} check-ber check-xer check-per

--- a/examples/sample.source.LTE-RRC/Makefile
+++ b/examples/sample.source.LTE-RRC/Makefile
@@ -3578,7 +3578,7 @@ libsomething_la_SOURCES=$(ASN_MODULE_SOURCES) $(ASN_MODULE_HEADERS)
 # This file may be used as an input for make(3)
 # Remove the lines below to convert it into a pure .am file
 TARGET = lte-rrc-dump
-CFLAGS += -DJUNKTEST -DPDU=DL_DCCH_Message -DASN_PDU_COLLECTION -I.
+CFLAGS += -DHAVE_CONFIG_H -DJUNKTEST -D_DEFAULT_SOURCE  -DPDU=DL_DCCH_Message -DASN_PDU_COLLECTION -I.
 OBJS=${ASN_MODULE_SOURCES:.c=.o} ${ASN_CONVERTER_SOURCES:.c=.o}
 
 all: DL-DCCH-Message.c $(TARGET)
@@ -3612,6 +3612,7 @@ regen-makefile:
 	ASN1MODULES="../lte-rrc-14.2.1.asn1" \
 	ASN1PDU=DL-DCCH-Message \
 	PROGNAME=lte-rrc-dump \
+	CFLAGS="" \
 	../sample.makefile.regen
 
 check: ${TARGET} check-ber check-xer check-per

--- a/examples/sample.source.MEGACO/Makefile
+++ b/examples/sample.source.MEGACO/Makefile
@@ -285,7 +285,7 @@ libsomething_la_SOURCES=$(ASN_MODULE_SOURCES) $(ASN_MODULE_HEADERS)
 # This file may be used as an input for make(3)
 # Remove the lines below to convert it into a pure .am file
 TARGET = megaco-dump
-CFLAGS += -DHAVE_CONFIG_H -DJUNKTEST -DPDU=MegacoMessage -I.
+CFLAGS += -DHAVE_CONFIG_H -DJUNKTEST -D_DEFAULT_SOURCE  -DPDU=MegacoMessage -I.
 OBJS=${ASN_MODULE_SOURCES:.c=.o} ${ASN_CONVERTER_SOURCES:.c=.o}
 
 all: MegacoMessage.c $(TARGET)
@@ -319,6 +319,7 @@ regen-makefile:
 	ASN1MODULES="../rfc3525-MEDIA-GATEWAY-CONTROL.asn1" \
 	ASN1PDU=MegacoMessage \
 	PROGNAME=megaco-dump \
+	CFLAGS="" \
 	../sample.makefile.regen
 
 check: ${TARGET} check-ber check-xer check-per

--- a/examples/sample.source.MHEG5/Makefile
+++ b/examples/sample.source.MHEG5/Makefile
@@ -186,8 +186,7 @@ ASN_MODULE_SOURCES=	\
 	GenericBoolean.c	\
 	GenericOctetString.c	\
 	Colour.c	\
-	XYPosition.c	\
-	OctetString.c
+	XYPosition.c
 
 ASN_MODULE_HEADERS=	\
 	InterchangedObject.h	\
@@ -377,19 +376,12 @@ ASN_MODULE_HEADERS=	\
 	GenericBoolean.h	\
 	GenericOctetString.h	\
 	Colour.h	\
-	XYPosition.h	\
-	OctetString.h
+	XYPosition.h
 
-ASN_MODULE_HEADERS+=ANY.h
-ASN_MODULE_SOURCES+=ANY.c
 ASN_MODULE_HEADERS+=BOOLEAN.h
 ASN_MODULE_SOURCES+=BOOLEAN.c
-ASN_MODULE_HEADERS+=ENUMERATED.h
-ASN_MODULE_SOURCES+=ENUMERATED.c
 ASN_MODULE_HEADERS+=INTEGER.h
 ASN_MODULE_HEADERS+=NativeEnumerated.h
-ASN_MODULE_HEADERS+=IA5String.h
-ASN_MODULE_SOURCES+=IA5String.c
 ASN_MODULE_SOURCES+=INTEGER.c
 ASN_MODULE_HEADERS+=NULL.h
 ASN_MODULE_SOURCES+=NULL.c
@@ -444,6 +436,8 @@ ASN_MODULE_HEADERS+=per_decoder.h
 ASN_MODULE_SOURCES+=per_decoder.c
 ASN_MODULE_HEADERS+=per_encoder.h
 ASN_MODULE_SOURCES+=per_encoder.c
+ASN_MODULE_HEADERS+=per_opentype.h
+ASN_MODULE_SOURCES+=per_opentype.c
 ASN_CONVERTER_SOURCES+=converter-sample.c
 
 
@@ -453,7 +447,7 @@ libsomething_la_SOURCES=$(ASN_MODULE_SOURCES) $(ASN_MODULE_HEADERS)
 # This file may be used as an input for make(3)
 # Remove the lines below to convert it into a pure .am file
 TARGET = mheg5dump
-CFLAGS += -DHAVE_CONFIG_H -DJUNKTEST -DPDU=InterchangedObject -I.
+CFLAGS += -DHAVE_CONFIG_H -DJUNKTEST -D_DEFAULT_SOURCE  -DPDU=InterchangedObject -I.
 OBJS=${ASN_MODULE_SOURCES:.c=.o} ${ASN_CONVERTER_SOURCES:.c=.o}
 
 all: InterchangedObject.c $(TARGET)
@@ -487,6 +481,7 @@ regen-makefile:
 	ASN1MODULES="../ISO13522-MHEG-5.asn" \
 	ASN1PDU=InterchangedObject \
 	PROGNAME=mheg5dump \
+	CFLAGS="" \
 	../sample.makefile.regen
 
 check: ${TARGET} check-ber check-xer check-per
@@ -500,12 +495,12 @@ check-ber:
 	for b in 1 17 33 980 8192; do \
 	echo "Recoding $$f into XER and back ($$b)..."; \
 	./${TARGET} -b $$b -iber -oxer $$f > ./.tmp.1.$$$$ || exit 2; \
-	./${TARGET} -b $$b -ixer -oxer ./.tmp.1.$$$$ > ./.tmp.2.$$$$ || exit 2; \
-	diff ./.tmp.1.$$$$ ./.tmp.2.$$$$ || exit 2; \
+	./${TARGET} -b $$b -ixer -oxer ./.tmp.1.$$$$ > ./.tmp.2.$$$$ || exit 3; \
+	diff ./.tmp.1.$$$$ ./.tmp.2.$$$$ || exit 4; \
 	rm -f ./.tmp.[12].$$$$; \
 	echo "Test junking $$f (please wait)..."; \
-	./${TARGET} -J0.0001 -n 1000 -b $$b -iber -onull $$f || exit 2; \
-	./${TARGET} -J0.001 -n 1000 -b $$b -iber -onull $$f || exit 2; \
+	./${TARGET} -J0.0001 -n 1000 -b $$b -iber -onull $$f || exit 5; \
+	./${TARGET} -J0.001 -n 1000 -b $$b -iber -onull $$f || exit 6; \
 	done; done; fi
 
 check-xer:
@@ -514,41 +509,41 @@ check-xer:
 	for b in 1 17 33 980 8192; do \
 	echo "Recoding $$f into DER and back ($$b)..."; \
 	./${TARGET} -b $$b -ixer -oder $$f > ./.tmp.1.$$$$ || exit 2; \
-	./${TARGET} -b $$b -iber -oxer ./.tmp.1.$$$$ > ./.tmp.2.$$$$ || exit 2; \
-	diff $$f ./.tmp.2.$$$$ || exit 2; \
+	./${TARGET} -b $$b -iber -oxer ./.tmp.1.$$$$ > ./.tmp.2.$$$$ || exit 3; \
+	diff $$f ./.tmp.2.$$$$ || exit 4; \
 	rm -f ./.tmp.[12].$$$$; \
 	echo "Test junking $$f (please wait)..."; \
-	./${TARGET} -J0.0001 -n 1000 -b $$b -ixer -onull $$f || exit 2; \
-	./${TARGET} -J0.001 -n 1000 -b $$b -ixer -onull $$f || exit 2; \
+	./${TARGET} -J0.0001 -n 1000 -b $$b -ixer -onull $$f || exit 5; \
+	./${TARGET} -J0.001 -n 1000 -b $$b -ixer -onull $$f || exit 6; \
 	done; done; fi
 
 check-per:
-	@if test -f sample-InterchangedObject-1.per ; then \
-	for f in sample-InterchangedObject-[1-9].per; do \
+	@if test -f sample-InterchangedObject-1-nopad.per ; then \
+	for f in sample-InterchangedObject-[1-9]-nopad.per; do \
 	for b in 1 17 33 980 8192; do \
-	echo "Recoding $$f into DER into XER and back ($$b)..."; \
-	./${TARGET} -b $$b -iper -oder $$f > ./.tmp.1.$$$$ || exit 2; \
-	./${TARGET} -b $$b -iber -oxer ./.tmp.1.$$$$ > ./.tmp.2.$$$$ || exit 2; \
-	./${TARGET} -b $$b -ixer -oder ./.tmp.2.$$$$ > ./.tmp.3.$$$$ || exit 2; \
-	diff ./.tmp.1.$$$$ ./.tmp.3.$$$$ || exit 2; \
+	echo "Recoding non-padded $$f into DER into XER and back ($$b)..."; \
+	./${TARGET} -b $$b -per-nopad -iper -oder $$f > ./.tmp.1.$$$$ || exit 2; \
+	./${TARGET} -b $$b -iber -oxer ./.tmp.1.$$$$ > ./.tmp.2.$$$$ || exit 3; \
+	./${TARGET} -b $$b -ixer -oder ./.tmp.2.$$$$ > ./.tmp.3.$$$$ || exit 4; \
+	diff ./.tmp.1.$$$$ ./.tmp.3.$$$$ || exit 5; \
 	rm -f ./.tmp.[123].$$$$; \
 	echo "Test junking $$f (please wait)..."; \
-	./${TARGET} -J0.0001 -n 1000 -b $$b -iper -onull $$f || exit 2; \
-	./${TARGET} -J0.001 -n 1000 -b $$b -iper -onull $$f || exit 2; \
+	./${TARGET} -J0.0001 -n 1000 -b $$b -per-nopad -iper -onull $$f || exit 6; \
+	./${TARGET} -J0.001 -n 1000 -b $$b -per-nopad -iper -onull $$f || exit 7; \
 	done; done; fi
-	@if test -f sample-InterchangedObject-1-padded.per ; then \
-	for f in sample-*-[1-9]-padded.per; do \
+	@if test -f sample-InterchangedObject-1.per ; then \
+	for f in sample-*-[1-9].per; do \
 	pdu=`echo $$f | sed -E -e "s/sample-([A-Za-z-]+)-[0-9].*/\1/"`; \
 	for b in 1 17 33 980 8192; do \
-	echo "Recoding byte-padded $$f into DER into XER and back ($$b)..."; \
-	./${TARGET} -b $$b -per-padded -p $$pdu -iper -oder $$f > ./.tmp.1.$$$$ || exit 2; \
-	./${TARGET} -b $$b -p $$pdu -iber -oxer ./.tmp.1.$$$$ > ./.tmp.2.$$$$ || exit 2; \
-	./${TARGET} -b $$b -p $$pdu -ixer -oper ./.tmp.2.$$$$ > ./.tmp.1.$$$$ || exit 2; \
-	diff $$f ./.tmp.1.$$$$ || exit 2; \
+	echo "Recoding $$f into DER into XER and back ($$b)..."; \
+	./${TARGET} -b $$b -p $$pdu -iper -oder $$f > ./.tmp.1.$$$$ || exit 3; \
+	./${TARGET} -b $$b -p $$pdu -iber -oxer ./.tmp.1.$$$$ > ./.tmp.2.$$$$ || exit 4; \
+	./${TARGET} -b $$b -p $$pdu -ixer -oper ./.tmp.2.$$$$ > ./.tmp.1.$$$$ || exit 5; \
+	diff $$f ./.tmp.1.$$$$ || exit 6; \
 	rm -f ./.tmp.[12].$$$$; \
 	echo "Test junking $$f (please wait)..."; \
-	./${TARGET} -J0.0001 -n 1000 -b $$b -per-padded -iper -onull $$f || exit 2; \
-	./${TARGET} -J0.001 -n 1000 -b $$b -per-padded -iper -onull $$f || exit 2; \
+	./${TARGET} -J0.0001 -n 1000 -b $$b -iper -onull $$f || exit 7; \
+	./${TARGET} -J0.001 -n 1000 -b $$b -iper -onull $$f || exit 8; \
 	done; done; fi
 
 distclean: clean

--- a/examples/sample.source.PKIX1/Makefile
+++ b/examples/sample.source.PKIX1/Makefile
@@ -261,6 +261,8 @@ ASN_MODULE_SOURCES+=BMPString.c
 ASN_MODULE_HEADERS+=UTF8String.h
 ASN_MODULE_HEADERS+=BOOLEAN.h
 ASN_MODULE_SOURCES+=BOOLEAN.c
+ASN_MODULE_HEADERS+=ENUMERATED.h
+ASN_MODULE_SOURCES+=ENUMERATED.c
 ASN_MODULE_HEADERS+=INTEGER.h
 ASN_MODULE_HEADERS+=NativeEnumerated.h
 ASN_MODULE_HEADERS+=GeneralizedTime.h
@@ -345,7 +347,7 @@ libsomething_la_SOURCES=$(ASN_MODULE_SOURCES) $(ASN_MODULE_HEADERS)
 # This file may be used as an input for make(3)
 # Remove the lines below to convert it into a pure .am file
 TARGET = x509dump
-CFLAGS += -DHAVE_CONFIG_H -DJUNKTEST -DPDU=Certificate -I.
+CFLAGS += -DHAVE_CONFIG_H -DJUNKTEST -D_DEFAULT_SOURCE  -DPDU=Certificate -I.
 OBJS=${ASN_MODULE_SOURCES:.c=.o} ${ASN_CONVERTER_SOURCES:.c=.o}
 
 all: Certificate.c $(TARGET)
@@ -366,7 +368,7 @@ clean:
 regen: regenerate-from-asn1-source
 
 regenerate-from-asn1-source:
-	../../asn1c/asn1c -S ../../skeletons -pdu=Certificate ../rfc3280-PKIX1Explicit88.asn1 ../rfc3280-PKIX1Implicit88.asn1
+	../../asn1c/asn1c -S ../../skeletons -pdu=Certificate -fwide-types ../rfc3280-PKIX1Explicit88.asn1 ../rfc3280-PKIX1Implicit88.asn1
 
 
 Certificate.c: ../sample.makefile.regen ../rfc3280-*.asn1
@@ -379,6 +381,7 @@ regen-makefile:
 	ASN1MODULES="../rfc3280-*.asn1" \
 	ASN1PDU=Certificate \
 	PROGNAME=x509dump \
+	CFLAGS="" \
 	../sample.makefile.regen
 
 check: ${TARGET} check-ber check-xer check-per

--- a/examples/sample.source.RRC/Makefile
+++ b/examples/sample.source.RRC/Makefile
@@ -4740,7 +4740,7 @@ libsomething_la_SOURCES=$(ASN_MODULE_SOURCES) $(ASN_MODULE_HEADERS)
 # This file may be used as an input for make(3)
 # Remove the lines below to convert it into a pure .am file
 TARGET = rrc-dump
-CFLAGS += -DHAVE_CONFIG_H -DJUNKTEST -DPDU=DL_DCCH_Message -DASN_PDU_COLLECTION -I.
+CFLAGS += -DHAVE_CONFIG_H -DJUNKTEST -D_DEFAULT_SOURCE  -DPDU=DL_DCCH_Message -DASN_PDU_COLLECTION -I.
 OBJS=${ASN_MODULE_SOURCES:.c=.o} ${ASN_CONVERTER_SOURCES:.c=.o}
 
 all: DL-DCCH-Message.c $(TARGET)
@@ -4774,6 +4774,7 @@ regen-makefile:
 	ASN1MODULES="../rrc-7.1.0.asn1" \
 	ASN1PDU=DL-DCCH-Message \
 	PROGNAME=rrc-dump \
+	CFLAGS="" \
 	../sample.makefile.regen
 
 check: ${TARGET} check-ber check-xer check-per

--- a/examples/sample.source.TAP3/Makefile
+++ b/examples/sample.source.TAP3/Makefile
@@ -15,6 +15,8 @@ ASN_MODULE_SOURCES=	\
 	GprsCall.c	\
 	ContentTransaction.c	\
 	LocationService.c	\
+	MessagingEvent.c	\
+	MobileSession.c	\
 	AuditControlInfo.c	\
 	AccessPointNameNI.c	\
 	AccessPointNameOI.c	\
@@ -56,6 +58,7 @@ ASN_MODULE_SOURCES=	\
 	ChargeDetailList.c	\
 	ChargeDetailTimeStamp.c	\
 	ChargedItem.c	\
+	ChargedParty.c	\
 	ChargedPartyEquipment.c	\
 	ChargedPartyHomeIdentification.c	\
 	ChargedPartyHomeIdList.c	\
@@ -115,9 +118,12 @@ ASN_MODULE_SOURCES=	\
 	DiscountValue.c	\
 	DistanceChargeBandCode.c	\
 	EarliestCallTimeStamp.c	\
+	ElementId.c	\
+	ElementType.c	\
 	EquipmentId.c	\
 	EquipmentIdType.c	\
 	Esn.c	\
+	EventReference.c	\
 	ExchangeRate.c	\
 	ExchangeRateCode.c	\
 	FileAvailableTimeStamp.c	\
@@ -179,16 +185,23 @@ ASN_MODULE_SOURCES=	\
 	MessageDescriptionInformation.c	\
 	MessageStatus.c	\
 	MessageType.c	\
+	MessagingEventService.c	\
 	Min.c	\
 	MinChargeableSubscriber.c	\
 	MoBasicCallInformation.c	\
+	MobileSessionService.c	\
 	Msisdn.c	\
 	MtBasicCallInformation.c	\
 	NetworkAccessIdentifier.c	\
+	NetworkElement.c	\
+	NetworkElementList.c	\
 	NetworkId.c	\
 	NetworkInitPDPContext.c	\
 	NetworkLocation.c	\
 	NonChargedNumber.c	\
+	NonChargedParty.c	\
+	NonChargedPartyNumber.c	\
+	NonChargedPublicUserId.c	\
 	NumberOfDecimalPlaces.c	\
 	ObjectType.c	\
 	OperatorSpecInfoList.c	\
@@ -204,6 +217,7 @@ ASN_MODULE_SOURCES=	\
 	PlmnId.c	\
 	PositioningMethod.c	\
 	PriorityCode.c	\
+	PublicUserId.c	\
 	RapFileSequenceNumber.c	\
 	RecEntityCode.c	\
 	RecEntityCodeList.c	\
@@ -221,10 +235,13 @@ ASN_MODULE_SOURCES=	\
 	ScuTimeStamps.c	\
 	ScuChargeableSubscriber.c	\
 	Sender.c	\
+	ServiceStartTimestamp.c	\
 	ServingBid.c	\
 	ServingLocationDescription.c	\
 	ServingNetwork.c	\
 	ServingPartiesInformation.c	\
+	SessionChargeInfoList.c	\
+	SessionChargeInformation.c	\
 	SimChargeableSubscriber.c	\
 	SimToolkitIndicator.c	\
 	SMSDestinationNumber.c	\
@@ -240,6 +257,7 @@ ASN_MODULE_SOURCES=	\
 	Taxation.c	\
 	TaxationList.c	\
 	TaxCode.c	\
+	TaxIndicator.c	\
 	TaxInformation.c	\
 	TaxInformationList.c	\
 	TaxRate.c	\
@@ -324,6 +342,8 @@ ASN_MODULE_HEADERS=	\
 	GprsCall.h	\
 	ContentTransaction.h	\
 	LocationService.h	\
+	MessagingEvent.h	\
+	MobileSession.h	\
 	AuditControlInfo.h	\
 	AccessPointNameNI.h	\
 	AccessPointNameOI.h	\
@@ -365,6 +385,7 @@ ASN_MODULE_HEADERS=	\
 	ChargeDetailList.h	\
 	ChargeDetailTimeStamp.h	\
 	ChargedItem.h	\
+	ChargedParty.h	\
 	ChargedPartyEquipment.h	\
 	ChargedPartyHomeIdentification.h	\
 	ChargedPartyHomeIdList.h	\
@@ -424,9 +445,12 @@ ASN_MODULE_HEADERS=	\
 	DiscountValue.h	\
 	DistanceChargeBandCode.h	\
 	EarliestCallTimeStamp.h	\
+	ElementId.h	\
+	ElementType.h	\
 	EquipmentId.h	\
 	EquipmentIdType.h	\
 	Esn.h	\
+	EventReference.h	\
 	ExchangeRate.h	\
 	ExchangeRateCode.h	\
 	FileAvailableTimeStamp.h	\
@@ -488,16 +512,23 @@ ASN_MODULE_HEADERS=	\
 	MessageDescriptionInformation.h	\
 	MessageStatus.h	\
 	MessageType.h	\
+	MessagingEventService.h	\
 	Min.h	\
 	MinChargeableSubscriber.h	\
 	MoBasicCallInformation.h	\
+	MobileSessionService.h	\
 	Msisdn.h	\
 	MtBasicCallInformation.h	\
 	NetworkAccessIdentifier.h	\
+	NetworkElement.h	\
+	NetworkElementList.h	\
 	NetworkId.h	\
 	NetworkInitPDPContext.h	\
 	NetworkLocation.h	\
 	NonChargedNumber.h	\
+	NonChargedParty.h	\
+	NonChargedPartyNumber.h	\
+	NonChargedPublicUserId.h	\
 	NumberOfDecimalPlaces.h	\
 	ObjectType.h	\
 	OperatorSpecInfoList.h	\
@@ -513,6 +544,7 @@ ASN_MODULE_HEADERS=	\
 	PlmnId.h	\
 	PositioningMethod.h	\
 	PriorityCode.h	\
+	PublicUserId.h	\
 	RapFileSequenceNumber.h	\
 	RecEntityCode.h	\
 	RecEntityCodeList.h	\
@@ -530,10 +562,13 @@ ASN_MODULE_HEADERS=	\
 	ScuTimeStamps.h	\
 	ScuChargeableSubscriber.h	\
 	Sender.h	\
+	ServiceStartTimestamp.h	\
 	ServingBid.h	\
 	ServingLocationDescription.h	\
 	ServingNetwork.h	\
 	ServingPartiesInformation.h	\
+	SessionChargeInfoList.h	\
+	SessionChargeInformation.h	\
 	SimChargeableSubscriber.h	\
 	SimToolkitIndicator.h	\
 	SMSDestinationNumber.h	\
@@ -549,6 +584,7 @@ ASN_MODULE_HEADERS=	\
 	Taxation.h	\
 	TaxationList.h	\
 	TaxCode.h	\
+	TaxIndicator.h	\
 	TaxInformation.h	\
 	TaxInformationList.h	\
 	TaxRate.h	\
@@ -618,8 +654,6 @@ ASN_MODULE_HEADERS=	\
 
 ASN_MODULE_HEADERS+=INTEGER.h
 ASN_MODULE_HEADERS+=NativeEnumerated.h
-ASN_MODULE_HEADERS+=IA5String.h
-ASN_MODULE_SOURCES+=IA5String.c
 ASN_MODULE_SOURCES+=INTEGER.c
 ASN_MODULE_SOURCES+=NativeEnumerated.c
 ASN_MODULE_HEADERS+=NativeInteger.h
@@ -681,7 +715,7 @@ libsomething_la_SOURCES=$(ASN_MODULE_SOURCES) $(ASN_MODULE_HEADERS)
 # This file may be used as an input for make(3)
 # Remove the lines below to convert it into a pure .am file
 TARGET = tap3dump
-CFLAGS += -DASN_CONVERTER_TITLE="GSM TAP3 (Transferred Account Procedure, Version 3) decoder" -DHAVE_CONFIG_H -DJUNKTEST -DPDU=DataInterChange -I.
+CFLAGS += -DASN_CONVERTER_TITLE="GSM TAP3 (Transferred Account Procedure, Version 3) decoder" -DHAVE_CONFIG_H -DJUNKTEST -D_DEFAULT_SOURCE  -DPDU=DataInterChange -I.
 OBJS=${ASN_MODULE_SOURCES:.c=.o} ${ASN_CONVERTER_SOURCES:.c=.o}
 
 all: DataInterChange.c $(TARGET)
@@ -716,6 +750,7 @@ regen-makefile:
 	ASN1MODULES="../tap3.asn1" \
 	ASN1PDU=DataInterChange \
 	PROGNAME=tap3dump \
+	CFLAGS="" \
 	../sample.makefile.regen
 
 check: ${TARGET} check-ber check-xer check-per

--- a/examples/sample.source.ULP/Makefile
+++ b/examples/sample.source.ULP/Makefile
@@ -234,7 +234,7 @@ libsomething_la_SOURCES=$(ASN_MODULE_SOURCES) $(ASN_MODULE_HEADERS)
 # This file may be used as an input for make(3)
 # Remove the lines below to convert it into a pure .am file
 TARGET = ulp-dump
-CFLAGS += -DASN_CONVERTER_TITLE="OMA UserPlane Location Protocol decoder" -DHAVE_CONFIG_H -DJUNKTEST -DPDU=ULP_PDU -DASN_PDU_COLLECTION -I.
+CFLAGS += -DASN_CONVERTER_TITLE="OMA UserPlane Location Protocol decoder" -DHAVE_CONFIG_H -DJUNKTEST -D_DEFAULT_SOURCE -DPDU=ULP_PDU -DASN_PDU_COLLECTION -I.
 OBJS=${ASN_MODULE_SOURCES:.c=.o} ${ASN_CONVERTER_SOURCES:.c=.o}
 
 all: ULP-PDU.c $(TARGET)
@@ -269,6 +269,7 @@ regen-makefile:
 	ASN1MODULES="../ulp.asn1" \
 	ASN1PDU=ULP-PDU \
 	PROGNAME=ulp-dump \
+	CFLAGS="" \
 	../sample.makefile.regen
 
 check: ${TARGET} check-ber check-xer check-per


### PR DESCRIPTION
According to `/usr/include/features.h`, the source of excessive warning messages :  

```
#if (defined _BSD_SOURCE || defined _SVID_SOURCE) \
    && !defined _DEFAULT_SOURCE
# warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
# undef  _DEFAULT_SOURCE
# define _DEFAULT_SOURCE	1
#endif
```
We can define `_DEFAULT_SOURCE` in command line option to `gcc` to suppress this warning and fix [issue 144](https://github.com/vlm/asn1c/issues/144).
