### PR TITLE
Redefine ASN_DEBUG in asn_internal.h (EMIT_ASN_DEBUG != 1)

### DIFF
--- a/skeletons/asn_internal.h
+++ b/skeletons/asn_internal.h
@@ -59,7 +59,7 @@ void ASN_DEBUG_f(const char *fmt, ...);
 #define	ASN_DEBUG	ASN_DEBUG_f
 #endif	/* __GNUC__ */
 #else	/* EMIT_ASN_DEBUG != 1 */
-static void ASN_DEBUG(const char *fmt, ...) { (void)fmt; }
+#define ASN_DEBUG(...) {}
 #endif	/* EMIT_ASN_DEBUG */
 #endif	/* ASN_DEBUG */
 


### PR DESCRIPTION
Change proposed in #124.

By evaluating the arguments passed to "static void ASN_DEBUG(...)", many unnecessary calls are made to ber_tlv_tag_string(). My experience suggests replacing the dummy function definition with an empty macro results in a significant decrease in CPU time.