### PR TITLE
Omit constraints code if -fno-constraints

### DIFF
--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -2816,10 +2816,15 @@ do {				\
 
 		FUNCREF2(free);
 		FUNCREF2(print);
-		if (!expr->combined_constraints)
-			FUNCREF2(constraint);
+		if (arg->flags & A1C_NO_CONSTRAINTS)
+			OUT("0,\t/* No check because of -fno-constraints */\n");
 		else
-			FUNCREF(constraint);
+		{
+			if (!expr->combined_constraints)
+				FUNCREF2(constraint);
+			else
+				FUNCREF(constraint);
+		}
 		FUNCREF2(decode_ber);
 		FUNCREF2(encode_der);
 		FUNCREF2(decode_xer);


### PR DESCRIPTION
Raised in #122, prevent reference to constraints in generated code if compiled with -fno-constraints