### PR TITLE
Fix compile SAE J2735_201603DA.ASN issue

### DIFF
--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -2670,8 +2670,6 @@ out_name_chain(arg_t *arg, enum onc_flags onc_flags) {
 	asn1p_expr_t *expr = arg->expr;
 	char *id;
 
-	assert(expr->Identifier);
-
 	if((arg->flags & A1C_COMPOUND_NAMES
 	   || onc_flags & ONC_force_compound_name)
 	&& ((expr->expr_type & ASN_CONSTR_MASK)
@@ -2680,8 +2678,8 @@ out_name_chain(arg_t *arg, enum onc_flags onc_flags) {
 	   	|| expr->expr_type == ASN_BASIC_BIT_STRING)
 		&& expr_elements_count(arg, expr))
 	   )
-	&& expr->parent_expr
-	&& expr->parent_expr->Identifier) {
+	&& expr->parent_expr) {
+
 		arg_t tmparg = *arg;
 
 		tmparg.expr = expr->parent_expr;
@@ -2689,7 +2687,7 @@ out_name_chain(arg_t *arg, enum onc_flags onc_flags) {
 
 		out_name_chain(&tmparg, onc_flags);
 
-		OUT("__");	/* a separator between id components */
+		if(expr->parent_expr->Identifier) OUT("__");	/* a separator between id components */
 
 		/* Fall through */
 	}

--- a/libasn1compiler/asn1c_misc.c
+++ b/libasn1compiler/asn1c_misc.c
@@ -221,7 +221,7 @@ asn1c_type_name(arg_t *arg, asn1p_expr_t *expr, enum tnfmt _format) {
 			}
 		}
 
-		if(_format != TNF_RSAFE && terminal && terminal->spec_index != -1) {
+		if(_format != TNF_RSAFE  && terminal && ((terminal->spec_index != -1) || (terminal->_mark & TM_NAMECLASH))) {
 			exprid = terminal;
 			typename = 0;
 		}


### PR DESCRIPTION
These are un-merged lines of code that I forgot adding in pull request #154.

See comment of my commit  [37b9ca...](https://github.com/mouse07410/asn1c/pull/18/commits/37b9cac0fcb86097bc32648898911411291f9b6b) and [8ccd9d...](https://github.com/mouse07410/asn1c/pull/18/commits/8ccd9d6b9193e5df4cac46bffd8d8a1423946223)  to [mouse07410's asn1c repository](https://github.com/mouse07410/asn1c).

