### PR TITLE
Move type operations to another structure

### DIFF
--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -1416,10 +1416,10 @@ asn1c_lang_C_type_SIMPLE_TYPE(arg_t *arg) {
 		DEBUG("expr constraint checking code for %s", p);
 		if(asn1c_emit_constraint_checking_code(arg) == 1) {
 			OUT("/* Replace with underlying type checker */\n");
-			OUT("td->check_constraints "
-				"= asn_DEF_%s.check_constraints;\n",
-				asn1c_type_name(arg, expr, TNF_SAFE));
-			OUT("return td->check_constraints"
+			// OUT("td->check_constraints "
+			//	"= asn_DEF_%s.check_constraints;\n",
+			//	asn1c_type_name(arg, expr, TNF_SAFE));
+			OUT("return td->op->check_constraints"
 				"(td, sptr, ctfailcb, app_key);\n");
 		}
 		INDENT(-1);
@@ -2917,7 +2917,7 @@ emit_member_type_selector(arg_t *arg, asn1p_expr_t *expr, asn1c_ioc_table_and_ob
     OUT("    const asn_ioc_cell_t *constraining_cell = &itable->rows[row * itable->columns_count + constraining_column];\n");
     OUT("    const asn_ioc_cell_t *type_cell = &itable->rows[row * itable->columns_count + for_column];\n");
     OUT("\n");
-    OUT("    if(constraining_cell->type_descriptor->compare_struct(constraining_cell->type_descriptor, constraining_value, constraining_cell->value_sptr) == 0) {\n");
+    OUT("    if(constraining_cell->type_descriptor->op->compare_struct(constraining_cell->type_descriptor, constraining_value, constraining_cell->value_sptr) == 0) {\n");
     OUT("        result.type_descriptor = type_cell->type_descriptor;\n");
     OUT("        result.presence_index = row + 1;\n");
     OUT("        break;\n");
@@ -3199,9 +3199,7 @@ do {				\
 	OUT("_" #foo ",\n");	\
 } while(0)
 
-		FUNCREF2(free);
-		FUNCREF2(print);
-		FUNCREF2(compare);
+		OUT("&asn_OP_%s,\n", p2);
 		if (arg->flags & A1C_NO_CONSTRAINTS)
 			OUT("0,\t/* No check because of -fno-constraints */\n");
 		else
@@ -3211,33 +3209,7 @@ do {				\
 			else
 				FUNCREF(constraint);
 		}
-		FUNCREF2(decode_ber);
-		FUNCREF2(encode_der);
-		FUNCREF2(decode_xer);
-		FUNCREF2(encode_xer);
-
-		if(arg->flags & A1C_GEN_OER) {
-			FUNCREF2(decode_oer);
-			FUNCREF2(encode_oer);
-		} else {
-			OUT("0, 0,\t/* No OER support, "
-				"use \"-gen-OER\" to enable */\n");
-		}
-		if(arg->flags & A1C_GEN_PER) {
-			FUNCREF2(decode_uper);
-			FUNCREF2(encode_uper);
-		} else {
-			OUT("0, 0,\t/* No PER support, "
-				"use \"-gen-PER\" to enable */\n");
-		}
 		if (p2) free(p2);
-
-		if(!terminal || terminal->expr_type == ASN_CONSTR_CHOICE) {
-		//if(expr->expr_type == ASN_CONSTR_CHOICE) {
-			OUT("CHOICE_outmost_tag,\n");
-		} else {
-			OUT("0,\t/* Use generic outmost tag fetcher */\n");
-		}
 
 		p = MKID(expr);
 		if(tags_count) {

--- a/skeletons/ANY.c
+++ b/skeletons/ANY.c
@@ -11,9 +11,7 @@ asn_OCTET_STRING_specifics_t asn_SPC_ANY_specs = {
 	offsetof(ANY_t, _asn_ctx),
 	ASN_OSUBV_ANY
 };
-asn_TYPE_descriptor_t asn_DEF_ANY = {
-	"ANY",
-	"ANY",
+asn_TYPE_operation_t asn_OP_ANY = {
 	OCTET_STRING_free,
 	OCTET_STRING_print,
 	OCTET_STRING_compare,
@@ -32,10 +30,16 @@ asn_TYPE_descriptor_t asn_DEF_ANY = {
 #ifdef	ASN_DISABLE_PER_SUPPORT
 	0, 0,
 #else
-    ANY_decode_uper,
-    ANY_encode_uper,
+	ANY_decode_uper,
+	ANY_encode_uper,
 #endif  /* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_ANY = {
+	"ANY",
+	"ANY",
+	&asn_OP_ANY,
+	asn_generic_no_constraint,
 	0, 0, 0, 0,
 	0,	/* No OER visible constraints */
 	0,	/* No PER visible constraints */

--- a/skeletons/ANY.h
+++ b/skeletons/ANY.h
@@ -19,6 +19,7 @@ typedef struct ANY {
 } ANY_t;
 
 extern asn_TYPE_descriptor_t asn_DEF_ANY;
+extern asn_TYPE_operation_t asn_OP_ANY;
 extern asn_OCTET_STRING_specifics_t asn_SPC_ANY_specs;
 
 asn_struct_free_f ANY_free;

--- a/skeletons/BIT_STRING.c
+++ b/skeletons/BIT_STRING.c
@@ -17,9 +17,7 @@ asn_OCTET_STRING_specifics_t asn_SPC_BIT_STRING_specs = {
 	offsetof(BIT_STRING_t, _asn_ctx),
 	ASN_OSUBV_BIT
 };
-asn_TYPE_descriptor_t asn_DEF_BIT_STRING = {
-	"BIT STRING",
-	"BIT_STRING",
+asn_TYPE_operation_t asn_OP_BIT_STRING = {
 	OCTET_STRING_free,         /* Implemented in terms of OCTET STRING */
 	BIT_STRING_print,
 	BIT_STRING_compare,
@@ -42,7 +40,13 @@ asn_TYPE_descriptor_t asn_DEF_BIT_STRING = {
 	OCTET_STRING_decode_uper,	/* Unaligned PER decoder */
 	OCTET_STRING_encode_uper,	/* Unaligned PER encoder */
 #endif  /* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_BIT_STRING = {
+	"BIT STRING",
+	"BIT_STRING",
+	&asn_OP_BIT_STRING,
+	BIT_STRING_constraint,
 	asn_DEF_BIT_STRING_tags,
 	sizeof(asn_DEF_BIT_STRING_tags)
 	  / sizeof(asn_DEF_BIT_STRING_tags[0]),

--- a/skeletons/BIT_STRING.h
+++ b/skeletons/BIT_STRING.h
@@ -21,6 +21,7 @@ typedef struct BIT_STRING_s {
 } BIT_STRING_t;
 
 extern asn_TYPE_descriptor_t asn_DEF_BIT_STRING;
+extern asn_TYPE_operation_t asn_OP_BIT_STRING;
 extern asn_OCTET_STRING_specifics_t asn_SPC_BIT_STRING_specs;
 
 asn_struct_print_f BIT_STRING_print;	/* Human-readable output */

--- a/skeletons/BMPString.c
+++ b/skeletons/BMPString.c
@@ -23,9 +23,7 @@ static asn_per_constraints_t asn_DEF_BMPString_per_constraints = {
 	{ APC_SEMI_CONSTRAINED, -1, -1, 0, 0 },
 	0, 0
 };
-asn_TYPE_descriptor_t asn_DEF_BMPString = {
-	"BMPString",
-	"BMPString",
+asn_TYPE_operation_t asn_OP_BMPString = {
 	OCTET_STRING_free,          /* Implemented in terms of OCTET STRING */
 	BMPString_print,
 	OCTET_STRING_compare,
@@ -48,7 +46,13 @@ asn_TYPE_descriptor_t asn_DEF_BMPString = {
 	OCTET_STRING_decode_uper,
 	OCTET_STRING_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_BMPString = {
+	"BMPString",
+	"BMPString",
+	&asn_OP_BMPString,
+	asn_generic_no_constraint,  /* No constraint by default */
 	asn_DEF_BMPString_tags,
 	sizeof(asn_DEF_BMPString_tags)
 	  / sizeof(asn_DEF_BMPString_tags[0]) - 1,

--- a/skeletons/BMPString.h
+++ b/skeletons/BMPString.h
@@ -14,6 +14,7 @@ extern "C" {
 typedef OCTET_STRING_t BMPString_t;  /* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_BMPString;
+extern asn_TYPE_operation_t asn_OP_BMPString;
 extern asn_OCTET_STRING_specifics_t asn_SPC_BMPString_specs;
 
 asn_struct_print_f BMPString_print;	/* Human-readable output */

--- a/skeletons/BOOLEAN.c
+++ b/skeletons/BOOLEAN.c
@@ -12,9 +12,7 @@
 static const ber_tlv_tag_t asn_DEF_BOOLEAN_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (1 << 2))
 };
-asn_TYPE_descriptor_t asn_DEF_BOOLEAN = {
-	"BOOLEAN",
-	"BOOLEAN",
+asn_TYPE_operation_t asn_OP_BOOLEAN = {
 	BOOLEAN_free,
 	BOOLEAN_print,
 	BOOLEAN_compare,
@@ -37,7 +35,13 @@ asn_TYPE_descriptor_t asn_DEF_BOOLEAN = {
 	BOOLEAN_decode_uper,	/* Unaligned PER decoder */
 	BOOLEAN_encode_uper,	/* Unaligned PER encoder */
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_BOOLEAN = {
+	"BOOLEAN",
+	"BOOLEAN",
+	&asn_OP_BOOLEAN,
+	asn_generic_no_constraint,
 	asn_DEF_BOOLEAN_tags,
 	sizeof(asn_DEF_BOOLEAN_tags) / sizeof(asn_DEF_BOOLEAN_tags[0]),
 	asn_DEF_BOOLEAN_tags,	/* Same as above */

--- a/skeletons/BOOLEAN.h
+++ b/skeletons/BOOLEAN.h
@@ -19,6 +19,7 @@ extern "C" {
 typedef int BOOLEAN_t;
 
 extern asn_TYPE_descriptor_t asn_DEF_BOOLEAN;
+extern asn_TYPE_operation_t asn_OP_BOOLEAN;
 
 asn_struct_free_f BOOLEAN_free;
 asn_struct_print_f BOOLEAN_print;

--- a/skeletons/ENUMERATED.c
+++ b/skeletons/ENUMERATED.c
@@ -14,9 +14,7 @@
 static const ber_tlv_tag_t asn_DEF_ENUMERATED_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (10 << 2))
 };
-asn_TYPE_descriptor_t asn_DEF_ENUMERATED = {
-	"ENUMERATED",
-	"ENUMERATED",
+asn_TYPE_operation_t asn_OP_ENUMERATED = {
 	ASN__PRIMITIVE_TYPE_free,
 	INTEGER_print,			/* Implemented in terms of INTEGER */
 	INTEGER_compare,		/* Implemented in terms of INTEGER */
@@ -39,7 +37,13 @@ asn_TYPE_descriptor_t asn_DEF_ENUMERATED = {
 	ENUMERATED_decode_uper,	/* Unaligned PER decoder */
 	ENUMERATED_encode_uper,	/* Unaligned PER encoder */
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_ENUMERATED = {
+	"ENUMERATED",
+	"ENUMERATED",
+	&asn_OP_ENUMERATED,
+	asn_generic_no_constraint,
 	asn_DEF_ENUMERATED_tags,
 	sizeof(asn_DEF_ENUMERATED_tags) / sizeof(asn_DEF_ENUMERATED_tags[0]),
 	asn_DEF_ENUMERATED_tags,	/* Same as above */

--- a/skeletons/ENUMERATED.h
+++ b/skeletons/ENUMERATED.h
@@ -14,6 +14,7 @@ extern "C" {
 typedef INTEGER_t ENUMERATED_t;		/* Implemented via INTEGER */
 
 extern asn_TYPE_descriptor_t asn_DEF_ENUMERATED;
+extern asn_TYPE_operation_t asn_OP_ENUMERATED;
 
 per_type_decoder_f ENUMERATED_decode_uper;
 per_type_encoder_f ENUMERATED_encode_uper;

--- a/skeletons/GeneralString.c
+++ b/skeletons/GeneralString.c
@@ -12,9 +12,7 @@ static const ber_tlv_tag_t asn_DEF_GeneralString_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (27 << 2)),	/* [UNIVERSAL 27] IMPLICIT ...*/
 	(ASN_TAG_CLASS_UNIVERSAL | (4 << 2))	/* ... OCTET STRING */
 };
-asn_TYPE_descriptor_t asn_DEF_GeneralString = {
-	"GeneralString",
-	"GeneralString",
+asn_TYPE_operation_t asn_OP_GeneralString = {
 	OCTET_STRING_free,
 	OCTET_STRING_print,         /* non-ascii string */
 	OCTET_STRING_compare,
@@ -37,7 +35,13 @@ asn_TYPE_descriptor_t asn_DEF_GeneralString = {
 	OCTET_STRING_decode_uper,    /* Implemented in terms of OCTET STRING */
 	OCTET_STRING_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_GeneralString = {
+	"GeneralString",
+	"GeneralString",
+	&asn_OP_GeneralString,
+	asn_generic_unknown_constraint,
 	asn_DEF_GeneralString_tags,
 	sizeof(asn_DEF_GeneralString_tags)
 	  / sizeof(asn_DEF_GeneralString_tags[0]) - 1,

--- a/skeletons/GeneralString.h
+++ b/skeletons/GeneralString.h
@@ -14,6 +14,7 @@ extern "C" {
 typedef OCTET_STRING_t GeneralString_t;	/* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_GeneralString;
+extern asn_TYPE_operation_t asn_OP_GeneralString;
 
 #define GeneralString_free          OCTET_STRING_free
 #define GeneralString_print         OCTET_STRING_print

--- a/skeletons/GeneralizedTime.c
+++ b/skeletons/GeneralizedTime.c
@@ -171,9 +171,7 @@ static asn_per_constraints_t asn_DEF_GeneralizedTime_constraints = {
 	{ APC_SEMI_CONSTRAINED, -1, -1, 0, 0 }, /* Size */
 	0, 0
 };
-asn_TYPE_descriptor_t asn_DEF_GeneralizedTime = {
-	"GeneralizedTime",
-	"GeneralizedTime",
+asn_TYPE_operation_t asn_OP_GeneralizedTime = {
 	OCTET_STRING_free,
 	GeneralizedTime_print,
 	OCTET_STRING_compare,   /* Does not normalize time zones! */
@@ -196,7 +194,13 @@ asn_TYPE_descriptor_t asn_DEF_GeneralizedTime = {
 	OCTET_STRING_decode_uper,
 	OCTET_STRING_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_GeneralizedTime = {
+	"GeneralizedTime",
+	"GeneralizedTime",
+	&asn_OP_GeneralizedTime,
+	GeneralizedTime_constraint, /* Check validity of time */
 	asn_DEF_GeneralizedTime_tags,
 	sizeof(asn_DEF_GeneralizedTime_tags)
 	  / sizeof(asn_DEF_GeneralizedTime_tags[0]) - 2,

--- a/skeletons/GeneralizedTime.h
+++ b/skeletons/GeneralizedTime.h
@@ -14,6 +14,7 @@ extern "C" {
 typedef OCTET_STRING_t GeneralizedTime_t;  /* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_GeneralizedTime;
+extern asn_TYPE_operation_t asn_OP_GeneralizedTime;
 
 asn_struct_print_f GeneralizedTime_print;
 asn_constr_check_f GeneralizedTime_constraint;

--- a/skeletons/GraphicString.c
+++ b/skeletons/GraphicString.c
@@ -12,9 +12,7 @@ static const ber_tlv_tag_t asn_DEF_GraphicString_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (25 << 2)),	/* [UNIVERSAL 25] IMPLICIT ...*/
 	(ASN_TAG_CLASS_UNIVERSAL | (4 << 2))	/* ... OCTET STRING */
 };
-asn_TYPE_descriptor_t asn_DEF_GraphicString = {
-	"GraphicString",
-	"GraphicString",
+asn_TYPE_operation_t asn_OP_GraphicString = {
 	OCTET_STRING_free,
 	OCTET_STRING_print,         /* non-ascii string */
 	OCTET_STRING_compare,
@@ -37,7 +35,13 @@ asn_TYPE_descriptor_t asn_DEF_GraphicString = {
 	OCTET_STRING_decode_uper,    /* Implemented in terms of OCTET STRING */
 	OCTET_STRING_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_GraphicString = {
+	"GraphicString",
+	"GraphicString",
+	&asn_OP_GraphicString,
+	asn_generic_unknown_constraint,
 	asn_DEF_GraphicString_tags,
 	sizeof(asn_DEF_GraphicString_tags)
 	  / sizeof(asn_DEF_GraphicString_tags[0]) - 1,

--- a/skeletons/GraphicString.h
+++ b/skeletons/GraphicString.h
@@ -14,6 +14,7 @@ extern "C" {
 typedef OCTET_STRING_t GraphicString_t;	/* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_GraphicString;
+extern asn_TYPE_operation_t asn_OP_GraphicString;
 
 #define GraphicString_free          OCTET_STRING_free
 #define GraphicString_print         OCTET_STRING_print

--- a/skeletons/IA5String.c
+++ b/skeletons/IA5String.c
@@ -17,9 +17,7 @@ static asn_per_constraints_t asn_DEF_IA5String_per_constraints = {
 	{ APC_SEMI_CONSTRAINED, -1, -1, 0, 0 },	/* Size */
 	0, 0
 };
-asn_TYPE_descriptor_t asn_DEF_IA5String = {
-	"IA5String",
-	"IA5String",
+asn_TYPE_operation_t asn_OP_IA5String = {
 	OCTET_STRING_free,
 	OCTET_STRING_print_utf8,	/* ASCII subset */
 	OCTET_STRING_compare,
@@ -42,7 +40,13 @@ asn_TYPE_descriptor_t asn_DEF_IA5String = {
 	OCTET_STRING_decode_uper,
 	OCTET_STRING_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_IA5String = {
+	"IA5String",
+	"IA5String",
+	&asn_OP_IA5String,
+	IA5String_constraint,       /* Constraint on the alphabet */
 	asn_DEF_IA5String_tags,
 	sizeof(asn_DEF_IA5String_tags)
 	  / sizeof(asn_DEF_IA5String_tags[0]) - 1,

--- a/skeletons/IA5String.h
+++ b/skeletons/IA5String.h
@@ -17,6 +17,7 @@ typedef OCTET_STRING_t IA5String_t;  /* Implemented via OCTET STRING */
  * IA5String ASN.1 type definition.
  */
 extern asn_TYPE_descriptor_t asn_DEF_IA5String;
+extern asn_TYPE_operation_t asn_OP_IA5String;
 
 asn_constr_check_f IA5String_constraint;
 

--- a/skeletons/INTEGER.c
+++ b/skeletons/INTEGER.c
@@ -14,9 +14,7 @@
 static const ber_tlv_tag_t asn_DEF_INTEGER_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (2 << 2))
 };
-asn_TYPE_descriptor_t asn_DEF_INTEGER = {
-	"INTEGER",
-	"INTEGER",
+asn_TYPE_operation_t asn_OP_INTEGER = {
 	INTEGER_free,
 	INTEGER_print,
 	INTEGER_compare,
@@ -39,7 +37,13 @@ asn_TYPE_descriptor_t asn_DEF_INTEGER = {
 	INTEGER_decode_uper,	/* Unaligned PER decoder */
 	INTEGER_encode_uper,	/* Unaligned PER encoder */
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_INTEGER = {
+	"INTEGER",
+	"INTEGER",
+	&asn_OP_INTEGER,
+	asn_generic_no_constraint,
 	asn_DEF_INTEGER_tags,
 	sizeof(asn_DEF_INTEGER_tags) / sizeof(asn_DEF_INTEGER_tags[0]),
 	asn_DEF_INTEGER_tags,	/* Same as above */

--- a/skeletons/INTEGER.h
+++ b/skeletons/INTEGER.h
@@ -16,6 +16,7 @@ extern "C" {
 typedef ASN__PRIMITIVE_TYPE_t INTEGER_t;
 
 extern asn_TYPE_descriptor_t asn_DEF_INTEGER;
+extern asn_TYPE_operation_t asn_OP_INTEGER;
 
 /* Map with <tag> to integer value association */
 typedef struct asn_INTEGER_enum_map_s {

--- a/skeletons/ISO646String.c
+++ b/skeletons/ISO646String.c
@@ -17,9 +17,7 @@ static asn_per_constraints_t asn_DEF_ISO646String_per_constraints = {
 	{ APC_SEMI_CONSTRAINED, -1, -1, 0, 0 },	/* Size */
 	0, 0
 };
-asn_TYPE_descriptor_t asn_DEF_ISO646String = {
-	"ISO646String",
-	"ISO646String",
+asn_TYPE_operation_t asn_OP_ISO646String = {
 	OCTET_STRING_free,
 	OCTET_STRING_print_utf8,	/* ASCII subset */
 	OCTET_STRING_compare,
@@ -42,7 +40,13 @@ asn_TYPE_descriptor_t asn_DEF_ISO646String = {
 	OCTET_STRING_decode_uper,
 	OCTET_STRING_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_ISO646String = {
+	"ISO646String",
+	"ISO646String",
+	&asn_OP_ISO646String,
+	VisibleString_constraint,
 	asn_DEF_ISO646String_tags,
 	sizeof(asn_DEF_ISO646String_tags)
 	  / sizeof(asn_DEF_ISO646String_tags[0]) - 1,

--- a/skeletons/ISO646String.h
+++ b/skeletons/ISO646String.h
@@ -15,6 +15,7 @@ extern "C" {
 typedef VisibleString_t ISO646String_t;	/* Implemented using VisibleString */
 
 extern asn_TYPE_descriptor_t asn_DEF_ISO646String;
+extern asn_TYPE_operation_t asn_OP_ISO646String;
 
 #define ISO646String_free           OCTET_STRING_free
 #define ISO646String_print          OCTET_STRING_print_utf8

--- a/skeletons/NULL.c
+++ b/skeletons/NULL.c
@@ -13,9 +13,7 @@
 static const ber_tlv_tag_t asn_DEF_NULL_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (5 << 2))
 };
-asn_TYPE_descriptor_t asn_DEF_NULL = {
-	"NULL",
-	"NULL",
+asn_TYPE_operation_t asn_OP_NULL = {
 	BOOLEAN_free,
 	NULL_print,
 	NULL_compare,
@@ -38,7 +36,13 @@ asn_TYPE_descriptor_t asn_DEF_NULL = {
 	NULL_decode_uper,	/* Unaligned PER decoder */
 	NULL_encode_uper,	/* Unaligned PER encoder */
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_NULL = {
+	"NULL",
+	"NULL",
+	&asn_OP_NULL,
+	asn_generic_no_constraint,
 	asn_DEF_NULL_tags,
 	sizeof(asn_DEF_NULL_tags) / sizeof(asn_DEF_NULL_tags[0]),
 	asn_DEF_NULL_tags,	/* Same as above */

--- a/skeletons/NULL.h
+++ b/skeletons/NULL.h
@@ -19,6 +19,7 @@ extern "C" {
 typedef int NULL_t;
 
 extern asn_TYPE_descriptor_t asn_DEF_NULL;
+extern asn_TYPE_operation_t asn_OP_NULL;
 
 asn_struct_print_f NULL_print;
 asn_struct_compare_f NULL_compare;
@@ -28,7 +29,7 @@ xer_type_encoder_f NULL_encode_xer;
 per_type_decoder_f NULL_decode_uper;
 per_type_encoder_f NULL_encode_uper;
 
-#define NULL_free		BOOLEAN_free
+#define NULL_free	BOOLEAN_free
 #define NULL_decode_ber	BOOLEAN_decode_ber
 #define NULL_constraint	asn_generic_no_constraint
 

--- a/skeletons/NativeEnumerated.c
+++ b/skeletons/NativeEnumerated.c
@@ -18,9 +18,7 @@
 static const ber_tlv_tag_t asn_DEF_NativeEnumerated_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (10 << 2))
 };
-asn_TYPE_descriptor_t asn_DEF_NativeEnumerated = {
-	"ENUMERATED",			/* The ASN.1 type is still ENUMERATED */
-	"ENUMERATED",
+asn_TYPE_operation_t asn_OP_NativeEnumerated = {
 	NativeInteger_free,
 	NativeInteger_print,
 	NativeInteger_compare,
@@ -43,7 +41,13 @@ asn_TYPE_descriptor_t asn_DEF_NativeEnumerated = {
 	NativeEnumerated_decode_uper,
 	NativeEnumerated_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_NativeEnumerated = {
+	"ENUMERATED",			/* The ASN.1 type is still ENUMERATED */
+	"ENUMERATED",
+	&asn_OP_NativeEnumerated,
+	asn_generic_no_constraint,
 	asn_DEF_NativeEnumerated_tags,
 	sizeof(asn_DEF_NativeEnumerated_tags) / sizeof(asn_DEF_NativeEnumerated_tags[0]),
 	asn_DEF_NativeEnumerated_tags,	/* Same as above */

--- a/skeletons/NativeEnumerated.h
+++ b/skeletons/NativeEnumerated.h
@@ -20,6 +20,7 @@ extern "C" {
 #endif
 
 extern asn_TYPE_descriptor_t asn_DEF_NativeEnumerated;
+extern asn_TYPE_operation_t asn_OP_NativeEnumerated;
 
 xer_type_encoder_f NativeEnumerated_encode_xer;
 per_type_decoder_f NativeEnumerated_decode_uper;

--- a/skeletons/NativeInteger.c
+++ b/skeletons/NativeInteger.c
@@ -19,9 +19,7 @@
 static const ber_tlv_tag_t asn_DEF_NativeInteger_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (2 << 2))
 };
-asn_TYPE_descriptor_t asn_DEF_NativeInteger = {
-	"INTEGER",			/* The ASN.1 type is still INTEGER */
-	"INTEGER",
+asn_TYPE_operation_t asn_OP_NativeInteger = {
 	NativeInteger_free,
 	NativeInteger_print,
 	NativeInteger_compare,
@@ -44,7 +42,13 @@ asn_TYPE_descriptor_t asn_DEF_NativeInteger = {
 	NativeInteger_decode_uper,	/* Unaligned PER decoder */
 	NativeInteger_encode_uper,	/* Unaligned PER encoder */
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_NativeInteger = {
+	"INTEGER",			/* The ASN.1 type is still INTEGER */
+	"INTEGER",
+	&asn_OP_NativeInteger,
+	asn_generic_no_constraint,
 	asn_DEF_NativeInteger_tags,
 	sizeof(asn_DEF_NativeInteger_tags) / sizeof(asn_DEF_NativeInteger_tags[0]),
 	asn_DEF_NativeInteger_tags,	/* Same as above */

--- a/skeletons/NativeInteger.h
+++ b/skeletons/NativeInteger.h
@@ -20,6 +20,7 @@ extern "C" {
 #endif
 
 extern asn_TYPE_descriptor_t asn_DEF_NativeInteger;
+extern asn_TYPE_operation_t asn_OP_NativeInteger;
 
 asn_struct_free_f  NativeInteger_free;
 asn_struct_print_f NativeInteger_print;

--- a/skeletons/NativeReal.c
+++ b/skeletons/NativeReal.c
@@ -21,9 +21,7 @@
 static const ber_tlv_tag_t asn_DEF_NativeReal_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (9 << 2))
 };
-asn_TYPE_descriptor_t asn_DEF_NativeReal = {
-	"REAL",			/* The ASN.1 type is still REAL */
-	"REAL",
+asn_TYPE_operation_t asn_OP_NativeReal = {
 	NativeReal_free,
 	NativeReal_print,
 	NativeReal_compare,
@@ -46,7 +44,13 @@ asn_TYPE_descriptor_t asn_DEF_NativeReal = {
 	NativeReal_decode_uper,
 	NativeReal_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_NativeReal = {
+	"REAL",			/* The ASN.1 type is still REAL */
+	"REAL",
+	&asn_OP_NativeReal,
+	asn_generic_no_constraint,
 	asn_DEF_NativeReal_tags,
 	sizeof(asn_DEF_NativeReal_tags) / sizeof(asn_DEF_NativeReal_tags[0]),
 	asn_DEF_NativeReal_tags,	/* Same as above */

--- a/skeletons/NativeReal.h
+++ b/skeletons/NativeReal.h
@@ -18,6 +18,7 @@ extern "C" {
 #endif
 
 extern asn_TYPE_descriptor_t asn_DEF_NativeReal;
+extern asn_TYPE_operation_t asn_OP_NativeReal;
 
 asn_struct_free_f  NativeReal_free;
 asn_struct_print_f NativeReal_print;

--- a/skeletons/NumericString.c
+++ b/skeletons/NumericString.c
@@ -37,9 +37,7 @@ static asn_per_constraints_t asn_DEF_NumericString_per_constraints = {
 	asn_DEF_NumericString_v2c,
 	asn_DEF_NumericString_c2v
 };
-asn_TYPE_descriptor_t asn_DEF_NumericString = {
-	"NumericString",
-	"NumericString",
+asn_TYPE_operation_t asn_OP_NumericString = {
 	OCTET_STRING_free,
 	OCTET_STRING_print_utf8,   /* ASCII subset */
 	OCTET_STRING_compare,
@@ -62,7 +60,13 @@ asn_TYPE_descriptor_t asn_DEF_NumericString = {
 	OCTET_STRING_decode_uper,
 	OCTET_STRING_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_NumericString = {
+	"NumericString",
+	"NumericString",
+	&asn_OP_NumericString,
+	NumericString_constraint,
 	asn_DEF_NumericString_tags,
 	sizeof(asn_DEF_NumericString_tags)
 	  / sizeof(asn_DEF_NumericString_tags[0]) - 1,

--- a/skeletons/NumericString.h
+++ b/skeletons/NumericString.h
@@ -14,6 +14,7 @@ extern "C" {
 typedef OCTET_STRING_t NumericString_t;	/* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_NumericString;
+extern asn_TYPE_operation_t asn_OP_NumericString;
 
 asn_constr_check_f NumericString_constraint;
 

--- a/skeletons/OBJECT_IDENTIFIER.c
+++ b/skeletons/OBJECT_IDENTIFIER.c
@@ -15,9 +15,7 @@
 static const ber_tlv_tag_t asn_DEF_OBJECT_IDENTIFIER_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (6 << 2))
 };
-asn_TYPE_descriptor_t asn_DEF_OBJECT_IDENTIFIER = {
-	"OBJECT IDENTIFIER",
-	"OBJECT_IDENTIFIER",
+asn_TYPE_operation_t asn_OP_OBJECT_IDENTIFIER = {
 	ASN__PRIMITIVE_TYPE_free,
 	OBJECT_IDENTIFIER_print,
 	OCTET_STRING_compare,   /* Implemented in terms of a string comparison */
@@ -40,7 +38,13 @@ asn_TYPE_descriptor_t asn_DEF_OBJECT_IDENTIFIER = {
 	OCTET_STRING_decode_uper,
 	OCTET_STRING_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_OBJECT_IDENTIFIER = {
+	"OBJECT IDENTIFIER",
+	"OBJECT_IDENTIFIER",
+	&asn_OP_OBJECT_IDENTIFIER,
+	OBJECT_IDENTIFIER_constraint,
 	asn_DEF_OBJECT_IDENTIFIER_tags,
 	sizeof(asn_DEF_OBJECT_IDENTIFIER_tags)
 	    / sizeof(asn_DEF_OBJECT_IDENTIFIER_tags[0]),

--- a/skeletons/OBJECT_IDENTIFIER.h
+++ b/skeletons/OBJECT_IDENTIFIER.h
@@ -17,6 +17,7 @@ extern "C" {
 typedef ASN__PRIMITIVE_TYPE_t OBJECT_IDENTIFIER_t;
 
 extern asn_TYPE_descriptor_t asn_DEF_OBJECT_IDENTIFIER;
+extern asn_TYPE_operation_t asn_OP_OBJECT_IDENTIFIER;
 
 asn_struct_print_f OBJECT_IDENTIFIER_print;
 asn_constr_check_f OBJECT_IDENTIFIER_constraint;

--- a/skeletons/OCTET_STRING.c
+++ b/skeletons/OCTET_STRING.c
@@ -24,9 +24,7 @@ static asn_per_constraints_t asn_DEF_OCTET_STRING_constraints = {
 	{ APC_SEMI_CONSTRAINED, -1, -1, 0, 0 },
 	0, 0
 };
-asn_TYPE_descriptor_t asn_DEF_OCTET_STRING = {
-	"OCTET STRING",		/* Canonical name */
-	"OCTET_STRING",		/* XML tag name */
+asn_TYPE_operation_t asn_OP_OCTET_STRING = {
 	OCTET_STRING_free,
 	OCTET_STRING_print,	/* OCTET STRING generally means a non-ascii sequence */
 	OCTET_STRING_compare,
@@ -49,7 +47,13 @@ asn_TYPE_descriptor_t asn_DEF_OCTET_STRING = {
 	OCTET_STRING_decode_uper,	/* Unaligned PER decoder */
 	OCTET_STRING_encode_uper,	/* Unaligned PER encoder */
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_OCTET_STRING = {
+	"OCTET STRING",		/* Canonical name */
+	"OCTET_STRING",		/* XML tag name */
+	&asn_OP_OCTET_STRING,
+	asn_generic_no_constraint,
 	asn_DEF_OCTET_STRING_tags,
 	sizeof(asn_DEF_OCTET_STRING_tags)
 	  / sizeof(asn_DEF_OCTET_STRING_tags[0]),

--- a/skeletons/OCTET_STRING.h
+++ b/skeletons/OCTET_STRING.h
@@ -19,6 +19,7 @@ typedef struct OCTET_STRING {
 } OCTET_STRING_t;
 
 extern asn_TYPE_descriptor_t asn_DEF_OCTET_STRING;
+extern asn_TYPE_operation_t asn_OP_OCTET_STRING;
 
 asn_struct_free_f OCTET_STRING_free;
 asn_struct_print_f OCTET_STRING_print;

--- a/skeletons/OPEN_TYPE.c
+++ b/skeletons/OPEN_TYPE.c
@@ -8,6 +8,20 @@
 #include <per_opentype.h>
 #include <errno.h>
 
+asn_TYPE_operation_t asn_OP_OPEN_TYPE = {
+	OPEN_TYPE_free,
+	OPEN_TYPE_print,
+	OPEN_TYPE_compare,
+	OPEN_TYPE_constraint,
+	OPEN_TYPE_decode_ber,
+	OPEN_TYPE_encode_der,
+	OPEN_TYPE_decode_xer,
+	OPEN_TYPE_encode_xer,
+	0, 0,	/* No OER support, use "-gen-OER" to enable */
+	OPEN_TYPE_decode_uper,
+	OPEN_TYPE_encode_uper,
+	0,	/* Use generic outmost tag fetcher */
+};
 
 asn_dec_rval_t
 OPEN_TYPE_uper_get(asn_codec_ctx_t *opt_codec_ctx,

--- a/skeletons/OPEN_TYPE.h
+++ b/skeletons/OPEN_TYPE.h
@@ -22,6 +22,7 @@ extern "C" {
 #define OPEN_TYPE_decode_uper NULL
 #define OPEN_TYPE_encode_uper CHOICE_encode_uper
 
+extern asn_TYPE_operation_t asn_OP_OPEN_TYPE;
 
 /*
  * Decode an Open Type which is potentially constraiend

--- a/skeletons/ObjectDescriptor.c
+++ b/skeletons/ObjectDescriptor.c
@@ -12,9 +12,7 @@ static const ber_tlv_tag_t asn_DEF_ObjectDescriptor_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (7 << 2)),	/* [UNIVERSAL 7] IMPLICIT ... */
 	(ASN_TAG_CLASS_UNIVERSAL | (4 << 2))	/* ... OCTET STRING */
 };
-asn_TYPE_descriptor_t asn_DEF_ObjectDescriptor = {
-	"ObjectDescriptor",
-	"ObjectDescriptor",
+asn_TYPE_operation_t asn_OP_ObjectDescriptor = {
 	OCTET_STRING_free,
 	OCTET_STRING_print_utf8,   /* Treat as ASCII subset (it's not) */
 	OCTET_STRING_compare,
@@ -37,7 +35,13 @@ asn_TYPE_descriptor_t asn_DEF_ObjectDescriptor = {
 	OCTET_STRING_decode_uper,
 	OCTET_STRING_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_ObjectDescriptor = {
+	"ObjectDescriptor",
+	"ObjectDescriptor",
+	&asn_OP_ObjectDescriptor,
+	asn_generic_unknown_constraint,
 	asn_DEF_ObjectDescriptor_tags,
 	sizeof(asn_DEF_ObjectDescriptor_tags)
 	  / sizeof(asn_DEF_ObjectDescriptor_tags[0]) - 1,

--- a/skeletons/ObjectDescriptor.h
+++ b/skeletons/ObjectDescriptor.h
@@ -14,6 +14,7 @@ extern "C" {
 typedef GraphicString_t ObjectDescriptor_t;  /* Implemented via GraphicString */
 
 extern asn_TYPE_descriptor_t asn_DEF_ObjectDescriptor;
+extern asn_TYPE_operation_t asn_OP_ObjectDescriptor;
 
 #define ObjectDescriptor_free         OCTET_STRING_free
 #define ObjectDescriptor_print        OCTET_STRING_print_utf8

--- a/skeletons/PrintableString.c
+++ b/skeletons/PrintableString.c
@@ -47,9 +47,7 @@ static asn_per_constraints_t asn_DEF_PrintableString_per_constraints = {
 	asn_DEF_PrintableString_v2c,
 	asn_DEF_PrintableString_c2v
 };
-asn_TYPE_descriptor_t asn_DEF_PrintableString = {
-	"PrintableString",
-	"PrintableString",
+asn_TYPE_operation_t asn_OP_PrintableString = {
 	OCTET_STRING_free,
 	OCTET_STRING_print_utf8,	/* ASCII subset */
 	OCTET_STRING_compare,
@@ -72,7 +70,13 @@ asn_TYPE_descriptor_t asn_DEF_PrintableString = {
 	OCTET_STRING_decode_uper,
 	OCTET_STRING_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_PrintableString = {
+	"PrintableString",
+	"PrintableString",
+	&asn_OP_PrintableString,
+	PrintableString_constraint,
 	asn_DEF_PrintableString_tags,
 	sizeof(asn_DEF_PrintableString_tags)
 	  / sizeof(asn_DEF_PrintableString_tags[0]) - 1,

--- a/skeletons/PrintableString.h
+++ b/skeletons/PrintableString.h
@@ -14,6 +14,7 @@ extern "C" {
 typedef OCTET_STRING_t PrintableString_t;  /* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_PrintableString;
+extern asn_TYPE_operation_t asn_OP_PrintableString;
 
 asn_constr_check_f PrintableString_constraint;
 

--- a/skeletons/REAL.c
+++ b/skeletons/REAL.c
@@ -41,41 +41,45 @@ static volatile double real_zero GCC_NOTUSED = 0.0;
 static const ber_tlv_tag_t asn_DEF_REAL_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (9 << 2))
 };
-asn_TYPE_descriptor_t asn_DEF_REAL = {
-    "REAL",
-    "REAL",
-    ASN__PRIMITIVE_TYPE_free,
-    REAL_print,
-    REAL_compare,
-    asn_generic_no_constraint,
-    ber_decode_primitive,
-    der_encode_primitive,
-    REAL_decode_xer,
-    REAL_encode_xer,
+asn_TYPE_operation_t asn_OP_REAL = {
+	ASN__PRIMITIVE_TYPE_free,
+	REAL_print,
+	REAL_compare,
+	asn_generic_no_constraint,
+	ber_decode_primitive,
+	der_encode_primitive,
+	REAL_decode_xer,
+	REAL_encode_xer,
 #ifdef	ASN_DISABLE_OER_SUPPORT
-    0,
-    0,
+	0,
+	0,
 #else
-    0,
-    0,
+	0,
+	0,
 #endif  /* ASN_DISABLE_OER_SUPPORT */
 #ifdef	ASN_DISABLE_PER_SUPPORT
-    0,
-    0,
+	0,
+	0,
 #else
-    REAL_decode_uper,
-    REAL_encode_uper,
+	REAL_decode_uper,
+	REAL_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-    0,  /* Use generic outmost tag fetcher */
-    asn_DEF_REAL_tags,
-    sizeof(asn_DEF_REAL_tags) / sizeof(asn_DEF_REAL_tags[0]),
-    asn_DEF_REAL_tags, /* Same as above */
-    sizeof(asn_DEF_REAL_tags) / sizeof(asn_DEF_REAL_tags[0]),
-    0, /* No OER visible constraints */
-    0, /* No PER visible constraints */
-    0,
-    0, /* No members */
-    0  /* No specifics */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_REAL = {
+	"REAL",
+	"REAL",
+	&asn_OP_REAL,
+	asn_generic_no_constraint,
+	asn_DEF_REAL_tags,
+	sizeof(asn_DEF_REAL_tags) / sizeof(asn_DEF_REAL_tags[0]),
+	asn_DEF_REAL_tags, /* Same as above */
+	sizeof(asn_DEF_REAL_tags) / sizeof(asn_DEF_REAL_tags[0]),
+	0,	/* No OER visible constraints */
+	0,	/* No PER visible constraints */
+	0,
+	0,	/* No members */
+	0	/* No specifics */
 };
 
 typedef enum specialRealValue {

--- a/skeletons/REAL.h
+++ b/skeletons/REAL.h
@@ -15,6 +15,7 @@ extern "C" {
 typedef ASN__PRIMITIVE_TYPE_t REAL_t;
 
 extern asn_TYPE_descriptor_t asn_DEF_REAL;
+extern asn_TYPE_operation_t asn_OP_REAL;
 
 asn_struct_print_f REAL_print;
 asn_struct_compare_f REAL_compare;

--- a/skeletons/RELATIVE-OID.c
+++ b/skeletons/RELATIVE-OID.c
@@ -16,9 +16,7 @@
 static const ber_tlv_tag_t asn_DEF_RELATIVE_OID_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (13 << 2))
 };
-asn_TYPE_descriptor_t asn_DEF_RELATIVE_OID = {
-	"RELATIVE-OID",
-	"RELATIVE_OID",
+asn_TYPE_operation_t asn_OP_RELATIVE_OID = {
 	ASN__PRIMITIVE_TYPE_free,
 	RELATIVE_OID_print,
 	OCTET_STRING_compare,   /* Implemented in terms of opaque comparison */
@@ -41,7 +39,13 @@ asn_TYPE_descriptor_t asn_DEF_RELATIVE_OID = {
 	OCTET_STRING_decode_uper,
 	OCTET_STRING_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_RELATIVE_OID = {
+	"RELATIVE-OID",
+	"RELATIVE_OID",
+	&asn_OP_RELATIVE_OID,
+	asn_generic_no_constraint,
 	asn_DEF_RELATIVE_OID_tags,
 	sizeof(asn_DEF_RELATIVE_OID_tags)
 	    / sizeof(asn_DEF_RELATIVE_OID_tags[0]),

--- a/skeletons/RELATIVE-OID.h
+++ b/skeletons/RELATIVE-OID.h
@@ -15,6 +15,7 @@ extern "C" {
 typedef OBJECT_IDENTIFIER_t RELATIVE_OID_t;
 
 extern asn_TYPE_descriptor_t asn_DEF_RELATIVE_OID;
+extern asn_TYPE_operation_t asn_OP_RELATIVE_OID;
 
 asn_struct_print_f RELATIVE_OID_print;
 xer_type_decoder_f RELATIVE_OID_decode_xer;

--- a/skeletons/T61String.c
+++ b/skeletons/T61String.c
@@ -12,9 +12,7 @@ static const ber_tlv_tag_t asn_DEF_T61String_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (20 << 2)),	/* [UNIVERSAL 20] IMPLICIT ...*/
 	(ASN_TAG_CLASS_UNIVERSAL | (4 << 2))	/* ... OCTET STRING */
 };
-asn_TYPE_descriptor_t asn_DEF_T61String = {
-	"T61String",
-	"T61String",
+asn_TYPE_operation_t asn_OP_T61String = {
 	OCTET_STRING_free,
 	OCTET_STRING_print,         /* non-ascii string */
 	OCTET_STRING_compare,
@@ -37,7 +35,13 @@ asn_TYPE_descriptor_t asn_DEF_T61String = {
 	OCTET_STRING_decode_uper,
 	OCTET_STRING_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_T61String = {
+	"T61String",
+	"T61String",
+	&asn_OP_T61String,
+	asn_generic_unknown_constraint,
 	asn_DEF_T61String_tags,
 	sizeof(asn_DEF_T61String_tags)
 	  / sizeof(asn_DEF_T61String_tags[0]) - 1,

--- a/skeletons/T61String.h
+++ b/skeletons/T61String.h
@@ -14,6 +14,7 @@ extern "C" {
 typedef OCTET_STRING_t T61String_t;	/* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_T61String;
+extern asn_TYPE_operation_t asn_OP_T61String;
 
 #define T61String_free          OCTET_STRING_free
 #define T61String_print         OCTET_STRING_print

--- a/skeletons/TeletexString.c
+++ b/skeletons/TeletexString.c
@@ -12,9 +12,7 @@ static const ber_tlv_tag_t asn_DEF_TeletexString_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (20 << 2)),	/* [UNIVERSAL 20] IMPLICIT ...*/
 	(ASN_TAG_CLASS_UNIVERSAL | (4 << 2)),	/* ... OCTET STRING */
 };
-asn_TYPE_descriptor_t asn_DEF_TeletexString = {
-	"TeletexString",
-	"TeletexString",
+asn_TYPE_operation_t asn_OP_TeletexString = {
 	OCTET_STRING_free,
 	OCTET_STRING_print,         /* non-ascii string */
 	OCTET_STRING_compare,
@@ -37,7 +35,13 @@ asn_TYPE_descriptor_t asn_DEF_TeletexString = {
 	OCTET_STRING_decode_uper,
 	OCTET_STRING_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_TeletexString = {
+	"TeletexString",
+	"TeletexString",
+	&asn_OP_TeletexString,
+	asn_generic_unknown_constraint,
 	asn_DEF_TeletexString_tags,
 	sizeof(asn_DEF_TeletexString_tags)
 	  / sizeof(asn_DEF_TeletexString_tags[0]) - 1,

--- a/skeletons/TeletexString.h
+++ b/skeletons/TeletexString.h
@@ -14,6 +14,7 @@ extern "C" {
 typedef OCTET_STRING_t TeletexString_t;	/* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_TeletexString;
+extern asn_TYPE_operation_t asn_OP_TeletexString;
 
 #define TeletexString_free          OCTET_STRING_free
 #define TeletexString_print         OCTET_STRING_print

--- a/skeletons/UTCTime.c
+++ b/skeletons/UTCTime.c
@@ -28,9 +28,7 @@ static asn_per_constraints_t asn_DEF_UTCTime_constraints = {
         { APC_SEMI_CONSTRAINED, -1, -1, 0, 0 }, /* Size */
         0, 0
 };
-asn_TYPE_descriptor_t asn_DEF_UTCTime = {
-	"UTCTime",
-	"UTCTime",
+asn_TYPE_operation_t asn_OP_UTCTime = {
 	OCTET_STRING_free,
 	UTCTime_print,
 	OCTET_STRING_compare,   /* Does not deal with time zones. */
@@ -53,7 +51,13 @@ asn_TYPE_descriptor_t asn_DEF_UTCTime = {
 	OCTET_STRING_decode_uper,
 	OCTET_STRING_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_UTCTime = {
+	"UTCTime",
+	"UTCTime",
+	&asn_OP_UTCTime,
+	UTCTime_constraint,
 	asn_DEF_UTCTime_tags,
 	sizeof(asn_DEF_UTCTime_tags)
 	  / sizeof(asn_DEF_UTCTime_tags[0]) - 2,

--- a/skeletons/UTCTime.h
+++ b/skeletons/UTCTime.h
@@ -14,6 +14,7 @@ extern "C" {
 typedef OCTET_STRING_t UTCTime_t;  /* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_UTCTime;
+extern asn_TYPE_operation_t asn_OP_UTCTime;
 
 asn_struct_print_f UTCTime_print;
 asn_constr_check_f UTCTime_constraint;

--- a/skeletons/UTF8String.c
+++ b/skeletons/UTF8String.c
@@ -13,9 +13,7 @@ static const ber_tlv_tag_t asn_DEF_UTF8String_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (12 << 2)),	/* [UNIVERSAL 12] IMPLICIT ...*/
 	(ASN_TAG_CLASS_UNIVERSAL | (4 << 2)),	/* ... OCTET STRING */
 };
-asn_TYPE_descriptor_t asn_DEF_UTF8String = {
-	"UTF8String",
-	"UTF8String",
+asn_TYPE_operation_t asn_OP_UTF8String = {
 	OCTET_STRING_free,
 	UTF8String_print,
 	OCTET_STRING_compare,
@@ -38,7 +36,13 @@ asn_TYPE_descriptor_t asn_DEF_UTF8String = {
 	OCTET_STRING_decode_uper,
 	OCTET_STRING_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_UTF8String = {
+	"UTF8String",
+	"UTF8String",
+	&asn_OP_UTF8String,
+	UTF8String_constraint,      /* Check for invalid codes, etc. */
 	asn_DEF_UTF8String_tags,
 	sizeof(asn_DEF_UTF8String_tags)
 	  / sizeof(asn_DEF_UTF8String_tags[0]) - 1,

--- a/skeletons/UTF8String.h
+++ b/skeletons/UTF8String.h
@@ -14,6 +14,7 @@ extern "C" {
 typedef OCTET_STRING_t UTF8String_t;	/* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_UTF8String;
+extern asn_TYPE_operation_t asn_OP_UTF8String;
 
 asn_struct_print_f UTF8String_print;
 asn_constr_check_f UTF8String_constraint;

--- a/skeletons/UniversalString.c
+++ b/skeletons/UniversalString.c
@@ -23,9 +23,7 @@ static asn_per_constraints_t asn_DEF_UniversalString_per_constraints = {
 	{ APC_SEMI_CONSTRAINED, -1, -1, 0, 0 },
 	0, 0
 };
-asn_TYPE_descriptor_t asn_DEF_UniversalString = {
-	"UniversalString",
-	"UniversalString",
+asn_TYPE_operation_t asn_OP_UniversalString = {
 	OCTET_STRING_free,
 	UniversalString_print,      /* Convert into UTF8 and print */
 	OCTET_STRING_compare,
@@ -48,7 +46,13 @@ asn_TYPE_descriptor_t asn_DEF_UniversalString = {
 	OCTET_STRING_decode_uper,
 	OCTET_STRING_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_UniversalString = {
+	"UniversalString",
+	"UniversalString",
+	&asn_OP_UniversalString,
+	asn_generic_no_constraint,
 	asn_DEF_UniversalString_tags,
 	sizeof(asn_DEF_UniversalString_tags)
 	  / sizeof(asn_DEF_UniversalString_tags[0]) - 1,

--- a/skeletons/UniversalString.h
+++ b/skeletons/UniversalString.h
@@ -14,6 +14,7 @@ extern "C" {
 typedef OCTET_STRING_t UniversalString_t;  /* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_UniversalString;
+extern asn_TYPE_operation_t asn_OP_UniversalString;
 extern asn_OCTET_STRING_specifics_t asn_SPC_UniversalString_specs;
 
 asn_struct_print_f UniversalString_print;	/* Human-readable output */

--- a/skeletons/VideotexString.c
+++ b/skeletons/VideotexString.c
@@ -12,9 +12,7 @@ static const ber_tlv_tag_t asn_DEF_VideotexString_tags[] = {
 	(ASN_TAG_CLASS_UNIVERSAL | (21 << 2)),	/* [UNIVERSAL 21] IMPLICIT */
 	(ASN_TAG_CLASS_UNIVERSAL | (4 << 2))	/* ... OCTET STRING */
 };
-asn_TYPE_descriptor_t asn_DEF_VideotexString = {
-	"VideotexString",
-	"VideotexString",
+asn_TYPE_operation_t asn_OP_VideotexString = {
 	OCTET_STRING_free,
 	OCTET_STRING_print,         /* non-ascii string */
 	OCTET_STRING_compare,
@@ -37,7 +35,13 @@ asn_TYPE_descriptor_t asn_DEF_VideotexString = {
 	OCTET_STRING_decode_uper,    /* Implemented in terms of OCTET STRING */
 	OCTET_STRING_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_VideotexString = {
+	"VideotexString",
+	"VideotexString",
+	&asn_OP_VideotexString,
+	asn_generic_unknown_constraint,
 	asn_DEF_VideotexString_tags,
 	sizeof(asn_DEF_VideotexString_tags)
 	  / sizeof(asn_DEF_VideotexString_tags[0]) - 1,

--- a/skeletons/VideotexString.h
+++ b/skeletons/VideotexString.h
@@ -14,6 +14,7 @@ extern "C" {
 typedef OCTET_STRING_t VideotexString_t;  /* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_VideotexString;
+extern asn_TYPE_operation_t asn_OP_VideotexString;
 
 #define VideotexString_free         OCTET_STRING_free
 #define VideotexString_print        OCTET_STRING_print

--- a/skeletons/VisibleString.c
+++ b/skeletons/VisibleString.c
@@ -17,9 +17,7 @@ static asn_per_constraints_t asn_DEF_VisibleString_constraints = {
 	{ APC_SEMI_CONSTRAINED, -1, -1, 0, 0 },	/* Size */
 	0, 0
 };
-asn_TYPE_descriptor_t asn_DEF_VisibleString = {
-	"VisibleString",
-	"VisibleString",
+asn_TYPE_operation_t asn_OP_VisibleString = {
 	OCTET_STRING_free,
 	OCTET_STRING_print_utf8,   /* ASCII subset */
 	OCTET_STRING_compare,
@@ -42,7 +40,13 @@ asn_TYPE_descriptor_t asn_DEF_VisibleString = {
 	OCTET_STRING_decode_uper,
 	OCTET_STRING_encode_uper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
-	0, /* Use generic outmost tag fetcher */
+	0	/* Use generic outmost tag fetcher */
+};
+asn_TYPE_descriptor_t asn_DEF_VisibleString = {
+	"VisibleString",
+	"VisibleString",
+	&asn_OP_VisibleString,
+	VisibleString_constraint,
 	asn_DEF_VisibleString_tags,
 	sizeof(asn_DEF_VisibleString_tags)
 	  / sizeof(asn_DEF_VisibleString_tags[0]) - 1,

--- a/skeletons/VisibleString.h
+++ b/skeletons/VisibleString.h
@@ -14,6 +14,7 @@ extern "C" {
 typedef OCTET_STRING_t VisibleString_t;  /* Implemented via OCTET STRING */
 
 extern asn_TYPE_descriptor_t asn_DEF_VisibleString;
+extern asn_TYPE_operation_t asn_OP_VisibleString;
 
 asn_constr_check_f VisibleString_constraint;
 

--- a/skeletons/ber_decoder.c
+++ b/skeletons/ber_decoder.c
@@ -51,7 +51,7 @@ ber_decode(asn_codec_ctx_t *opt_codec_ctx,
 	/*
 	 * Invoke type-specific decoder.
 	 */
-	return type_descriptor->ber_decoder(opt_codec_ctx, type_descriptor,
+	return type_descriptor->op->ber_decoder(opt_codec_ctx, type_descriptor,
 		struct_ptr,	/* Pointer to the destination structure */
 		ptr, size,	/* Buffer and its size */
 		0		/* Default tag mode is 0 */

--- a/skeletons/constr_CHOICE.h
+++ b/skeletons/constr_CHOICE.h
@@ -13,27 +13,27 @@ extern "C" {
 #endif
 
 typedef const struct asn_CHOICE_specifics_s {
-    /*
-     * Target structure description.
-     */
-    unsigned struct_size;       /* Size of the target structure. */
-    unsigned ctx_offset;        /* Offset of the asn_codec_ctx_t member */
-    unsigned pres_offset;       /* Identifier of the present member */
-    unsigned pres_size;         /* Size of the identifier (enum) */
+	/*
+	 * Target structure description.
+	 */
+	unsigned struct_size;       /* Size of the target structure. */
+	unsigned ctx_offset;        /* Offset of the asn_codec_ctx_t member */
+	unsigned pres_offset;       /* Identifier of the present member */
+	unsigned pres_size;         /* Size of the identifier (enum) */
 
-    /*
-     * Tags to members mapping table.
-     */
-    const asn_TYPE_tag2member_t *tag2el;
-    unsigned tag2el_count;
+	/*
+	 * Tags to members mapping table.
+	 */
+	const asn_TYPE_tag2member_t *tag2el;
+	unsigned tag2el_count;
 
-    /* Canonical ordering of CHOICE elements, for PER */
-    const unsigned *canonical_order;
+	/* Canonical ordering of CHOICE elements, for PER */
+	const unsigned *canonical_order;
 
-    /*
-     * Extensions-related stuff.
-     */
-    signed ext_start; /* First member of extensions, or -1 */
+	/*
+	 * Extensions-related stuff.
+	 */
+	signed ext_start; /* First member of extensions, or -1 */
 } asn_CHOICE_specifics_t;
 
 /*
@@ -50,6 +50,7 @@ xer_type_encoder_f CHOICE_encode_xer;
 per_type_decoder_f CHOICE_decode_uper;
 per_type_encoder_f CHOICE_encode_uper;
 asn_outmost_tag_f CHOICE_outmost_tag;
+extern asn_TYPE_operation_t asn_OP_CHOICE;
 
 /*
  * Return the 1-based choice variant presence index.

--- a/skeletons/constr_SEQUENCE.c
+++ b/skeletons/constr_SEQUENCE.c
@@ -410,7 +410,7 @@ SEQUENCE_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
 		/*
 		 * Invoke the member fetch routine according to member's type
 		 */
-		rval = elements[edx].type->ber_decoder(opt_codec_ctx,
+		rval = elements[edx].type->op->ber_decoder(opt_codec_ctx,
 				elements[edx].type,
 				memb_ptr2, ptr, LEFT,
 				elements[edx].tag_mode);
@@ -538,7 +538,7 @@ SEQUENCE_encode_der(asn_TYPE_descriptor_t *td,
 		} else {
 			memb_ptr = (void *)((char *)sptr + elm->memb_offset);
 		}
-		erval = elm->type->der_encoder(elm->type, memb_ptr,
+		erval = elm->type->op->der_encoder(elm->type, memb_ptr,
 			elm->tag_mode, elm->tag,
 			0, 0);
 		if(erval.encoded == -1)
@@ -573,7 +573,7 @@ SEQUENCE_encode_der(asn_TYPE_descriptor_t *td,
 		} else {
 			memb_ptr = (void *)((char *)sptr + elm->memb_offset);
 		}
-		tmperval = elm->type->der_encoder(elm->type, memb_ptr,
+		tmperval = elm->type->op->der_encoder(elm->type, memb_ptr,
 			elm->tag_mode, elm->tag,
 			cb, app_key);
 		if(tmperval.encoded == -1)
@@ -673,7 +673,7 @@ SEQUENCE_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
 			}
 
 			/* Invoke the inner type decoder, m.b. multiple times */
-			tmprval = elm->type->xer_decoder(opt_codec_ctx,
+			tmprval = elm->type->op->xer_decoder(opt_codec_ctx,
 					elm->type, memb_ptr2, elm->name,
 					buf_ptr, size);
 			XER_ADVANCE(tmprval.consumed);
@@ -776,8 +776,8 @@ SEQUENCE_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
 				/*
 				 * Search which member corresponds to this tag.
 				 */
-                size_t n;
-                size_t edx_end = edx + elements[edx].optional + 1;
+				size_t n;
+				size_t edx_end = edx + elements[edx].optional + 1;
 				if(edx_end > td->elements_count)
 					edx_end = td->elements_count;
 				for(n = edx; n < edx_end; n++) {
@@ -885,7 +885,7 @@ SEQUENCE_encode_xer(asn_TYPE_descriptor_t *td, void *sptr,
 		ASN__CALLBACK3("<", 1, mname, mlen, ">", 1);
 
 		/* Print the member itself */
-		tmper = elm->type->xer_encoder(elm->type, memb_ptr,
+		tmper = elm->type->op->xer_encoder(elm->type, memb_ptr,
 			ilevel + 1, flags, cb, app_key);
 		if(tmper.encoded == -1) return tmper;
 
@@ -937,7 +937,7 @@ SEQUENCE_print(asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
 			return -1;
 
 		/* Print the member itself */
-		ret = elm->type->print_struct(elm->type, memb_ptr, ilevel + 1,
+		ret = elm->type->op->print_struct(elm->type, memb_ptr, ilevel + 1,
 			cb, app_key);
 		if(ret) return ret;
 	}
@@ -1031,7 +1031,7 @@ asn_dec_rval_t
 SEQUENCE_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
                      const asn_per_constraints_t *constraints, void **sptr,
                      asn_per_data_t *pd) {
-    asn_SEQUENCE_specifics_t *specs = (asn_SEQUENCE_specifics_t *)td->specifics;
+	asn_SEQUENCE_specifics_t *specs = (asn_SEQUENCE_specifics_t *)td->specifics;
 	void *st = *sptr;	/* Target structure. */
 	int extpresent;		/* Extension additions are present */
 	uint8_t *opres;		/* Presence of optional root members */
@@ -1082,7 +1082,7 @@ SEQUENCE_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
 	 */
 	for(edx = 0; edx < td->elements_count; edx++) {
 		asn_TYPE_member_t *elm = &td->elements[edx];
-        void *memb_ptr;		/* Pointer to the member */
+		void *memb_ptr;		/* Pointer to the member */
 		void **memb_ptr2;	/* Pointer to that pointer */
 
 		if(IN_EXTENSION_GROUP(specs, edx))
@@ -1121,13 +1121,13 @@ SEQUENCE_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
 		/* Fetch the member from the stream */
 		ASN_DEBUG("Decoding member \"%s\" in %s", elm->name, td->name);
 
-        if((elm->flags & ATF_OPEN_TYPE) && elm->type_selector) {
-            rv = OPEN_TYPE_uper_get(opt_codec_ctx, td, st, elm, pd);
-        } else {
-            rv = elm->type->uper_decoder(opt_codec_ctx, elm->type,
-                                        elm->per_constraints, memb_ptr2, pd);
-        }
-        if(rv.code != RC_OK) {
+		if((elm->flags & ATF_OPEN_TYPE) && elm->type_selector) {
+			rv = OPEN_TYPE_uper_get(opt_codec_ctx, td, st, elm, pd);
+		} else {
+            		rv = elm->type->op->uper_decoder(opt_codec_ctx, elm->type,
+					elm->per_constraints, memb_ptr2, pd);
+		}
+		if(rv.code != RC_OK) {
 			ASN_DEBUG("Failed decode %s in %s",
 				elm->name, td->name);
 			FREEMEM(opres);
@@ -1304,7 +1304,7 @@ asn_enc_rval_t
 SEQUENCE_encode_uper(asn_TYPE_descriptor_t *td,
                      const asn_per_constraints_t *constraints, void *sptr,
                      asn_per_outp_t *po) {
-    asn_SEQUENCE_specifics_t *specs
+	asn_SEQUENCE_specifics_t *specs
 		= (asn_SEQUENCE_specifics_t *)td->specifics;
 	asn_enc_rval_t er;
 	int n_extensions;
@@ -1327,7 +1327,7 @@ SEQUENCE_encode_uper(asn_TYPE_descriptor_t *td,
 	 */
 	if(specs->ext_before >= 0) {
 		n_extensions = SEQUENCE_handle_extensions(td, sptr, 0, 0);
-        if(n_extensions < 0)
+		if(n_extensions < 0)
 			ASN__ENCODE_FAILED;
 		if(per_put_few_bits(po, n_extensions ? 1 : 0, 1))
 			ASN__ENCODE_FAILED;
@@ -1405,7 +1405,7 @@ SEQUENCE_encode_uper(asn_TYPE_descriptor_t *td,
 			continue;
 
 		ASN_DEBUG("Encoding %s->%s", td->name, elm->name);
-		er = elm->type->uper_encoder(elm->type, elm->per_constraints,
+		er = elm->type->op->uper_encoder(elm->type, elm->per_constraints,
 			*memb_ptr2, po);
 		if(er.encoded == -1)
 			return er;
@@ -1460,10 +1460,36 @@ SEQUENCE_compare(const asn_TYPE_descriptor_t *td, const void *aptr,
             bmemb = (const void *)((const char *)bptr + elm->memb_offset);
 		}
 
-        ret = elm->type->compare_struct(elm->type, amemb, bmemb);
+        ret = elm->type->op->compare_struct(elm->type, amemb, bmemb);
         if(ret != 0) return ret;
     }
 
     return 0;
 }
+
+asn_TYPE_operation_t asn_OP_SEQUENCE = {
+	SEQUENCE_free,
+	SEQUENCE_print,
+	SEQUENCE_compare,
+	SEQUENCE_constraint,
+	SEQUENCE_decode_ber,
+	SEQUENCE_encode_der,
+	SEQUENCE_decode_xer,
+	SEQUENCE_encode_xer,
+#ifdef	ASN_DISABLE_OER_SUPPORT
+	0,
+	0,
+#else
+	SEQUENCE_decode_oer,
+	SEQUENCE_encode_oer,
+#endif  /* ASN_DISABLE_OER_SUPPORT */
+#ifdef ASN_DISABLE_PER_SUPPORT
+	0,
+	0,
+#else
+	SEQUENCE_decode_uper,
+	SEQUENCE_encode_uper,
+#endif /* ASN_DISABLE_PER_SUPPORT */
+	0	/* Use generic outmost tag fetcher */
+};
 

--- a/skeletons/constr_SEQUENCE.h
+++ b/skeletons/constr_SEQUENCE.h
@@ -22,21 +22,21 @@ typedef const struct asn_SEQUENCE_specifics_s {
 	 * Tags to members mapping table (sorted).
 	 */
 	const asn_TYPE_tag2member_t *tag2el;
-    unsigned tag2el_count;
+	unsigned tag2el_count;
 
-    /*
+	/*
 	 * Optional members of the extensions root (roms) or additions (aoms).
 	 * Meaningful for PER.
 	 */
-    const int *oms;         /* Optional MemberS */
-    unsigned roms_count;    /* Root optional members count */
-    unsigned aoms_count;    /* Additions optional members count */
+	const int *oms;         /* Optional MemberS */
+	unsigned roms_count;    /* Root optional members count */
+	unsigned aoms_count;    /* Additions optional members count */
 
-    /*
+	/*
 	 * Description of an extensions group.
 	 */
-    signed ext_after;       /* Extensions start after this member */
-    signed ext_before;      /* Extensions stop before this member */
+	signed ext_after;       /* Extensions start after this member */
+	signed ext_before;      /* Extensions stop before this member */
 } asn_SEQUENCE_specifics_t;
 
 
@@ -55,6 +55,7 @@ oer_type_decoder_f SEQUENCE_decode_oer;
 oer_type_encoder_f SEQUENCE_encode_oer;
 per_type_decoder_f SEQUENCE_decode_uper;
 per_type_encoder_f SEQUENCE_encode_uper;
+extern asn_TYPE_operation_t asn_OP_SEQUENCE;
 
 #ifdef __cplusplus
 }

--- a/skeletons/constr_SEQUENCE_OF.c
+++ b/skeletons/constr_SEQUENCE_OF.c
@@ -29,7 +29,7 @@ SEQUENCE_OF_encode_der(asn_TYPE_descriptor_t *td, void *ptr,
 	for(edx = 0; edx < list->count; edx++) {
 		void *memb_ptr = list->array[edx];
 		if(!memb_ptr) continue;
-		erval = elm->type->der_encoder(elm->type, memb_ptr,
+		erval = elm->type->op->der_encoder(elm->type, memb_ptr,
 			0, elm->tag,
 			0, 0);
 		if(erval.encoded == -1)
@@ -63,7 +63,7 @@ SEQUENCE_OF_encode_der(asn_TYPE_descriptor_t *td, void *ptr,
 	for(edx = 0; edx < list->count; edx++) {
 		void *memb_ptr = list->array[edx];
 		if(!memb_ptr) continue;
-		erval = elm->type->der_encoder(elm->type, memb_ptr,
+		erval = elm->type->op->der_encoder(elm->type, memb_ptr,
 			0, elm->tag,
 			cb, app_key);
 		if(erval.encoded == -1)
@@ -115,7 +115,7 @@ SEQUENCE_OF_encode_xer(asn_TYPE_descriptor_t *td, void *sptr,
 			ASN__CALLBACK3("<", 1, mname, mlen, ">", 1);
 		}
 
-		tmper = elm->type->xer_encoder(elm->type, memb_ptr,
+		tmper = elm->type->op->xer_encoder(elm->type, memb_ptr,
 				ilevel + 1, flags, cb, app_key);
 		if(tmper.encoded == -1) return tmper;
                 if(tmper.encoded == 0 && specs->as_XMLValueList) {
@@ -144,7 +144,7 @@ asn_enc_rval_t
 SEQUENCE_OF_encode_uper(asn_TYPE_descriptor_t *td,
                         const asn_per_constraints_t *constraints, void *sptr,
                         asn_per_outp_t *po) {
-    asn_anonymous_sequence_ *list;
+	asn_anonymous_sequence_ *list;
 	const asn_per_constraint_t *ct;
 	asn_enc_rval_t er;
 	asn_TYPE_member_t *elm = td->elements;
@@ -197,7 +197,7 @@ SEQUENCE_OF_encode_uper(asn_TYPE_descriptor_t *td,
 		while(mayEncode--) {
 			void *memb_ptr = list->array[seq++];
 			if(!memb_ptr) ASN__ENCODE_FAILED;
-			er = elm->type->uper_encoder(elm->type,
+			er = elm->type->op->uper_encoder(elm->type,
 				elm->per_constraints, memb_ptr, po);
 			if(er.encoded == -1)
 				ASN__ENCODE_FAILED;
@@ -206,4 +206,30 @@ SEQUENCE_OF_encode_uper(asn_TYPE_descriptor_t *td,
 
 	ASN__ENCODED_OK(er);
 }
+
+asn_TYPE_operation_t asn_OP_SEQUENCE_OF = {
+	SEQUENCE_OF_free,
+	SEQUENCE_OF_print,
+	SEQUENCE_OF_compare,
+	SEQUENCE_OF_constraint,
+	SEQUENCE_OF_decode_ber,
+	SEQUENCE_OF_encode_der,
+	SEQUENCE_OF_decode_xer,
+	SEQUENCE_OF_encode_xer,
+#ifdef	ASN_DISABLE_OER_SUPPORT
+	0,
+	0,
+#else
+	0,
+	0,
+#endif  /* ASN_DISABLE_OER_SUPPORT */
+#ifdef ASN_DISABLE_PER_SUPPORT
+	0,
+	0,
+#else
+	SEQUENCE_OF_decode_uper,
+	SEQUENCE_OF_encode_uper,
+#endif /* ASN_DISABLE_PER_SUPPORT */
+	0	/* Use generic outmost tag fetcher */
+};
 

--- a/skeletons/constr_SEQUENCE_OF.h
+++ b/skeletons/constr_SEQUENCE_OF.h
@@ -18,7 +18,7 @@ extern "C" {
  */
 #define	SEQUENCE_OF_free	SET_OF_free
 #define	SEQUENCE_OF_print	SET_OF_print
-#define	SEQUENCE_OF_compare SET_OF_compare
+#define	SEQUENCE_OF_compare	SET_OF_compare
 #define	SEQUENCE_OF_constraint	SET_OF_constraint
 #define	SEQUENCE_OF_decode_ber	SET_OF_decode_ber
 #define	SEQUENCE_OF_decode_xer	SET_OF_decode_xer
@@ -26,6 +26,7 @@ extern "C" {
 der_type_encoder_f SEQUENCE_OF_encode_der;
 xer_type_encoder_f SEQUENCE_OF_encode_xer;
 per_type_encoder_f SEQUENCE_OF_encode_uper;
+extern asn_TYPE_operation_t asn_OP_SEQUENCE_OF;
 
 #ifdef __cplusplus
 }

--- a/skeletons/constr_SEQUENCE_oer.c
+++ b/skeletons/constr_SEQUENCE_oer.c
@@ -201,7 +201,7 @@ SEQUENCE_decode_oer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
                     memb_ptr2 = &memb_tmpptr; /* Ensure remains in scope! */
                 }
 
-                rval = elm->type->oer_decoder(opt_codec_ctx, elm->type,
+                rval = elm->type->op->oer_decoder(opt_codec_ctx, elm->type,
                                               elm->oer_constraints, memb_ptr2,
                                               ptr, size);
             }
@@ -458,11 +458,11 @@ SEQUENCE_encode_oer(asn_TYPE_descriptor_t *td,
             /* Mandatory element is missing */
             ASN__ENCODE_FAILED;
         }
-        if(!elm->type->oer_encoder) {
+        if(!elm->type->op->oer_encoder) {
             ASN_DEBUG("OER encoder is not defined for type %s", elm->type->name);
             ASN__ENCODE_FAILED;
         }
-        er = elm->type->oer_encoder(elm->type, elm->oer_constraints, memb_ptr,
+        er = elm->type->op->oer_encoder(elm->type, elm->oer_constraints, memb_ptr,
                                     cb, app_key);
         if(er.encoded == -1) {
             ASN_DEBUG("... while encoding %s member \"%s\"\n", td->name,
@@ -517,7 +517,7 @@ SEQUENCE_encode_oer(asn_TYPE_descriptor_t *td,
             void *memb_ptr = element_ptr(sptr, elm);
 
             if(memb_ptr) {
-                asn_enc_rval_t er = elm->type->oer_encoder(
+                asn_enc_rval_t er = elm->type->op->oer_encoder(
                     elm->type, elm->oer_constraints, memb_ptr, cb, app_key);
                 if(er.encoded == -1) {
                     return er;

--- a/skeletons/constr_SET.c
+++ b/skeletons/constr_SET.c
@@ -296,7 +296,7 @@ SET_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
 		/*
 		 * Invoke the member fetch routine according to member's type
 		 */
-		rval = elements[edx].type->ber_decoder(opt_codec_ctx,
+		rval = elements[edx].type->op->ber_decoder(opt_codec_ctx,
 				elements[edx].type,
 				memb_ptr2, ptr, LEFT,
 				elements[edx].tag_mode);
@@ -488,7 +488,7 @@ SET_encode_der(asn_TYPE_descriptor_t *td,
 		} else {
 			memb_ptr = (void *)((char *)sptr + elm->memb_offset);
 		}
-		tmper = elm->type->der_encoder(elm->type, memb_ptr,
+		tmper = elm->type->op->der_encoder(elm->type, memb_ptr,
 			elm->tag_mode, elm->tag,
 			0, 0);
 		if(tmper.encoded == -1)
@@ -555,7 +555,7 @@ SET_encode_der(asn_TYPE_descriptor_t *td,
 		} else {
 			memb_ptr = (void *)((char *)sptr + elm->memb_offset);
 		}
-		tmper = elm->type->der_encoder(elm->type, memb_ptr,
+		tmper = elm->type->op->der_encoder(elm->type, memb_ptr,
 			elm->tag_mode, elm->tag,
 			cb, app_key);
 		if(tmper.encoded == -1)
@@ -658,7 +658,7 @@ SET_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
 			}
 
 			/* Invoke the inner type decoder, m.b. multiple times */
-			tmprval = elm->type->xer_decoder(opt_codec_ctx,
+			tmprval = elm->type->op->xer_decoder(opt_codec_ctx,
 					elm->type, memb_ptr2, elm->name,
 					buf_ptr, size);
 			XER_ADVANCE(tmprval.consumed);
@@ -846,7 +846,7 @@ SET_encode_xer(asn_TYPE_descriptor_t *td, void *sptr,
 		ASN__CALLBACK3("<", 1, mname, mlen, ">", 1);
 
 		/* Print the member itself */
-		tmper = elm->type->xer_encoder(elm->type, memb_ptr,
+		tmper = elm->type->op->xer_encoder(elm->type, memb_ptr,
 				ilevel + 1, flags, cb, app_key);
 		if(tmper.encoded == -1) return tmper;
 
@@ -898,7 +898,7 @@ SET_print(asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
 			return -1;
 
 		/* Print the member itself */
-		ret = elm->type->print_struct(elm->type, memb_ptr, ilevel + 1,
+		ret = elm->type->op->print_struct(elm->type, memb_ptr, ilevel + 1,
 			cb, app_key);
 		if(ret) return ret;
 	}
@@ -911,7 +911,7 @@ SET_print(asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
 
 void
 SET_free(const asn_TYPE_descriptor_t *td, void *ptr, int contents_only) {
-    size_t edx;
+	size_t edx;
 
 	if(!td || !ptr)
 		return;
@@ -997,7 +997,7 @@ SET_compare(const asn_TYPE_descriptor_t *td, const void *aptr,
 		asn_TYPE_member_t *elm = &td->elements[edx];
 		const void *amemb;
 		const void *bmemb;
-        int ret;
+		int ret;
 
 		if(elm->flags & ATF_POINTER) {
             amemb =
@@ -1015,10 +1015,25 @@ SET_compare(const asn_TYPE_descriptor_t *td, const void *aptr,
             bmemb = (const void *)((const char *)bptr + elm->memb_offset);
 		}
 
-        ret = elm->type->compare_struct(elm->type, amemb, bmemb);
+        ret = elm->type->op->compare_struct(elm->type, amemb, bmemb);
         if(ret != 0) return ret;
     }
 
     return 0;
 }
+
+
+asn_TYPE_operation_t asn_OP_SET = {
+	SET_free,
+	SET_print,
+	SET_compare,
+	SET_constraint,
+	SET_decode_ber,
+	SET_encode_der,
+	SET_decode_xer,
+	SET_encode_xer,
+	0,	/* SET_decode_uper */
+	0,	/* SET_encode_uper */
+	0	/* Use generic outmost tag fetcher */
+};
 

--- a/skeletons/constr_SET.h
+++ b/skeletons/constr_SET.h
@@ -13,33 +13,33 @@ extern "C" {
 
 
 typedef const struct asn_SET_specifics_s {
-    /*
-     * Target structure description.
-     */
-    unsigned struct_size;       /* Size of the target structure. */
-    unsigned ctx_offset;        /* Offset of the asn_struct_ctx_t member */
-    unsigned pres_offset;       /* Offset of _presence_map member */
+	/*
+	 * Target structure description.
+	 */
+	unsigned struct_size;       /* Size of the target structure. */
+	unsigned ctx_offset;        /* Offset of the asn_struct_ctx_t member */
+	unsigned pres_offset;       /* Offset of _presence_map member */
 
-    /*
-     * Tags to members mapping table (sorted).
-     * Sometimes suitable for DER encoding (untagged CHOICE is present);
-     * if so, tag2el_count will be greater than td->elements_count.
-     */
-    const asn_TYPE_tag2member_t *tag2el;
-    unsigned tag2el_count;
+	/*
+	 * Tags to members mapping table (sorted).
+	 * Sometimes suitable for DER encoding (untagged CHOICE is present);
+	 * if so, tag2el_count will be greater than td->elements_count.
+	 */
+	const asn_TYPE_tag2member_t *tag2el;
+	unsigned tag2el_count;
 
-    /*
-     * Tags to members mapping table, second edition.
-     * Suitable for CANONICAL-XER encoding.
-     */
-    const asn_TYPE_tag2member_t *tag2el_cxer;
-    unsigned tag2el_cxer_count;
+	/*
+	 * Tags to members mapping table, second edition.
+	 * Suitable for CANONICAL-XER encoding.
+	 */
+	const asn_TYPE_tag2member_t *tag2el_cxer;
+	unsigned tag2el_cxer_count;
 
-    /*
-     * Extensions-related stuff.
-     */
-    int extensible;                             /* Whether SET is extensible */
-    const unsigned int *_mandatory_elements;    /* Bitmask of mandatory ones */
+	/*
+	 * Extensions-related stuff.
+	 */
+	int extensible;                             /* Whether SET is extensible */
+	const unsigned int *_mandatory_elements;    /* Bitmask of mandatory ones */
 } asn_SET_specifics_t;
 
 /*
@@ -55,6 +55,7 @@ xer_type_decoder_f SET_decode_xer;
 xer_type_encoder_f SET_encode_xer;
 per_type_decoder_f SET_decode_uper;
 per_type_encoder_f SET_encode_uper;
+extern asn_TYPE_operation_t asn_OP_SET;
 
 /***********************
  * Some handy helpers. *

--- a/skeletons/constr_SET_OF.c
+++ b/skeletons/constr_SET_OF.c
@@ -205,7 +205,7 @@ SET_OF_decode_ber(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
 		/*
 		 * Invoke the member fetch routine according to member's type
 		 */
-		rval = elm->type->ber_decoder(opt_codec_ctx,
+		rval = elm->type->op->ber_decoder(opt_codec_ctx,
 				elm->type, &ctx->ptr, ptr, LEFT, 0);
 		ASN_DEBUG("In %s SET OF %s code %d consumed %d",
 			td->name, elm->type->name,
@@ -315,7 +315,7 @@ SET_OF_encode_der(asn_TYPE_descriptor_t *td, void *ptr,
 	asn_app_consume_bytes_f *cb, void *app_key) {
 	asn_TYPE_member_t *elm = td->elements;
 	asn_TYPE_descriptor_t *elm_type = elm->type;
-	der_type_encoder_f *der_encoder = elm_type->der_encoder;
+	der_type_encoder_f *der_encoder = elm_type->op->der_encoder;
 	asn_anonymous_set_ *list = _A_SET_FROM_VOID(ptr);
 	size_t computed_size = 0;
 	ssize_t encoding_size = 0;
@@ -526,7 +526,7 @@ SET_OF_decode_xer(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
 
 			/* Invoke the inner type decoder, m.b. multiple times */
 			ASN_DEBUG("XER/SET OF element [%s]", elm_tag);
-			tmprval = element->type->xer_decoder(opt_codec_ctx,
+			tmprval = element->type->op->xer_decoder(opt_codec_ctx,
 					element->type, &ctx->ptr, elm_tag,
 					buf_ptr, size);
 			if(tmprval.code == RC_OK) {
@@ -697,7 +697,7 @@ SET_OF_encode_xer(asn_TYPE_descriptor_t *td, void *sptr,
 
 		if(!xcan && specs->as_XMLValueList == 1)
 			ASN__TEXT_INDENT(1, ilevel + 1);
-		tmper = elm->type->xer_encoder(elm->type, memb_ptr,
+		tmper = elm->type->op->xer_encoder(elm->type, memb_ptr,
 				ilevel + (specs->as_XMLValueList != 2),
 				flags, cb, app_key);
 		if(tmper.encoded == -1) {
@@ -776,7 +776,7 @@ SET_OF_print(asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
 
 		_i_INDENT(1);
 
-		ret = elm->type->print_struct(elm->type, memb_ptr,
+		ret = elm->type->op->print_struct(elm->type, memb_ptr,
 			ilevel + 1, cb, app_key);
 		if(ret) return ret;
 	}
@@ -868,7 +868,7 @@ asn_dec_rval_t
 SET_OF_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
                    const asn_per_constraints_t *constraints, void **sptr,
                    asn_per_data_t *pd) {
-    asn_dec_rval_t rv;
+	asn_dec_rval_t rv;
         asn_SET_OF_specifics_t *specs = (asn_SET_OF_specifics_t *)td->specifics;
 	asn_TYPE_member_t *elm = td->elements;	/* Single one */
 	void *st = *sptr;
@@ -924,7 +924,7 @@ SET_OF_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
 		for(i = 0; i < nelems; i++) {
 			void *ptr = 0;
 			ASN_DEBUG("SET OF %s decoding", elm->type->name);
-			rv = elm->type->uper_decoder(opt_codec_ctx, elm->type,
+			rv = elm->type->op->uper_decoder(opt_codec_ctx, elm->type,
 				elm->per_constraints, &ptr, pd);
 			ASN_DEBUG("%s SET OF %s decoded %d, %p",
 				td->name, elm->type->name, rv.code, ptr);
@@ -956,9 +956,31 @@ SET_OF_decode_uper(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
 int
 SET_OF_compare(const asn_TYPE_descriptor_t *td, const void *aptr,
                const void *bptr) {
-    (void)td;
-    (void)aptr;
-    (void)bptr;
-    /* Not implemented yet. */
-    return 0;
+	(void)td;
+	(void)aptr;
+	(void)bptr;
+	/* Not implemented yet. */
+	return 0;
 }
+
+
+asn_TYPE_operation_t asn_OP_SET_OF = {
+	SET_OF_free,
+	SET_OF_print,
+	SET_OF_compare,
+	SET_OF_constraint,
+	SET_OF_decode_ber,
+	SET_OF_encode_der,
+	SET_OF_decode_xer,
+	SET_OF_encode_xer,
+	0,
+	0,
+#ifdef ASN_DISABLE_PER_SUPPORT
+	0,
+	0,
+#else
+	SET_OF_decode_uper,
+	0,	/* SET_OF_encode_uper */
+#endif /* ASN_DISABLE_PER_SUPPORT */
+	0	/* Use generic outmost tag fetcher */
+};

--- a/skeletons/constr_SET_OF.h
+++ b/skeletons/constr_SET_OF.h
@@ -35,6 +35,7 @@ xer_type_decoder_f SET_OF_decode_xer;
 xer_type_encoder_f SET_OF_encode_xer;
 per_type_decoder_f SET_OF_decode_uper;
 per_type_encoder_f SET_OF_encode_uper;
+extern asn_TYPE_operation_t asn_OP_SET_OF;
 
 #ifdef __cplusplus
 }

--- a/skeletons/constr_TYPE.c
+++ b/skeletons/constr_TYPE.c
@@ -26,7 +26,7 @@ asn_TYPE_outmost_tag(const asn_TYPE_descriptor_t *type_descriptor,
 	if(type_descriptor->tags_count)
 		return type_descriptor->tags[0];
 
-	return type_descriptor->outmost_tag(type_descriptor, struct_ptr, 0, 0);
+	return type_descriptor->op->outmost_tag(type_descriptor, struct_ptr, 0, 0);
 }
 
 /*
@@ -41,7 +41,7 @@ asn_fprint(FILE *stream, asn_TYPE_descriptor_t *td, const void *struct_ptr) {
 	}
 
 	/* Invoke type-specific printer */
-	if(td->print_struct(td, struct_ptr, 1, _print2fp, stream))
+	if(td->op->print_struct(td, struct_ptr, 1, _print2fp, stream))
 		return -1;
 
 	/* Terminate the output */

--- a/skeletons/converter-sample.c
+++ b/skeletons/converter-sample.c
@@ -94,9 +94,9 @@ main(int ac, char *av[]) {
     int ch;
 
     /* Figure out if specialty decoder needs to be default */
-    if(pduType->oer_decoder)
+    if(pduType->op->oer_decoder)
         iform = INP_OER;
-    else if(pduType->uper_decoder)
+    else if(pduType->op->uper_decoder)
         iform = INP_PER;
 
     /*
@@ -107,18 +107,18 @@ main(int ac, char *av[]) {
     case 'i':
         if(optarg[0] == 'b') { iform = INP_BER; break; }
         if(optarg[0] == 'x') { iform = INP_XER; break; }
-        if(pduType->oer_decoder
+        if(pduType->op->oer_decoder
         && optarg[0] == 'o') { iform = INP_OER; break; }
-        if(pduType->uper_decoder
+        if(pduType->op->uper_decoder
         && optarg[0] == 'p') { iform = INP_PER; break; }
         fprintf(stderr, "-i<format>: '%s': improper format selector\n",
             optarg);
         exit(EX_UNAVAILABLE);
     case 'o':
         if(optarg[0] == 'd') { oform = OUT_DER; break; }
-        if(pduType->oer_encoder
+        if(pduType->op->oer_encoder
         && optarg[0] == 'o') { oform = OUT_OER; break; }
-        if(pduType->uper_encoder
+        if(pduType->op->uper_encoder
         && optarg[0] == 'p') { oform = OUT_PER; break; }
         if(optarg[0] == 'x') { oform = OUT_XER; break; }
         if(optarg[0] == 't') { oform = OUT_TEXT; break; }
@@ -215,11 +215,11 @@ main(int ac, char *av[]) {
 #endif
         fprintf(stderr, "Usage: %s [options] <data.ber> ...\n", av[0]);
         fprintf(stderr, "Where options are:\n");
-        if(pduType->oer_decoder)
+        if(pduType->op->oer_decoder)
         fprintf(stderr,
         "  -ioer        Input is in OER (Octet Encoding Rules)%s\n",
             iform == INP_OER ? " (DEFAULT)" : "");
-        if(pduType->uper_decoder)
+        if(pduType->op->uper_decoder)
         fprintf(stderr,
         "  -iper        Input is in Unaligned PER (Packed Encoding Rules)%s\n",
             iform == INP_PER ? " (DEFAULT)" : "");
@@ -228,10 +228,10 @@ main(int ac, char *av[]) {
             iform == INP_BER ? " (DEFAULT)" : "");
         fprintf(stderr,
         "  -ixer        Input is in XER (XML Encoding Rules)\n");
-        if(pduType->oer_encoder)
+        if(pduType->op->oer_encoder)
         fprintf(stderr,
         "  -ooer        Output in Canonical OER (Octet Encoding Rules)\n");
-        if(pduType->uper_encoder)
+        if(pduType->op->uper_encoder)
         fprintf(stderr,
         "  -oper        Output in Unaligned PER (Packed Encoding Rules)\n");
         fprintf(stderr,
@@ -239,7 +239,7 @@ main(int ac, char *av[]) {
         "  -oxer        Output in XER (XML Encoding Rules) (DEFAULT)\n"
         "  -otext       Output in plain semi-structured text (dump)\n"
         "  -onull       Verify (decode) input, but do not output\n");
-        if(pduType->uper_decoder)
+        if(pduType->op->uper_decoder)
         fprintf(stderr,
         "  -per-nopad   Assume PER PDUs are not padded (-iper)\n");
 #ifdef    ASN_PDU_COLLECTION

--- a/skeletons/der_encoder.c
+++ b/skeletons/der_encoder.c
@@ -21,7 +21,7 @@ der_encode(asn_TYPE_descriptor_t *type_descriptor, void *struct_ptr,
 	/*
 	 * Invoke type-specific encoder.
 	 */
-	return type_descriptor->der_encoder(type_descriptor,
+	return type_descriptor->op->der_encoder(type_descriptor,
 		struct_ptr,	/* Pointer to the destination structure */
 		0, 0,
 		consume_bytes, app_key);
@@ -59,7 +59,7 @@ der_encode_to_buffer(asn_TYPE_descriptor_t *type_descriptor, void *struct_ptr,
 	arg.buffer = buffer;
 	arg.left = buffer_size;
 
-	ec = type_descriptor->der_encoder(type_descriptor,
+	ec = type_descriptor->op->der_encoder(type_descriptor,
 		struct_ptr,	/* Pointer to the destination structure */
 		0, 0, encode_to_buffer_cb, &arg);
 	if(ec.encoded != -1) {

--- a/skeletons/oer_decoder.c
+++ b/skeletons/oer_decoder.c
@@ -32,7 +32,7 @@ oer_decode(asn_codec_ctx_t *opt_codec_ctx,
 	/*
 	 * Invoke type-specific decoder.
 	 */
-	return type_descriptor->oer_decoder(opt_codec_ctx, type_descriptor, 0,
+	return type_descriptor->op->oer_decoder(opt_codec_ctx, type_descriptor, 0,
 		struct_ptr,	/* Pointer to the destination structure */
 		ptr, size	/* Buffer and its size */
 		);
@@ -80,7 +80,7 @@ oer_open_type_get(asn_codec_ctx_t *opt_codec_ctx,
         return 0;
     }
 
-    dr = td->oer_decoder(opt_codec_ctx, td, constraints, struct_ptr,
+    dr = td->op->oer_decoder(opt_codec_ctx, td, constraints, struct_ptr,
                          (const uint8_t *)bufptr + len_len, container_len);
     if(dr.code == RC_OK) {
         return len_len + container_len;

--- a/skeletons/oer_encoder.c
+++ b/skeletons/oer_encoder.c
@@ -17,7 +17,7 @@ oer_encode(asn_TYPE_descriptor_t *type_descriptor, void *struct_ptr,
         /*
          * Invoke type-specific encoder.
          */
-        return type_descriptor->oer_encoder(type_descriptor, 0,
+        return type_descriptor->op->oer_encoder(type_descriptor, 0,
                 struct_ptr,     /* Pointer to the destination structure */
                 consume_bytes, app_key);
 }
@@ -58,14 +58,14 @@ oer_encode_to_buffer(struct asn_TYPE_descriptor_s *type_descriptor,
     arg.buffer = buffer;
     arg.left = buffer_size;
 
-    if(type_descriptor->oer_encoder == NULL) {
+    if(type_descriptor->op->oer_encoder == NULL) {
         ec.encoded = -1;
         ec.failed_type = type_descriptor;
         ec.structure_ptr = struct_ptr;
         ASN_DEBUG("OER encoder is not defined for %s",
                 type_descriptor->name);
     } else {
-        ec = type_descriptor->oer_encoder(
+        ec = type_descriptor->op->oer_encoder(
             type_descriptor, constraints,
             struct_ptr, /* Pointer to the destination structure */
             encode_to_buffer_cb, &arg);

--- a/skeletons/per_decoder.c
+++ b/skeletons/per_decoder.c
@@ -74,9 +74,9 @@ uper_decode(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td, void **sp
 	/*
 	 * Invoke type-specific decoder.
 	 */
-	if(!td->uper_decoder)
+	if(!td->op->uper_decoder)
 		ASN__DECODE_FAILED;	/* PER is not compiled in */
-	rval = td->uper_decoder(opt_codec_ctx, td, 0, sptr, &pd);
+	rval = td->op->uper_decoder(opt_codec_ctx, td, 0, sptr, &pd);
 	if(rval.code == RC_OK) {
 		/* Return the number of consumed bits */
 		rval.consumed = ((pd.buffer - (const uint8_t *)buffer) << 3)

--- a/skeletons/per_encoder.c
+++ b/skeletons/per_encoder.c
@@ -121,13 +121,13 @@ static asn_enc_rval_t
 uper_encode_internal(asn_TYPE_descriptor_t *td,
                      const asn_per_constraints_t *constraints, void *sptr,
                      asn_app_consume_bytes_f *cb, void *app_key) {
-    asn_per_outp_t po;
+	asn_per_outp_t po;
 	asn_enc_rval_t er;
 
 	/*
 	 * Invoke type-specific encoder.
 	 */
-	if(!td || !td->uper_encoder)
+	if(!td || !td->op->uper_encoder)
 		ASN__ENCODE_FAILED;	/* PER is not compiled in */
 
 	po.buffer = po.tmpspace;
@@ -137,7 +137,7 @@ uper_encode_internal(asn_TYPE_descriptor_t *td,
 	po.op_key = app_key;
 	po.flushed_bytes = 0;
 
-	er = td->uper_encoder(td, constraints, sptr, &po);
+	er = td->op->uper_encoder(td, constraints, sptr, &po);
 	if(er.encoded != -1) {
 		size_t bits_to_flush;
 

--- a/skeletons/per_opentype.c
+++ b/skeletons/per_opentype.c
@@ -103,7 +103,7 @@ uper_open_type_get_simple(asn_codec_ctx_t *ctx, asn_TYPE_descriptor_t *td,
 	spd.nbits = bufLen << 3;
 
 	ASN_DEBUG_INDENT_ADD(+4);
-	rv = td->uper_decoder(ctx, td, constraints, sptr, &spd);
+	rv = td->op->uper_decoder(ctx, td, constraints, sptr, &spd);
 	ASN_DEBUG_INDENT_ADD(-4);
 
 	if(rv.code == RC_OK) {
@@ -155,7 +155,7 @@ uper_open_type_get_complex(asn_codec_ctx_t *ctx, asn_TYPE_descriptor_t *td,
 	pd->moved = 0;	/* This now counts the open type size in bits */
 
 	ASN_DEBUG_INDENT_ADD(+4);
-	rv = td->uper_decoder(ctx, td, constraints, sptr, pd);
+	rv = td->op->uper_decoder(ctx, td, constraints, sptr, pd);
 	ASN_DEBUG_INDENT_ADD(-4);
 
 #define	UPDRESTOREPD	do {						\
@@ -257,7 +257,7 @@ uper_open_type_skip(asn_codec_ctx_t *ctx, asn_per_data_t *pd) {
 	asn_dec_rval_t rv;
 
 	s_td.name = "<unknown extension>";
-	s_td.uper_decoder = uper_sot_suck;
+	s_td.op->uper_decoder = uper_sot_suck;
 
 	rv = uper_open_type_get(ctx, &s_td, 0, 0, pd);
 	if(rv.code != RC_OK)

--- a/skeletons/tests/check-INTEGER.c
+++ b/skeletons/tests/check-INTEGER.c
@@ -166,7 +166,7 @@ check_xer(int tofail, char *xmldata, long orig_value) {
 
 	assert(value == orig_value);
 
-	asn_DEF_INTEGER.free_struct(&asn_DEF_INTEGER, st, 0);
+	ASN_STRUCT_FREE(asn_DEF_INTEGER, st);
 }
 
 int

--- a/skeletons/tests/check-OER-INTEGER.c
+++ b/skeletons/tests/check-OER-INTEGER.c
@@ -40,7 +40,7 @@ check_decode(int lineno, enum asn_dec_rval_code_e code, intmax_t control, const 
 
     (void)dummy;
 
-    ret = asn_DEF_INTEGER.oer_decoder(0, &asn_DEF_INTEGER, constraints,
+    ret = asn_DEF_INTEGER.op->oer_decoder(0, &asn_DEF_INTEGER, constraints,
                                       (void **)&st, buf, size);
     if(ret.code != RC_OK) {
         /* Basic OER decode does not work */
@@ -124,7 +124,7 @@ check_roundtrip(int lineno, intmax_t value, intmax_t lower_bound, intmax_t upper
 
     dump_data(lineno, tmpbuf, tmpbuf_size);
 
-    ret = asn_DEF_INTEGER.oer_decoder(0, &asn_DEF_INTEGER, constraints,
+    ret = asn_DEF_INTEGER.op->oer_decoder(0, &asn_DEF_INTEGER, constraints,
                                       (void **)&stIn, tmpbuf, tmpbuf_size);
     if(ret.code != RC_OK) {
         /* Basic OER decode does not work */

--- a/skeletons/tests/check-OIDs.c
+++ b/skeletons/tests/check-OIDs.c
@@ -246,7 +246,7 @@ static void check_xer(int expect_arcs, char *xer) {
 	int i;
 
 	printf("[%s] => ", xer); fflush(stdout);
-	rc = asn_DEF_RELATIVE_OID.xer_decoder(0,
+	rc = asn_DEF_RELATIVE_OID.op->xer_decoder(0,
 		&asn_DEF_RELATIVE_OID, (void **)stp, "t",
 			xer, strlen(xer));
 	if(expect_arcs == -1) {

--- a/skeletons/tests/check-length.c
+++ b/skeletons/tests/check-length.c
@@ -74,8 +74,8 @@ check(size_t size) {
 	}
 
 
-	asn_DEF_OCTET_STRING.free_struct(&asn_DEF_OCTET_STRING, os, 0);
-	asn_DEF_OCTET_STRING.free_struct(&asn_DEF_OCTET_STRING, nos, 0);
+	ASN_STRUCT_FREE(asn_DEF_OCTET_STRING, os);
+	ASN_STRUCT_FREE(asn_DEF_OCTET_STRING, nos);
 }
 
 int

--- a/skeletons/xer_decoder.c
+++ b/skeletons/xer_decoder.c
@@ -34,7 +34,7 @@ xer_decode(asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td,
 	/*
 	 * Invoke type-specific decoder.
 	 */
-	return td->xer_decoder(opt_codec_ctx, td, struct_ptr, 0, buffer, size);
+	return td->op->xer_decoder(opt_codec_ctx, td, struct_ptr, 0, buffer, size);
 }
 
 

--- a/skeletons/xer_encoder.c
+++ b/skeletons/xer_encoder.c
@@ -25,7 +25,7 @@ xer_encode(asn_TYPE_descriptor_t *td, void *sptr,
 
 	ASN__CALLBACK3("<", 1, mname, mlen, ">", 1);
 
-	tmper = td->xer_encoder(td, sptr, 1, xer_flags, cb, app_key);
+	tmper = td->op->xer_encoder(td, sptr, 1, xer_flags, cb, app_key);
 	if(tmper.encoded == -1) return tmper;
 
 	ASN__CALLBACK3("</", 2, mname, mlen, ">\n", xcan);

--- a/tests/tests-asn1c-compiler/03-enum-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/03-enum-OK.asn1.-Pfwide-types
@@ -68,17 +68,8 @@ static const ber_tlv_tag_t asn_DEF_Enum1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Enum1 = {
 	"Enum1",
 	"Enum1",
-	ENUMERATED_free,
-	ENUMERATED_print,
-	ENUMERATED_compare,
+	&asn_OP_ENUMERATED,
 	ENUMERATED_constraint,
-	ENUMERATED_decode_ber,
-	ENUMERATED_encode_der,
-	ENUMERATED_decode_xer,
-	ENUMERATED_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Enum1_tags_1,
 	sizeof(asn_DEF_Enum1_tags_1)
 		/sizeof(asn_DEF_Enum1_tags_1[0]), /* 1 */
@@ -170,17 +161,8 @@ static const ber_tlv_tag_t asn_DEF_Enum2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Enum2 = {
 	"Enum2",
 	"Enum2",
-	ENUMERATED_free,
-	ENUMERATED_print,
-	ENUMERATED_compare,
+	&asn_OP_ENUMERATED,
 	ENUMERATED_constraint,
-	ENUMERATED_decode_ber,
-	ENUMERATED_encode_der,
-	ENUMERATED_decode_xer,
-	ENUMERATED_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Enum2_tags_1,
 	sizeof(asn_DEF_Enum2_tags_1)
 		/sizeof(asn_DEF_Enum2_tags_1[0]), /* 1 */
@@ -260,17 +242,8 @@ static const ber_tlv_tag_t asn_DEF_Enum3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Enum3 = {
 	"Enum3",
 	"Enum3",
-	ENUMERATED_free,
-	ENUMERATED_print,
-	ENUMERATED_compare,
+	&asn_OP_ENUMERATED,
 	ENUMERATED_constraint,
-	ENUMERATED_decode_ber,
-	ENUMERATED_encode_der,
-	ENUMERATED_decode_xer,
-	ENUMERATED_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Enum3_tags_1,
 	sizeof(asn_DEF_Enum3_tags_1)
 		/sizeof(asn_DEF_Enum3_tags_1[0]), /* 1 */
@@ -353,17 +326,8 @@ static const ber_tlv_tag_t asn_DEF_Enum4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Enum4 = {
 	"Enum4",
 	"Enum4",
-	ENUMERATED_free,
-	ENUMERATED_print,
-	ENUMERATED_compare,
+	&asn_OP_ENUMERATED,
 	ENUMERATED_constraint,
-	ENUMERATED_decode_ber,
-	ENUMERATED_encode_der,
-	ENUMERATED_decode_xer,
-	ENUMERATED_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Enum4_tags_1,
 	sizeof(asn_DEF_Enum4_tags_1)
 		/sizeof(asn_DEF_Enum4_tags_1[0]), /* 1 */
@@ -443,17 +407,8 @@ static const ber_tlv_tag_t asn_DEF_Enum5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Enum5 = {
 	"Enum5",
 	"Enum5",
-	ENUMERATED_free,
-	ENUMERATED_print,
-	ENUMERATED_compare,
+	&asn_OP_ENUMERATED,
 	ENUMERATED_constraint,
-	ENUMERATED_decode_ber,
-	ENUMERATED_encode_der,
-	ENUMERATED_decode_xer,
-	ENUMERATED_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Enum5_tags_1,
 	sizeof(asn_DEF_Enum5_tags_1)
 		/sizeof(asn_DEF_Enum5_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/104-param-1-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/104-param-1-OK.asn1.-Pfwide-types
@@ -56,17 +56,8 @@ asn_SET_OF_specifics_t asn_SPC_Collection_16P0_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Collection_16P0 = {
 	"Collection",
 	"Collection",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Collection_16P0_tags_1,
 	sizeof(asn_DEF_Collection_16P0_tags_1)
 		/sizeof(asn_DEF_Collection_16P0_tags_1[0]), /* 1 */
@@ -104,17 +95,8 @@ asn_SET_OF_specifics_t asn_SPC_Collection_16P1_specs_3 = {
 asn_TYPE_descriptor_t asn_DEF_Collection_16P1 = {
 	"Collection",
 	"Collection",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Collection_16P1_tags_3,
 	sizeof(asn_DEF_Collection_16P1_tags_3)
 		/sizeof(asn_DEF_Collection_16P1_tags_3[0]), /* 1 */
@@ -193,17 +175,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_Bunch_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Bunch = {
 	"Bunch",
 	"Bunch",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Bunch_tags_1,
 	sizeof(asn_DEF_Bunch_tags_1)
 		/sizeof(asn_DEF_Bunch_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/105-param-2-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/105-param-2-OK.asn1.-Pfwide-types
@@ -82,17 +82,8 @@ asn_SEQUENCE_specifics_t asn_SPC_SIGNED_16P0_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_SIGNED_16P0 = {
 	"SIGNED",
 	"SIGNED",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SIGNED_16P0_tags_1,
 	sizeof(asn_DEF_SIGNED_16P0_tags_1)
 		/sizeof(asn_DEF_SIGNED_16P0_tags_1[0]), /* 1 */
@@ -144,17 +135,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_signed_4 = {
 	"signed",
 	"signed",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_signed_tags_4,
 	sizeof(asn_DEF_signed_tags_4)
 		/sizeof(asn_DEF_signed_tags_4[0]), /* 1 */
@@ -199,17 +181,8 @@ asn_SEQUENCE_specifics_t asn_SPC_SIGNED_16P1_specs_3 = {
 asn_TYPE_descriptor_t asn_DEF_SIGNED_16P1 = {
 	"SIGNED",
 	"SIGNED",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SIGNED_16P1_tags_3,
 	sizeof(asn_DEF_SIGNED_16P1_tags_3)
 		/sizeof(asn_DEF_SIGNED_16P1_tags_3[0]), /* 1 */
@@ -258,17 +231,8 @@ static const ber_tlv_tag_t asn_DEF_SignedREAL_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_SignedREAL = {
 	"SignedREAL",
 	"SignedREAL",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SignedREAL_tags_1,
 	sizeof(asn_DEF_SignedREAL_tags_1)
 		/sizeof(asn_DEF_SignedREAL_tags_1[0]), /* 1 */
@@ -317,17 +281,8 @@ static const ber_tlv_tag_t asn_DEF_SignedSET_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_SignedSET = {
 	"SignedSET",
 	"SignedSET",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SignedSET_tags_1,
 	sizeof(asn_DEF_SignedSET_tags_1)
 		/sizeof(asn_DEF_SignedSET_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/106-param-constr-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/106-param-constr-OK.asn1.-P
@@ -174,17 +174,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Narrow_15P0_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Narrow_15P0 = {
 	"Narrow",
 	"Narrow",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Narrow_15P0_tags_1,
 	sizeof(asn_DEF_Narrow_15P0_tags_1)
 		/sizeof(asn_DEF_Narrow_15P0_tags_1[0]), /* 1 */
@@ -233,17 +224,8 @@ static const ber_tlv_tag_t asn_DEF_NarrowInteger_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NarrowInteger = {
 	"NarrowInteger",
 	"NarrowInteger",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NarrowInteger_tags_1,
 	sizeof(asn_DEF_NarrowInteger_tags_1)
 		/sizeof(asn_DEF_NarrowInteger_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/108-param-constr-3-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/108-param-constr-3-OK.asn1.-Pfwide-types
@@ -64,17 +64,8 @@ static const ber_tlv_tag_t asn_DEF_MinMax_16P0_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_MinMax_16P0 = {
 	"MinMax",
 	"MinMax",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	MinMax_16P0_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_MinMax_16P0_tags_1,
 	sizeof(asn_DEF_MinMax_16P0_tags_1)
 		/sizeof(asn_DEF_MinMax_16P0_tags_1[0]), /* 1 */
@@ -153,17 +144,8 @@ static const ber_tlv_tag_t asn_DEF_ThreePlus_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_ThreePlus = {
 	"ThreePlus",
 	"ThreePlus",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	ThreePlus_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_ThreePlus_tags_1,
 	sizeof(asn_DEF_ThreePlus_tags_1)
 		/sizeof(asn_DEF_ThreePlus_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/110-param-3-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/110-param-3-OK.asn1.-Pfwide-types
@@ -103,17 +103,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Flag_16P0_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Flag_16P0 = {
 	"Flag",
 	"Flag",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Flag_16P0_tags_1,
 	sizeof(asn_DEF_Flag_16P0_tags_1)
 		/sizeof(asn_DEF_Flag_16P0_tags_1[0]), /* 1 */
@@ -173,17 +164,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_field_7 = {
 	"field",
 	"field",
-	ENUMERATED_free,
-	ENUMERATED_print,
-	ENUMERATED_compare,
+	&asn_OP_ENUMERATED,
 	ENUMERATED_constraint,
-	ENUMERATED_decode_ber,
-	ENUMERATED_encode_der,
-	ENUMERATED_decode_xer,
-	ENUMERATED_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_field_tags_7,
 	sizeof(asn_DEF_field_tags_7)
 		/sizeof(asn_DEF_field_tags_7[0]), /* 1 */
@@ -227,17 +209,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Flag_16P1_specs_6 = {
 asn_TYPE_descriptor_t asn_DEF_Flag_16P1 = {
 	"Flag",
 	"Flag",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Flag_16P1_tags_6,
 	sizeof(asn_DEF_Flag_16P1_tags_6)
 		/sizeof(asn_DEF_Flag_16P1_tags_6[0]), /* 1 */
@@ -286,17 +259,8 @@ static const ber_tlv_tag_t asn_DEF_IntegerColorFlag_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_IntegerColorFlag = {
 	"IntegerColorFlag",
 	"IntegerColorFlag",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_IntegerColorFlag_tags_1,
 	sizeof(asn_DEF_IntegerColorFlag_tags_1)
 		/sizeof(asn_DEF_IntegerColorFlag_tags_1[0]), /* 1 */
@@ -345,17 +309,8 @@ static const ber_tlv_tag_t asn_DEF_EnumeratedColorFlag_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_EnumeratedColorFlag = {
 	"EnumeratedColorFlag",
 	"EnumeratedColorFlag",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_EnumeratedColorFlag_tags_1,
 	sizeof(asn_DEF_EnumeratedColorFlag_tags_1)
 		/sizeof(asn_DEF_EnumeratedColorFlag_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/119-per-strings-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/119-per-strings-OK.asn1.-Pgen-PER
@@ -1209,18 +1209,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_many_2 = {
 	"many",
 	"many",
-	SEQUENCE_OF_free,
-	SEQUENCE_OF_print,
-	SEQUENCE_OF_compare,
+	&asn_OP_SEQUENCE_OF,
 	SEQUENCE_OF_constraint,
-	SEQUENCE_OF_decode_ber,
-	SEQUENCE_OF_encode_der,
-	SEQUENCE_OF_decode_xer,
-	SEQUENCE_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	SEQUENCE_OF_decode_uper,
-	SEQUENCE_OF_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_many_tags_2,
 	sizeof(asn_DEF_many_tags_2)
 		/sizeof(asn_DEF_many_tags_2[0]) - 1, /* 1 */
@@ -1627,18 +1617,8 @@ asn_SEQUENCE_specifics_t asn_SPC_PDU_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_PDU = {
 	"PDU",
 	"PDU",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	SEQUENCE_decode_uper,
-	SEQUENCE_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_PDU_tags_1,
 	sizeof(asn_DEF_PDU_tags_1)
 		/sizeof(asn_DEF_PDU_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/125-bitstring-constraint-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/125-bitstring-constraint-OK.asn1.-P
@@ -47,8 +47,7 @@ T_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	}
 	
 	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_BIT_STRING.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
+	return td->op->check_constraints(td, sptr, ctfailcb, app_key);
 }
 
 /*
@@ -64,17 +63,8 @@ static const ber_tlv_tag_t asn_DEF_T_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	BIT_STRING_free,
-	BIT_STRING_print,
-	BIT_STRING_compare,
+	&asn_OP_BIT_STRING,
 	T_constraint,
-	BIT_STRING_decode_ber,
-	BIT_STRING_encode_der,
-	BIT_STRING_decode_xer,
-	BIT_STRING_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
 	sizeof(asn_DEF_T_tags_1)
 		/sizeof(asn_DEF_T_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/126-per-extensions-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/126-per-extensions-OK.asn1.-Pgen-PER
@@ -105,18 +105,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_PDU_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_PDU = {
 	"PDU",
 	"PDU",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	SEQUENCE_decode_uper,
-	SEQUENCE_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_PDU_tags_1,
 	sizeof(asn_DEF_PDU_tags_1)
 		/sizeof(asn_DEF_PDU_tags_1[0]), /* 1 */
@@ -212,18 +202,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Singleton_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Singleton = {
 	"Singleton",
 	"Singleton",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	SEQUENCE_decode_uper,
-	SEQUENCE_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Singleton_tags_1,
 	sizeof(asn_DEF_Singleton_tags_1)
 		/sizeof(asn_DEF_Singleton_tags_1[0]), /* 1 */
@@ -342,18 +322,8 @@ asn_CHOICE_specifics_t asn_SPC_PDU_2_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_PDU_2 = {
 	"PDU-2",
 	"PDU-2",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	CHOICE_decode_uper,
-	CHOICE_encode_uper,
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */

--- a/tests/tests-asn1c-compiler/127-per-long-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/127-per-long-OK.asn1.-Pgen-PER
@@ -213,18 +213,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_unsigned32_4 = {
 	"unsigned32",
 	"unsigned32",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	unsigned32_4_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_unsigned32_tags_4,
 	sizeof(asn_DEF_unsigned32_tags_4)
 		/sizeof(asn_DEF_unsigned32_tags_4[0]) - 1, /* 1 */
@@ -250,18 +240,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_unsplit32_5 = {
 	"unsplit32",
 	"unsplit32",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	unsplit32_5_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_unsplit32_tags_5,
 	sizeof(asn_DEF_unsplit32_tags_5)
 		/sizeof(asn_DEF_unsplit32_tags_5[0]) - 1, /* 1 */
@@ -341,18 +321,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_T_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	SEQUENCE_decode_uper,
-	SEQUENCE_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
 	sizeof(asn_DEF_T_tags_1)
 		/sizeof(asn_DEF_T_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/131-per-empty-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/131-per-empty-OK.asn1.-Pgen-PER
@@ -32,18 +32,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_T_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	SEQUENCE_decode_uper,
-	SEQUENCE_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
 	sizeof(asn_DEF_T_tags_1)
 		/sizeof(asn_DEF_T_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/134-per-long-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/134-per-long-OK.asn1.-Pgen-PER
@@ -239,18 +239,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_T_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	SEQUENCE_decode_uper,
-	SEQUENCE_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
 	sizeof(asn_DEF_T_tags_1)
 		/sizeof(asn_DEF_T_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/136-oer-long-OK.asn1.-Pgen-OER
+++ b/tests/tests-asn1c-compiler/136-oer-long-OK.asn1.-Pgen-OER
@@ -566,18 +566,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_T_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	SEQUENCE_decode_oer,
-	SEQUENCE_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
 	sizeof(asn_DEF_T_tags_1)
 		/sizeof(asn_DEF_T_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/137-oer-string-OK.asn1.-Pgen-OER
+++ b/tests/tests-asn1c-compiler/137-oer-string-OK.asn1.-Pgen-OER
@@ -226,18 +226,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_unconstrained_2 = {
 	"unconstrained",
 	"unconstrained",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	SEQUENCE_decode_oer,
-	SEQUENCE_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_unconstrained_tags_2,
 	sizeof(asn_DEF_unconstrained_tags_2)
 		/sizeof(asn_DEF_unconstrained_tags_2[0]), /* 1 */
@@ -307,18 +297,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_constrained_6 = {
 	"constrained",
 	"constrained",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	SEQUENCE_decode_oer,
-	SEQUENCE_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_constrained_tags_6,
 	sizeof(asn_DEF_constrained_tags_6)
 		/sizeof(asn_DEF_constrained_tags_6[0]), /* 1 */
@@ -375,18 +355,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_T_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	SEQUENCE_decode_oer,
-	SEQUENCE_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
 	sizeof(asn_DEF_T_tags_1)
 		/sizeof(asn_DEF_T_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/138-oer-constraints-OK.asn1.-Pgen-OER
+++ b/tests/tests-asn1c-compiler/138-oer-constraints-OK.asn1.-Pgen-OER
@@ -35,18 +35,8 @@ static const ber_tlv_tag_t asn_DEF_A_noc_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_A_noc = {
 	"A-noc",
 	"A-noc",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NativeInteger_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	NativeInteger_decode_oer,
-	NativeInteger_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_A_noc_tags_1,
 	sizeof(asn_DEF_A_noc_tags_1)
 		/sizeof(asn_DEF_A_noc_tags_1[0]), /* 1 */
@@ -127,18 +117,8 @@ static const ber_tlv_tag_t asn_DEF_B_0_0_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_B_0_0 = {
 	"B-0-0",
 	"B-0-0",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	B_0_0_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	NativeInteger_decode_oer,
-	NativeInteger_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_B_0_0_tags_1,
 	sizeof(asn_DEF_B_0_0_tags_1)
 		/sizeof(asn_DEF_B_0_0_tags_1[0]), /* 1 */
@@ -219,18 +199,8 @@ static const ber_tlv_tag_t asn_DEF_C_1_2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_C_1_2 = {
 	"C-1-2",
 	"C-1-2",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	C_1_2_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	NativeInteger_decode_oer,
-	NativeInteger_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_C_1_2_tags_1,
 	sizeof(asn_DEF_C_1_2_tags_1)
 		/sizeof(asn_DEF_C_1_2_tags_1[0]), /* 1 */
@@ -311,18 +281,8 @@ static const ber_tlv_tag_t asn_DEF_D_inv_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_D_inv = {
 	"D-inv",
 	"D-inv",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	D_inv_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	NativeInteger_decode_oer,
-	NativeInteger_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_D_inv_tags_1,
 	sizeof(asn_DEF_D_inv_tags_1)
 		/sizeof(asn_DEF_D_inv_tags_1[0]), /* 1 */
@@ -403,18 +363,8 @@ static const ber_tlv_tag_t asn_DEF_E_2_5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_E_2_5 = {
 	"E-2-5",
 	"E-2-5",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	E_2_5_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	NativeInteger_decode_oer,
-	NativeInteger_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_E_2_5_tags_1,
 	sizeof(asn_DEF_E_2_5_tags_1)
 		/sizeof(asn_DEF_E_2_5_tags_1[0]), /* 1 */
@@ -495,18 +445,8 @@ static const ber_tlv_tag_t asn_DEF_F_inv_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_F_inv = {
 	"F-inv",
 	"F-inv",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	F_inv_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	NativeInteger_decode_oer,
-	NativeInteger_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_F_inv_tags_1,
 	sizeof(asn_DEF_F_inv_tags_1)
 		/sizeof(asn_DEF_F_inv_tags_1[0]), /* 1 */
@@ -587,18 +527,8 @@ static const ber_tlv_tag_t asn_DEF_G_3_3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_G_3_3 = {
 	"G-3-3",
 	"G-3-3",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	G_3_3_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	NativeInteger_decode_oer,
-	NativeInteger_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_G_3_3_tags_1,
 	sizeof(asn_DEF_G_3_3_tags_1)
 		/sizeof(asn_DEF_G_3_3_tags_1[0]), /* 1 */
@@ -679,18 +609,8 @@ static const ber_tlv_tag_t asn_DEF_H_4_5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_H_4_5 = {
 	"H-4-5",
 	"H-4-5",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	H_4_5_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	NativeInteger_decode_oer,
-	NativeInteger_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_H_4_5_tags_1,
 	sizeof(asn_DEF_H_4_5_tags_1)
 		/sizeof(asn_DEF_H_4_5_tags_1[0]), /* 1 */
@@ -771,18 +691,8 @@ static const ber_tlv_tag_t asn_DEF_I_0_5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_I_0_5 = {
 	"I-0-5",
 	"I-0-5",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	I_0_5_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	NativeInteger_decode_oer,
-	NativeInteger_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_I_0_5_tags_1,
 	sizeof(asn_DEF_I_0_5_tags_1)
 		/sizeof(asn_DEF_I_0_5_tags_1[0]), /* 1 */
@@ -863,18 +773,8 @@ static const ber_tlv_tag_t asn_DEF_J_4_9_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_J_4_9 = {
 	"J-4-9",
 	"J-4-9",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	J_4_9_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	NativeInteger_decode_oer,
-	NativeInteger_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_J_4_9_tags_1,
 	sizeof(asn_DEF_J_4_9_tags_1)
 		/sizeof(asn_DEF_J_4_9_tags_1[0]), /* 1 */
@@ -955,18 +855,8 @@ static const ber_tlv_tag_t asn_DEF_K_inv_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_K_inv = {
 	"K-inv",
 	"K-inv",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	K_inv_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	NativeInteger_decode_oer,
-	NativeInteger_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_K_inv_tags_1,
 	sizeof(asn_DEF_K_inv_tags_1)
 		/sizeof(asn_DEF_K_inv_tags_1[0]), /* 1 */
@@ -1047,18 +937,8 @@ static const ber_tlv_tag_t asn_DEF_L_0_5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_L_0_5 = {
 	"L-0-5",
 	"L-0-5",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	L_0_5_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	NativeInteger_decode_oer,
-	NativeInteger_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_L_0_5_tags_1,
 	sizeof(asn_DEF_L_0_5_tags_1)
 		/sizeof(asn_DEF_L_0_5_tags_1[0]), /* 1 */
@@ -1139,18 +1019,8 @@ static const ber_tlv_tag_t asn_DEF_M_inv_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_M_inv = {
 	"M-inv",
 	"M-inv",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	M_inv_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	NativeInteger_decode_oer,
-	NativeInteger_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_M_inv_tags_1,
 	sizeof(asn_DEF_M_inv_tags_1)
 		/sizeof(asn_DEF_M_inv_tags_1[0]), /* 1 */
@@ -1231,18 +1101,8 @@ static const ber_tlv_tag_t asn_DEF_N_inv_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_N_inv = {
 	"N-inv",
 	"N-inv",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	N_inv_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	NativeInteger_decode_oer,
-	NativeInteger_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_N_inv_tags_1,
 	sizeof(asn_DEF_N_inv_tags_1)
 		/sizeof(asn_DEF_N_inv_tags_1[0]), /* 1 */
@@ -1323,18 +1183,8 @@ static const ber_tlv_tag_t asn_DEF_O_inv_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_O_inv = {
 	"O-inv",
 	"O-inv",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	O_inv_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	NativeInteger_decode_oer,
-	NativeInteger_encode_oer,
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_O_inv_tags_1,
 	sizeof(asn_DEF_O_inv_tags_1)
 		/sizeof(asn_DEF_O_inv_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/139-component-relation-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/139-component-relation-OK.asn1.-P
@@ -93,7 +93,7 @@ select_value_type(const asn_TYPE_descriptor_t *parent_type, const void *parent_s
 	    const asn_ioc_cell_t *constraining_cell = &itable->rows[row * itable->columns_count + constraining_column];
 	    const asn_ioc_cell_t *type_cell = &itable->rows[row * itable->columns_count + for_column];
 	
-	    if(constraining_cell->type_descriptor->compare_struct(constraining_cell->type_descriptor, constraining_value, constraining_cell->value_sptr) == 0) {
+	    if(constraining_cell->type_descriptor->op->compare_struct(constraining_cell->type_descriptor, constraining_value, constraining_cell->value_sptr) == 0) {
 	        result.type_descriptor = type_cell->type_descriptor;
 	        result.presence_index = row + 1;
 	        break;
@@ -167,17 +167,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_value_3 = {
 	"value",
 	"value",
-	OPEN_TYPE_free,
-	OPEN_TYPE_print,
-	OPEN_TYPE_compare,
+	&asn_OP_OPEN_TYPE,
 	OPEN_TYPE_constraint,
-	OPEN_TYPE_decode_ber,
-	OPEN_TYPE_encode_der,
-	OPEN_TYPE_decode_xer,
-	OPEN_TYPE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -231,17 +222,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_Frame_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Frame = {
 	"Frame",
 	"Frame",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Frame_tags_1,
 	sizeof(asn_DEF_Frame_tags_1)
 		/sizeof(asn_DEF_Frame_tags_1[0]), /* 1 */
@@ -290,17 +272,8 @@ asn_SEQUENCE_specifics_t asn_SPC_PrimitiveMessage_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_PrimitiveMessage = {
 	"PrimitiveMessage",
 	"PrimitiveMessage",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_PrimitiveMessage_tags_1,
 	sizeof(asn_DEF_PrimitiveMessage_tags_1)
 		/sizeof(asn_DEF_PrimitiveMessage_tags_1[0]), /* 1 */
@@ -348,17 +321,8 @@ asn_SEQUENCE_specifics_t asn_SPC_ComplexMessage_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_ComplexMessage = {
 	"ComplexMessage",
 	"ComplexMessage",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_ComplexMessage_tags_1,
 	sizeof(asn_DEF_ComplexMessage_tags_1)
 		/sizeof(asn_DEF_ComplexMessage_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/140-component-relation-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/140-component-relation-OK.asn1.-P
@@ -93,7 +93,7 @@ select_value_type(const asn_TYPE_descriptor_t *parent_type, const void *parent_s
 	    const asn_ioc_cell_t *constraining_cell = &itable->rows[row * itable->columns_count + constraining_column];
 	    const asn_ioc_cell_t *type_cell = &itable->rows[row * itable->columns_count + for_column];
 	
-	    if(constraining_cell->type_descriptor->compare_struct(constraining_cell->type_descriptor, constraining_value, constraining_cell->value_sptr) == 0) {
+	    if(constraining_cell->type_descriptor->op->compare_struct(constraining_cell->type_descriptor, constraining_value, constraining_cell->value_sptr) == 0) {
 	        result.type_descriptor = type_cell->type_descriptor;
 	        result.presence_index = row + 1;
 	        break;
@@ -167,17 +167,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_value_3 = {
 	"value",
 	"value",
-	OPEN_TYPE_free,
-	OPEN_TYPE_print,
-	OPEN_TYPE_compare,
+	&asn_OP_OPEN_TYPE,
 	OPEN_TYPE_constraint,
-	OPEN_TYPE_decode_ber,
-	OPEN_TYPE_encode_der,
-	OPEN_TYPE_decode_xer,
-	OPEN_TYPE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -231,17 +222,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_Frame_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Frame = {
 	"Frame",
 	"Frame",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Frame_tags_1,
 	sizeof(asn_DEF_Frame_tags_1)
 		/sizeof(asn_DEF_Frame_tags_1[0]), /* 1 */
@@ -290,17 +272,8 @@ asn_SEQUENCE_specifics_t asn_SPC_PrimitiveMessage_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_PrimitiveMessage = {
 	"PrimitiveMessage",
 	"PrimitiveMessage",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_PrimitiveMessage_tags_1,
 	sizeof(asn_DEF_PrimitiveMessage_tags_1)
 		/sizeof(asn_DEF_PrimitiveMessage_tags_1[0]), /* 1 */
@@ -348,17 +321,8 @@ asn_SEQUENCE_specifics_t asn_SPC_ComplexMessage_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_ComplexMessage = {
 	"ComplexMessage",
 	"ComplexMessage",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_ComplexMessage_tags_1,
 	sizeof(asn_DEF_ComplexMessage_tags_1)
 		/sizeof(asn_DEF_ComplexMessage_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/141-component-relation-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/141-component-relation-OK.asn1.-P
@@ -99,7 +99,7 @@ select_value_type(const asn_TYPE_descriptor_t *parent_type, const void *parent_s
 	    const asn_ioc_cell_t *constraining_cell = &itable->rows[row * itable->columns_count + constraining_column];
 	    const asn_ioc_cell_t *type_cell = &itable->rows[row * itable->columns_count + for_column];
 	
-	    if(constraining_cell->type_descriptor->compare_struct(constraining_cell->type_descriptor, constraining_value, constraining_cell->value_sptr) == 0) {
+	    if(constraining_cell->type_descriptor->op->compare_struct(constraining_cell->type_descriptor, constraining_value, constraining_cell->value_sptr) == 0) {
 	        result.type_descriptor = type_cell->type_descriptor;
 	        result.presence_index = row + 1;
 	        break;
@@ -173,17 +173,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_value_3 = {
 	"value",
 	"value",
-	OPEN_TYPE_free,
-	OPEN_TYPE_print,
-	OPEN_TYPE_compare,
+	&asn_OP_OPEN_TYPE,
 	OPEN_TYPE_constraint,
-	OPEN_TYPE_decode_ber,
-	OPEN_TYPE_encode_der,
-	OPEN_TYPE_decode_xer,
-	OPEN_TYPE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -238,17 +229,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_Frame_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Frame = {
 	"Frame",
 	"Frame",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Frame_tags_1,
 	sizeof(asn_DEF_Frame_tags_1)
 		/sizeof(asn_DEF_Frame_tags_1[0]), /* 1 */
@@ -322,17 +304,8 @@ static const ber_tlv_tag_t asn_DEF_ConstrainedInteger_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_ConstrainedInteger = {
 	"ConstrainedInteger",
 	"ConstrainedInteger",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	ConstrainedInteger_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_ConstrainedInteger_tags_1,
 	sizeof(asn_DEF_ConstrainedInteger_tags_1)
 		/sizeof(asn_DEF_ConstrainedInteger_tags_1[0]), /* 1 */
@@ -380,17 +353,8 @@ asn_SEQUENCE_specifics_t asn_SPC_PrimitiveMessage_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_PrimitiveMessage = {
 	"PrimitiveMessage",
 	"PrimitiveMessage",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_PrimitiveMessage_tags_1,
 	sizeof(asn_DEF_PrimitiveMessage_tags_1)
 		/sizeof(asn_DEF_PrimitiveMessage_tags_1[0]), /* 1 */
@@ -438,17 +402,8 @@ asn_SEQUENCE_specifics_t asn_SPC_ComplexMessage_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_ComplexMessage = {
 	"ComplexMessage",
 	"ComplexMessage",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_ComplexMessage_tags_1,
 	sizeof(asn_DEF_ComplexMessage_tags_1)
 		/sizeof(asn_DEF_ComplexMessage_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/142-anonymous-types-deco-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/142-anonymous-types-deco-OK.asn1.-P
@@ -73,17 +73,8 @@ static asn_CHOICE_specifics_t asn_SPC_CommonType_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_CommonType = {
 	"CommonType",
 	"CommonType",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -235,17 +226,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_anonType_2 = {
 	"anonType",
 	"anonType",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_anonType_tags_2,
 	sizeof(asn_DEF_anonType_tags_2)
 		/sizeof(asn_DEF_anonType_tags_2[0]) - 1, /* 1 */
@@ -288,17 +270,8 @@ asn_CHOICE_specifics_t asn_SPC_Type1_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Type1 = {
 	"Type1",
 	"Type1",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -450,17 +423,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_anonType_2 = {
 	"anonType",
 	"anonType",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_anonType_tags_2,
 	sizeof(asn_DEF_anonType_tags_2)
 		/sizeof(asn_DEF_anonType_tags_2[0]) - 1, /* 1 */
@@ -503,17 +467,8 @@ asn_CHOICE_specifics_t asn_SPC_Type2_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Type2 = {
 	"Type2",
 	"Type2",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */

--- a/tests/tests-asn1c-compiler/143-inner-parameterization-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/143-inner-parameterization-OK.asn1.-P
@@ -63,17 +63,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_Message_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Message = {
 	"Message",
 	"Message",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Message_tags_1,
 	sizeof(asn_DEF_Message_tags_1)
 		/sizeof(asn_DEF_Message_tags_1[0]), /* 1 */
@@ -203,17 +194,8 @@ asn_SEQUENCE_specifics_t asn_SPC_SpecializedContent_21P0_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_SpecializedContent_21P0 = {
 	"SpecializedContent",
 	"SpecializedContent",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SpecializedContent_21P0_tags_1,
 	sizeof(asn_DEF_SpecializedContent_21P0_tags_1)
 		/sizeof(asn_DEF_SpecializedContent_21P0_tags_1[0]), /* 1 */
@@ -258,17 +240,8 @@ asn_SEQUENCE_specifics_t asn_SPC_SpecializedContent_21P1_specs_3 = {
 asn_TYPE_descriptor_t asn_DEF_SpecializedContent_21P1 = {
 	"SpecializedContent",
 	"SpecializedContent",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SpecializedContent_21P1_tags_3,
 	sizeof(asn_DEF_SpecializedContent_21P1_tags_3)
 		/sizeof(asn_DEF_SpecializedContent_21P1_tags_3[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/144-ios-parameterization-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/144-ios-parameterization-OK.asn1.-P
@@ -50,17 +50,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_Message_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Message = {
 	"Message",
 	"Message",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Message_tags_1,
 	sizeof(asn_DEF_Message_tags_1)
 		/sizeof(asn_DEF_Message_tags_1[0]), /* 1 */
@@ -166,7 +157,7 @@ select_value_type(const asn_TYPE_descriptor_t *parent_type, const void *parent_s
 	    const asn_ioc_cell_t *constraining_cell = &itable->rows[row * itable->columns_count + constraining_column];
 	    const asn_ioc_cell_t *type_cell = &itable->rows[row * itable->columns_count + for_column];
 	
-	    if(constraining_cell->type_descriptor->compare_struct(constraining_cell->type_descriptor, constraining_value, constraining_cell->value_sptr) == 0) {
+	    if(constraining_cell->type_descriptor->op->compare_struct(constraining_cell->type_descriptor, constraining_value, constraining_cell->value_sptr) == 0) {
 	        result.type_descriptor = type_cell->type_descriptor;
 	        result.presence_index = row + 1;
 	        break;
@@ -240,17 +231,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_value_3 = {
 	"value",
 	"value",
-	OPEN_TYPE_free,
-	OPEN_TYPE_print,
-	OPEN_TYPE_compare,
+	&asn_OP_OPEN_TYPE,
 	OPEN_TYPE_constraint,
-	OPEN_TYPE_decode_ber,
-	OPEN_TYPE_encode_der,
-	OPEN_TYPE_decode_xer,
-	OPEN_TYPE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -304,17 +286,8 @@ asn_SEQUENCE_specifics_t asn_SPC_SpecializedContent_30P0_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_SpecializedContent_30P0 = {
 	"SpecializedContent",
 	"SpecializedContent",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SpecializedContent_30P0_tags_1,
 	sizeof(asn_DEF_SpecializedContent_30P0_tags_1)
 		/sizeof(asn_DEF_SpecializedContent_30P0_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/19-param-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/19-param-OK.asn1.-Pfwide-types
@@ -123,17 +123,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_toBeSigned_2 = {
 	"toBeSigned",
 	"toBeSigned",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_toBeSigned_tags_2,
 	sizeof(asn_DEF_toBeSigned_tags_2)
 		/sizeof(asn_DEF_toBeSigned_tags_2[0]), /* 1 */
@@ -202,17 +193,8 @@ asn_SEQUENCE_specifics_t asn_SPC_SIGNED_15P0_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_SIGNED_15P0 = {
 	"SIGNED",
 	"SIGNED",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SIGNED_15P0_tags_1,
 	sizeof(asn_DEF_SIGNED_15P0_tags_1)
 		/sizeof(asn_DEF_SIGNED_15P0_tags_1[0]), /* 1 */
@@ -261,17 +243,8 @@ static const ber_tlv_tag_t asn_DEF_Certificate_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Certificate = {
 	"Certificate",
 	"Certificate",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Certificate_tags_1,
 	sizeof(asn_DEF_Certificate_tags_1)
 		/sizeof(asn_DEF_Certificate_tags_1[0]), /* 1 */
@@ -340,17 +313,8 @@ asn_SET_OF_specifics_t asn_SPC_Name_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Name = {
 	"Name",
 	"Name",
-	SEQUENCE_OF_free,
-	SEQUENCE_OF_print,
-	SEQUENCE_OF_compare,
+	&asn_OP_SEQUENCE_OF,
 	SEQUENCE_OF_constraint,
-	SEQUENCE_OF_decode_ber,
-	SEQUENCE_OF_encode_der,
-	SEQUENCE_OF_decode_xer,
-	SEQUENCE_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Name_tags_1,
 	sizeof(asn_DEF_Name_tags_1)
 		/sizeof(asn_DEF_Name_tags_1[0]), /* 1 */
@@ -467,17 +431,8 @@ asn_SET_OF_specifics_t asn_SPC_RelativeDistinguishedName_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_RelativeDistinguishedName = {
 	"RelativeDistinguishedName",
 	"RelativeDistinguishedName",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_RelativeDistinguishedName_tags_1,
 	sizeof(asn_DEF_RelativeDistinguishedName_tags_1)
 		/sizeof(asn_DEF_RelativeDistinguishedName_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/22-tags-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/22-tags-OK.asn1.-Pfwide-types
@@ -83,17 +83,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_b_3 = {
 	"b",
 	"b",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -160,17 +151,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_T1_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T1 = {
 	"T1",
 	"T1",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T1_tags_1,
 	sizeof(asn_DEF_T1_tags_1)
 		/sizeof(asn_DEF_T1_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/30-set-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/30-set-OK.asn1.-Pfwide-types
@@ -104,17 +104,8 @@ asn_SET_specifics_t asn_SPC_T_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
 	sizeof(asn_DEF_T_tags_1)
 		/sizeof(asn_DEF_T_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/31-set-of-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/31-set-of-OK.asn1.-Pfwide-types
@@ -53,17 +53,8 @@ asn_SET_OF_specifics_t asn_SPC_Forest_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Forest = {
 	"Forest",
 	"Forest",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Forest_tags_1,
 	sizeof(asn_DEF_Forest_tags_1)
 		/sizeof(asn_DEF_Forest_tags_1[0]), /* 1 */
@@ -144,17 +135,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Tree_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Tree = {
 	"Tree",
 	"Tree",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Tree_tags_1,
 	sizeof(asn_DEF_Tree_tags_1)
 		/sizeof(asn_DEF_Tree_tags_1[0]), /* 1 */
@@ -287,17 +269,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_trees_2 = {
 	"trees",
 	"trees",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_trees_tags_2,
 	sizeof(asn_DEF_trees_tags_2)
 		/sizeof(asn_DEF_trees_tags_2[0]) - 1, /* 1 */
@@ -343,17 +316,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_Member_5 = {
 	"SEQUENCE",
 	"SEQUENCE",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Member_tags_5,
 	sizeof(asn_DEF_Member_tags_5)
 		/sizeof(asn_DEF_Member_tags_5[0]), /* 1 */
@@ -393,17 +357,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_anything_4 = {
 	"anything",
 	"anything",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_anything_tags_4,
 	sizeof(asn_DEF_anything_tags_4)
 		/sizeof(asn_DEF_anything_tags_4[0]) - 1, /* 1 */
@@ -459,17 +414,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_other_9 = {
 	"other",
 	"other",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -548,17 +494,8 @@ asn_SET_specifics_t asn_SPC_Stuff_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Stuff = {
 	"Stuff",
 	"Stuff",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Stuff_tags_1,
 	sizeof(asn_DEF_Stuff_tags_1)
 		/sizeof(asn_DEF_Stuff_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/32-sequence-of-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/32-sequence-of-OK.asn1.-P
@@ -51,17 +51,8 @@ static asn_SET_OF_specifics_t asn_SPC_Programming_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Programming = {
 	"Programming",
 	"Programming",
-	SEQUENCE_OF_free,
-	SEQUENCE_OF_print,
-	SEQUENCE_OF_compare,
+	&asn_OP_SEQUENCE_OF,
 	SEQUENCE_OF_constraint,
-	SEQUENCE_OF_decode_ber,
-	SEQUENCE_OF_encode_der,
-	SEQUENCE_OF_decode_xer,
-	SEQUENCE_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Programming_tags_1,
 	sizeof(asn_DEF_Programming_tags_1)
 		/sizeof(asn_DEF_Programming_tags_1[0]), /* 1 */
@@ -130,17 +121,8 @@ asn_SET_OF_specifics_t asn_SPC_Fault_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Fault = {
 	"Fault",
 	"Fault",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Fault_tags_1,
 	sizeof(asn_DEF_Fault_tags_1)
 		/sizeof(asn_DEF_Fault_tags_1[0]), /* 1 */
@@ -193,17 +175,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Error_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Error = {
 	"Error",
 	"Error",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Error_tags_1,
 	sizeof(asn_DEF_Error_tags_1)
 		/sizeof(asn_DEF_Error_tags_1[0]), /* 1 */
@@ -279,17 +252,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_seqOfMan_3 = {
 	"seqOfMan",
 	"seqOfMan",
-	SEQUENCE_OF_free,
-	SEQUENCE_OF_print,
-	SEQUENCE_OF_compare,
+	&asn_OP_SEQUENCE_OF,
 	SEQUENCE_OF_constraint,
-	SEQUENCE_OF_decode_ber,
-	SEQUENCE_OF_encode_der,
-	SEQUENCE_OF_decode_xer,
-	SEQUENCE_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_seqOfMan_tags_3,
 	sizeof(asn_DEF_seqOfMan_tags_3)
 		/sizeof(asn_DEF_seqOfMan_tags_3[0]), /* 2 */
@@ -346,17 +310,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_SeqWithMandatory_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_SeqWithMandatory = {
 	"SeqWithMandatory",
 	"SeqWithMandatory",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SeqWithMandatory_tags_1,
 	sizeof(asn_DEF_SeqWithMandatory_tags_1)
 		/sizeof(asn_DEF_SeqWithMandatory_tags_1[0]), /* 1 */
@@ -433,17 +388,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_seqOfOpt_3 = {
 	"seqOfOpt",
 	"seqOfOpt",
-	SEQUENCE_OF_free,
-	SEQUENCE_OF_print,
-	SEQUENCE_OF_compare,
+	&asn_OP_SEQUENCE_OF,
 	SEQUENCE_OF_constraint,
-	SEQUENCE_OF_decode_ber,
-	SEQUENCE_OF_encode_der,
-	SEQUENCE_OF_decode_xer,
-	SEQUENCE_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_seqOfOpt_tags_3,
 	sizeof(asn_DEF_seqOfOpt_tags_3)
 		/sizeof(asn_DEF_seqOfOpt_tags_3[0]), /* 2 */
@@ -500,17 +446,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_SeqWithOptional_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_SeqWithOptional = {
 	"SeqWithOptional",
 	"SeqWithOptional",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SeqWithOptional_tags_1,
 	sizeof(asn_DEF_SeqWithOptional_tags_1)
 		/sizeof(asn_DEF_SeqWithOptional_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/37-indirect-choice-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/37-indirect-choice-OK.asn1.-Pfwide-types
@@ -103,17 +103,8 @@ static asn_CHOICE_specifics_t asn_SPC_T_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -202,17 +193,8 @@ asn_CHOICE_specifics_t asn_SPC_Choice1_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Choice1 = {
 	"Choice1",
 	"Choice1",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -333,17 +315,8 @@ asn_CHOICE_specifics_t asn_SPC_Choice2_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Choice2 = {
 	"Choice2",
 	"Choice2",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	asn_DEF_Choice2_tags_1,
 	sizeof(asn_DEF_Choice2_tags_1)
 		/sizeof(asn_DEF_Choice2_tags_1[0]), /* 1 */
@@ -393,17 +366,8 @@ static const ber_tlv_tag_t asn_DEF_Choice3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Choice3 = {
 	"Choice3",
 	"Choice3",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	asn_DEF_Choice3_tags_1,
 	sizeof(asn_DEF_Choice3_tags_1)
 		/sizeof(asn_DEF_Choice3_tags_1[0]), /* 2 */
@@ -453,17 +417,8 @@ static const ber_tlv_tag_t asn_DEF_Choice4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Choice4 = {
 	"Choice4",
 	"Choice4",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	asn_DEF_Choice4_tags_1,
 	sizeof(asn_DEF_Choice4_tags_1)
 		/sizeof(asn_DEF_Choice4_tags_1[0]) - 1, /* 1 */
@@ -512,17 +467,8 @@ static const ber_tlv_tag_t asn_DEF_Choice5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Choice5 = {
 	"Choice5",
 	"Choice5",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	asn_DEF_Choice5_tags_1,
 	sizeof(asn_DEF_Choice5_tags_1)
 		/sizeof(asn_DEF_Choice5_tags_1[0]), /* 1 */
@@ -568,17 +514,8 @@ xer_type_encoder_f Choice6_encode_xer;
 asn_TYPE_descriptor_t asn_DEF_Choice6 = {
 	"Choice6",
 	"Choice6",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */

--- a/tests/tests-asn1c-compiler/39-sequence-of-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/39-sequence-of-OK.asn1.-Pfwide-types
@@ -60,17 +60,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_collection_3 = {
 	"collection",
 	"collection",
-	SEQUENCE_OF_free,
-	SEQUENCE_OF_print,
-	SEQUENCE_OF_compare,
+	&asn_OP_SEQUENCE_OF,
 	SEQUENCE_OF_constraint,
-	SEQUENCE_OF_decode_ber,
-	SEQUENCE_OF_encode_der,
-	SEQUENCE_OF_decode_xer,
-	SEQUENCE_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_collection_tags_3,
 	sizeof(asn_DEF_collection_tags_3)
 		/sizeof(asn_DEF_collection_tags_3[0]), /* 1 */
@@ -127,17 +118,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_T_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
 	sizeof(asn_DEF_T_tags_1)
 		/sizeof(asn_DEF_T_tags_1[0]), /* 1 */
@@ -219,17 +201,8 @@ asn_SEQUENCE_specifics_t asn_SPC_T2_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T2 = {
 	"T2",
 	"T2",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T2_tags_1,
 	sizeof(asn_DEF_T2_tags_1)
 		/sizeof(asn_DEF_T2_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/42-real-life-OK.asn1.-PR
+++ b/tests/tests-asn1c-compiler/42-real-life-OK.asn1.-PR
@@ -93,17 +93,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_varsets_3 = {
 	"varsets",
 	"varsets",
-	SEQUENCE_OF_free,
-	SEQUENCE_OF_print,
-	SEQUENCE_OF_compare,
+	&asn_OP_SEQUENCE_OF,
 	SEQUENCE_OF_constraint,
-	SEQUENCE_OF_decode_ber,
-	SEQUENCE_OF_encode_der,
-	SEQUENCE_OF_decode_xer,
-	SEQUENCE_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_varsets_tags_3,
 	sizeof(asn_DEF_varsets_tags_3)
 		/sizeof(asn_DEF_varsets_tags_3[0]), /* 1 */
@@ -160,17 +151,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_LogLine_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_LogLine = {
 	"LogLine",
 	"LogLine",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_LogLine_tags_1,
 	sizeof(asn_DEF_LogLine_tags_1)
 		/sizeof(asn_DEF_LogLine_tags_1[0]), /* 1 */
@@ -274,17 +256,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_vparts_2 = {
 	"vparts",
 	"vparts",
-	SEQUENCE_OF_free,
-	SEQUENCE_OF_print,
-	SEQUENCE_OF_compare,
+	&asn_OP_SEQUENCE_OF,
 	SEQUENCE_OF_constraint,
-	SEQUENCE_OF_decode_ber,
-	SEQUENCE_OF_encode_der,
-	SEQUENCE_OF_decode_xer,
-	SEQUENCE_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_vparts_tags_2,
 	sizeof(asn_DEF_vparts_tags_2)
 		/sizeof(asn_DEF_vparts_tags_2[0]), /* 1 */
@@ -341,17 +314,8 @@ asn_SEQUENCE_specifics_t asn_SPC_VariablePartSet_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_VariablePartSet = {
 	"VariablePartSet",
 	"VariablePartSet",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_VariablePartSet_tags_1,
 	sizeof(asn_DEF_VariablePartSet_tags_1)
 		/sizeof(asn_DEF_VariablePartSet_tags_1[0]), /* 1 */
@@ -478,17 +442,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_vset_2 = {
 	"vset",
 	"vset",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_vset_tags_2,
 	sizeof(asn_DEF_vset_tags_2)
 		/sizeof(asn_DEF_vset_tags_2[0]), /* 1 */
@@ -546,17 +501,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_vrange_4 = {
 	"vrange",
 	"vrange",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_vrange_tags_4,
 	sizeof(asn_DEF_vrange_tags_4)
 		/sizeof(asn_DEF_vrange_tags_4[0]), /* 1 */
@@ -611,17 +557,8 @@ asn_CHOICE_specifics_t asn_SPC_VariablePart_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_VariablePart = {
 	"VariablePart",
 	"VariablePart",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -727,17 +664,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_accept_as_2 = {
 	"accept-as",
 	"accept-as",
-	NativeEnumerated_free,
-	NativeEnumerated_print,
-	NativeEnumerated_compare,
+	&asn_OP_NativeEnumerated,
 	NativeEnumerated_constraint,
-	NativeEnumerated_decode_ber,
-	NativeEnumerated_encode_der,
-	NativeEnumerated_decode_xer,
-	NativeEnumerated_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_accept_as_tags_2,
 	sizeof(asn_DEF_accept_as_tags_2)
 		/sizeof(asn_DEF_accept_as_tags_2[0]), /* 1 */
@@ -775,17 +703,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_email_9 = {
 	"email",
 	"email",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_email_tags_9,
 	sizeof(asn_DEF_email_tags_9)
 		/sizeof(asn_DEF_email_tags_9[0]), /* 1 */
@@ -843,17 +762,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_notify_7 = {
 	"notify",
 	"notify",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_notify_tags_7,
 	sizeof(asn_DEF_notify_tags_7)
 		/sizeof(asn_DEF_notify_tags_7[0]), /* 1 */
@@ -910,17 +820,8 @@ asn_SEQUENCE_specifics_t asn_SPC_ActionItem_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_ActionItem = {
 	"ActionItem",
 	"ActionItem",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_ActionItem_tags_1,
 	sizeof(asn_DEF_ActionItem_tags_1)
 		/sizeof(asn_DEF_ActionItem_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/43-recursion-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/43-recursion-OK.asn1.-Pfwide-types
@@ -71,17 +71,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_t_member1_2 = {
 	"t-member1",
 	"t-member1",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_t_member1_tags_2,
 	sizeof(asn_DEF_t_member1_tags_2)
 		/sizeof(asn_DEF_t_member1_tags_2[0]), /* 1 */
@@ -120,17 +111,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_t_member2_4 = {
 	"t-member2",
 	"t-member2",
-	SEQUENCE_OF_free,
-	SEQUENCE_OF_print,
-	SEQUENCE_OF_compare,
+	&asn_OP_SEQUENCE_OF,
 	SEQUENCE_OF_constraint,
-	SEQUENCE_OF_decode_ber,
-	SEQUENCE_OF_encode_der,
-	SEQUENCE_OF_decode_xer,
-	SEQUENCE_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_t_member2_tags_4,
 	sizeof(asn_DEF_t_member2_tags_4)
 		/sizeof(asn_DEF_t_member2_tags_4[0]), /* 1 */
@@ -211,17 +193,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Test_structure_1_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Test_structure_1 = {
 	"Test-structure-1",
 	"Test-structure-1",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Test_structure_1_tags_1,
 	sizeof(asn_DEF_Test_structure_1_tags_1)
 		/sizeof(asn_DEF_Test_structure_1_tags_1[0]), /* 1 */
@@ -315,17 +288,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_or_3 = {
 	"or",
 	"or",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_or_tags_3,
 	sizeof(asn_DEF_or_tags_3)
 		/sizeof(asn_DEF_or_tags_3[0]) - 1, /* 1 */
@@ -404,17 +368,8 @@ asn_CHOICE_specifics_t asn_SPC_Choice_1_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Choice_1 = {
 	"Choice-1",
 	"Choice-1",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -506,17 +461,8 @@ asn_SET_specifics_t asn_SPC_Test_structure_2_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Test_structure_2 = {
 	"Test-structure-2",
 	"Test-structure-2",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Test_structure_2_tags_1,
 	sizeof(asn_DEF_Test_structure_2_tags_1)
 		/sizeof(asn_DEF_Test_structure_2_tags_1[0]), /* 1 */
@@ -610,17 +556,8 @@ asn_SET_specifics_t asn_SPC_Test_structure_3_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Test_structure_3 = {
 	"Test-structure-3",
 	"Test-structure-3",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Test_structure_3_tags_1,
 	sizeof(asn_DEF_Test_structure_3_tags_1)
 		/sizeof(asn_DEF_Test_structure_3_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/44-choice-in-sequence-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/44-choice-in-sequence-OK.asn1.-P
@@ -112,17 +112,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_e_6 = {
 	"e",
 	"e",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -176,17 +167,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_h_9 = {
 	"h",
 	"h",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -265,17 +247,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_b_3 = {
 	"b",
 	"b",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -335,17 +308,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_T_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
 	sizeof(asn_DEF_T_tags_1)
 		/sizeof(asn_DEF_T_tags_1[0]) - 1, /* 1 */

--- a/tests/tests-asn1c-compiler/46-redefine-OK.asn1.-PR
+++ b/tests/tests-asn1c-compiler/46-redefine-OK.asn1.-PR
@@ -33,17 +33,8 @@ static const ber_tlv_tag_t asn_DEF_PrimitiveType_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_PrimitiveType = {
 	"PrimitiveType",
 	"PrimitiveType",
-	OCTET_STRING_free,
-	OCTET_STRING_print,
-	OCTET_STRING_compare,
+	&asn_OP_OCTET_STRING,
 	OCTET_STRING_constraint,
-	OCTET_STRING_decode_ber,
-	OCTET_STRING_encode_der,
-	OCTET_STRING_decode_xer,
-	OCTET_STRING_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_PrimitiveType_tags_1,
 	sizeof(asn_DEF_PrimitiveType_tags_1)
 		/sizeof(asn_DEF_PrimitiveType_tags_1[0]), /* 1 */
@@ -110,17 +101,8 @@ asn_SEQUENCE_specifics_t asn_SPC_ConstructedType_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_ConstructedType = {
 	"ConstructedType",
 	"ConstructedType",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_ConstructedType_tags_1,
 	sizeof(asn_DEF_ConstructedType_tags_1)
 		/sizeof(asn_DEF_ConstructedType_tags_1[0]), /* 1 */
@@ -170,17 +152,8 @@ static const ber_tlv_tag_t asn_DEF_T_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
 	sizeof(asn_DEF_T_tags_1)
 		/sizeof(asn_DEF_T_tags_1[0]) - 1, /* 1 */

--- a/tests/tests-asn1c-compiler/47-set-ext-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/47-set-ext-OK.asn1.-Pfwide-types
@@ -74,17 +74,8 @@ asn_SET_specifics_t asn_SPC_T1_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T1 = {
 	"T1",
 	"T1",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T1_tags_1,
 	sizeof(asn_DEF_T1_tags_1)
 		/sizeof(asn_DEF_T1_tags_1[0]), /* 1 */
@@ -174,17 +165,8 @@ asn_SET_specifics_t asn_SPC_T2_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T2 = {
 	"T2",
 	"T2",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T2_tags_1,
 	sizeof(asn_DEF_T2_tags_1)
 		/sizeof(asn_DEF_T2_tags_1[0]), /* 1 */
@@ -264,17 +246,8 @@ static asn_CHOICE_specifics_t asn_SPC_T3_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T3 = {
 	"T3",
 	"T3",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -352,17 +325,8 @@ static asn_CHOICE_specifics_t asn_SPC_T4_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T4 = {
 	"T4",
 	"T4",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */

--- a/tests/tests-asn1c-compiler/50-constraint-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/50-constraint-OK.asn1.-Pfwide-types
@@ -33,17 +33,8 @@ static const ber_tlv_tag_t asn_DEF_Int1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int1 = {
 	"Int1",
 	"Int1",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	INTEGER_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int1_tags_1,
 	sizeof(asn_DEF_Int1_tags_1)
 		/sizeof(asn_DEF_Int1_tags_1[0]), /* 1 */
@@ -118,17 +109,8 @@ static const ber_tlv_tag_t asn_DEF_Int2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int2 = {
 	"Int2",
 	"Int2",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	Int2_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int2_tags_1,
 	sizeof(asn_DEF_Int2_tags_1)
 		/sizeof(asn_DEF_Int2_tags_1[0]), /* 1 */
@@ -207,17 +189,8 @@ static const ber_tlv_tag_t asn_DEF_Int3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int3 = {
 	"Int3",
 	"Int3",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	Int3_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int3_tags_1,
 	sizeof(asn_DEF_Int3_tags_1)
 		/sizeof(asn_DEF_Int3_tags_1[0]), /* 1 */
@@ -296,17 +269,8 @@ static const ber_tlv_tag_t asn_DEF_Int4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int4 = {
 	"Int4",
 	"Int4",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	Int4_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int4_tags_1,
 	sizeof(asn_DEF_Int4_tags_1)
 		/sizeof(asn_DEF_Int4_tags_1[0]), /* 1 */
@@ -385,17 +349,8 @@ static const ber_tlv_tag_t asn_DEF_Int5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int5 = {
 	"Int5",
 	"Int5",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	Int5_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int5_tags_1,
 	sizeof(asn_DEF_Int5_tags_1)
 		/sizeof(asn_DEF_Int5_tags_1[0]), /* 1 */
@@ -474,17 +429,8 @@ static const ber_tlv_tag_t asn_DEF_ExtensibleExtensions_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_ExtensibleExtensions = {
 	"ExtensibleExtensions",
 	"ExtensibleExtensions",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	ExtensibleExtensions_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_ExtensibleExtensions_tags_1,
 	sizeof(asn_DEF_ExtensibleExtensions_tags_1)
 		/sizeof(asn_DEF_ExtensibleExtensions_tags_1[0]), /* 1 */
@@ -532,17 +478,8 @@ static const ber_tlv_tag_t asn_DEF_Str1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Str1 = {
 	"Str1",
 	"Str1",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	IA5String_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Str1_tags_1,
 	sizeof(asn_DEF_Str1_tags_1)
 		/sizeof(asn_DEF_Str1_tags_1[0]), /* 1 */
@@ -633,17 +570,8 @@ static const ber_tlv_tag_t asn_DEF_Str2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Str2 = {
 	"Str2",
 	"Str2",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	Str2_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Str2_tags_1,
 	sizeof(asn_DEF_Str2_tags_1)
 		/sizeof(asn_DEF_Str2_tags_1[0]), /* 1 */
@@ -745,17 +673,8 @@ static const ber_tlv_tag_t asn_DEF_Str3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Str3 = {
 	"Str3",
 	"Str3",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	Str3_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Str3_tags_1,
 	sizeof(asn_DEF_Str3_tags_1)
 		/sizeof(asn_DEF_Str3_tags_1[0]), /* 1 */
@@ -843,17 +762,8 @@ static const ber_tlv_tag_t asn_DEF_Str4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Str4 = {
 	"Str4",
 	"Str4",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	Str4_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Str4_tags_1,
 	sizeof(asn_DEF_Str4_tags_1)
 		/sizeof(asn_DEF_Str4_tags_1[0]), /* 1 */
@@ -941,17 +851,8 @@ static const ber_tlv_tag_t asn_DEF_PER_Visible_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_PER_Visible = {
 	"PER-Visible",
 	"PER-Visible",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	PER_Visible_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_PER_Visible_tags_1,
 	sizeof(asn_DEF_PER_Visible_tags_1)
 		/sizeof(asn_DEF_PER_Visible_tags_1[0]), /* 1 */
@@ -1039,17 +940,8 @@ static const ber_tlv_tag_t asn_DEF_PER_Visible_2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_PER_Visible_2 = {
 	"PER-Visible-2",
 	"PER-Visible-2",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	PER_Visible_2_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_PER_Visible_2_tags_1,
 	sizeof(asn_DEF_PER_Visible_2_tags_1)
 		/sizeof(asn_DEF_PER_Visible_2_tags_1[0]), /* 1 */
@@ -1137,17 +1029,8 @@ static const ber_tlv_tag_t asn_DEF_Not_PER_Visible_1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Not_PER_Visible_1 = {
 	"Not-PER-Visible-1",
 	"Not-PER-Visible-1",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	Not_PER_Visible_1_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Not_PER_Visible_1_tags_1,
 	sizeof(asn_DEF_Not_PER_Visible_1_tags_1)
 		/sizeof(asn_DEF_Not_PER_Visible_1_tags_1[0]), /* 1 */
@@ -1235,17 +1118,8 @@ static const ber_tlv_tag_t asn_DEF_Not_PER_Visible_2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Not_PER_Visible_2 = {
 	"Not-PER-Visible-2",
 	"Not-PER-Visible-2",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	Not_PER_Visible_2_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Not_PER_Visible_2_tags_1,
 	sizeof(asn_DEF_Not_PER_Visible_2_tags_1)
 		/sizeof(asn_DEF_Not_PER_Visible_2_tags_1[0]), /* 1 */
@@ -1333,17 +1207,8 @@ static const ber_tlv_tag_t asn_DEF_Not_PER_Visible_3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Not_PER_Visible_3 = {
 	"Not-PER-Visible-3",
 	"Not-PER-Visible-3",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	Not_PER_Visible_3_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Not_PER_Visible_3_tags_1,
 	sizeof(asn_DEF_Not_PER_Visible_3_tags_1)
 		/sizeof(asn_DEF_Not_PER_Visible_3_tags_1[0]), /* 1 */
@@ -1434,17 +1299,8 @@ static const ber_tlv_tag_t asn_DEF_SIZE_but_not_FROM_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_SIZE_but_not_FROM = {
 	"SIZE-but-not-FROM",
 	"SIZE-but-not-FROM",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	SIZE_but_not_FROM_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SIZE_but_not_FROM_tags_1,
 	sizeof(asn_DEF_SIZE_but_not_FROM_tags_1)
 		/sizeof(asn_DEF_SIZE_but_not_FROM_tags_1[0]), /* 1 */
@@ -1535,17 +1391,8 @@ static const ber_tlv_tag_t asn_DEF_SIZE_and_FROM_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_SIZE_and_FROM = {
 	"SIZE-and-FROM",
 	"SIZE-and-FROM",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	SIZE_and_FROM_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SIZE_and_FROM_tags_1,
 	sizeof(asn_DEF_SIZE_and_FROM_tags_1)
 		/sizeof(asn_DEF_SIZE_and_FROM_tags_1[0]), /* 1 */
@@ -1633,17 +1480,8 @@ static const ber_tlv_tag_t asn_DEF_Neither_SIZE_nor_FROM_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Neither_SIZE_nor_FROM = {
 	"Neither-SIZE-nor-FROM",
 	"Neither-SIZE-nor-FROM",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	Neither_SIZE_nor_FROM_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Neither_SIZE_nor_FROM_tags_1,
 	sizeof(asn_DEF_Neither_SIZE_nor_FROM_tags_1)
 		/sizeof(asn_DEF_Neither_SIZE_nor_FROM_tags_1[0]), /* 1 */
@@ -1725,17 +1563,8 @@ static const ber_tlv_tag_t asn_DEF_Utf8_4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Utf8_4 = {
 	"Utf8-4",
 	"Utf8-4",
-	UTF8String_free,
-	UTF8String_print,
-	UTF8String_compare,
+	&asn_OP_UTF8String,
 	Utf8_4_constraint,
-	UTF8String_decode_ber,
-	UTF8String_encode_der,
-	UTF8String_decode_xer,
-	UTF8String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Utf8_4_tags_1,
 	sizeof(asn_DEF_Utf8_4_tags_1)
 		/sizeof(asn_DEF_Utf8_4_tags_1[0]), /* 1 */
@@ -1845,17 +1674,8 @@ static const ber_tlv_tag_t asn_DEF_Utf8_3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Utf8_3 = {
 	"Utf8-3",
 	"Utf8-3",
-	UTF8String_free,
-	UTF8String_print,
-	UTF8String_compare,
+	&asn_OP_UTF8String,
 	Utf8_3_constraint,
-	UTF8String_decode_ber,
-	UTF8String_encode_der,
-	UTF8String_decode_xer,
-	UTF8String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Utf8_3_tags_1,
 	sizeof(asn_DEF_Utf8_3_tags_1)
 		/sizeof(asn_DEF_Utf8_3_tags_1[0]), /* 1 */
@@ -1935,17 +1755,8 @@ static const ber_tlv_tag_t asn_DEF_Utf8_2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Utf8_2 = {
 	"Utf8-2",
 	"Utf8-2",
-	UTF8String_free,
-	UTF8String_print,
-	UTF8String_compare,
+	&asn_OP_UTF8String,
 	Utf8_2_constraint,
-	UTF8String_decode_ber,
-	UTF8String_encode_der,
-	UTF8String_decode_xer,
-	UTF8String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Utf8_2_tags_1,
 	sizeof(asn_DEF_Utf8_2_tags_1)
 		/sizeof(asn_DEF_Utf8_2_tags_1[0]), /* 1 */
@@ -1993,17 +1804,8 @@ static const ber_tlv_tag_t asn_DEF_Utf8_1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Utf8_1 = {
 	"Utf8-1",
 	"Utf8-1",
-	UTF8String_free,
-	UTF8String_print,
-	UTF8String_compare,
+	&asn_OP_UTF8String,
 	UTF8String_constraint,
-	UTF8String_decode_ber,
-	UTF8String_encode_der,
-	UTF8String_decode_xer,
-	UTF8String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Utf8_1_tags_1,
 	sizeof(asn_DEF_Utf8_1_tags_1)
 		/sizeof(asn_DEF_Utf8_1_tags_1[0]), /* 1 */
@@ -2106,17 +1908,8 @@ static const ber_tlv_tag_t asn_DEF_VisibleIdentifier_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_VisibleIdentifier = {
 	"VisibleIdentifier",
 	"VisibleIdentifier",
-	VisibleString_free,
-	VisibleString_print,
-	VisibleString_compare,
+	&asn_OP_VisibleString,
 	VisibleIdentifier_constraint,
-	VisibleString_decode_ber,
-	VisibleString_encode_der,
-	VisibleString_decode_xer,
-	VisibleString_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_VisibleIdentifier_tags_1,
 	sizeof(asn_DEF_VisibleIdentifier_tags_1)
 		/sizeof(asn_DEF_VisibleIdentifier_tags_1[0]), /* 1 */
@@ -2345,17 +2138,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_enum_c_6 = {
 	"enum-c",
 	"enum-c",
-	ENUMERATED_free,
-	ENUMERATED_print,
-	ENUMERATED_compare,
+	&asn_OP_ENUMERATED,
 	ENUMERATED_constraint,
-	ENUMERATED_decode_ber,
-	ENUMERATED_encode_der,
-	ENUMERATED_decode_xer,
-	ENUMERATED_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_enum_c_tags_6,
 	sizeof(asn_DEF_enum_c_tags_6)
 		/sizeof(asn_DEF_enum_c_tags_6[0]), /* 1 */
@@ -2471,17 +2255,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Sequence = {
 	"Sequence",
 	"Sequence",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Sequence_tags_1,
 	sizeof(asn_DEF_Sequence_tags_1)
 		/sizeof(asn_DEF_Sequence_tags_1[0]), /* 1 */
@@ -2548,17 +2323,8 @@ static asn_SET_OF_specifics_t asn_SPC_SequenceOf_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_SequenceOf = {
 	"SequenceOf",
 	"SequenceOf",
-	SEQUENCE_OF_free,
-	SEQUENCE_OF_print,
-	SEQUENCE_OF_compare,
+	&asn_OP_SEQUENCE_OF,
 	SEQUENCE_OF_constraint,
-	SEQUENCE_OF_decode_ber,
-	SEQUENCE_OF_encode_der,
-	SEQUENCE_OF_decode_xer,
-	SEQUENCE_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SequenceOf_tags_1,
 	sizeof(asn_DEF_SequenceOf_tags_1)
 		/sizeof(asn_DEF_SequenceOf_tags_1[0]), /* 1 */
@@ -2631,17 +2397,8 @@ static const ber_tlv_tag_t asn_DEF_Enum0_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Enum0 = {
 	"Enum0",
 	"Enum0",
-	ENUMERATED_free,
-	ENUMERATED_print,
-	ENUMERATED_compare,
+	&asn_OP_ENUMERATED,
 	ENUMERATED_constraint,
-	ENUMERATED_decode_ber,
-	ENUMERATED_encode_der,
-	ENUMERATED_decode_xer,
-	ENUMERATED_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Enum0_tags_1,
 	sizeof(asn_DEF_Enum0_tags_1)
 		/sizeof(asn_DEF_Enum0_tags_1[0]), /* 1 */
@@ -2738,17 +2495,8 @@ static const ber_tlv_tag_t asn_DEF_Enum1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Enum1 = {
 	"Enum1",
 	"Enum1",
-	NativeEnumerated_free,
-	NativeEnumerated_print,
-	NativeEnumerated_compare,
+	&asn_OP_NativeEnumerated,
 	Enum1_constraint,
-	NativeEnumerated_decode_ber,
-	NativeEnumerated_encode_der,
-	NativeEnumerated_decode_xer,
-	NativeEnumerated_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Enum1_tags_1,
 	sizeof(asn_DEF_Enum1_tags_1)
 		/sizeof(asn_DEF_Enum1_tags_1[0]), /* 1 */
@@ -2851,17 +2599,8 @@ static const ber_tlv_tag_t asn_DEF_Identifier_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Identifier = {
 	"Identifier",
 	"Identifier",
-	VisibleString_free,
-	VisibleString_print,
-	VisibleString_compare,
+	&asn_OP_VisibleString,
 	Identifier_constraint,
-	VisibleString_decode_ber,
-	VisibleString_encode_der,
-	VisibleString_decode_xer,
-	VisibleString_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Identifier_tags_1,
 	sizeof(asn_DEF_Identifier_tags_1)
 		/sizeof(asn_DEF_Identifier_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/50-constraint-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/50-constraint-OK.asn1.-Pgen-PER
@@ -35,18 +35,8 @@ static const ber_tlv_tag_t asn_DEF_Int1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int1 = {
 	"Int1",
 	"Int1",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NativeInteger_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int1_tags_1,
 	sizeof(asn_DEF_Int1_tags_1)
 		/sizeof(asn_DEF_Int1_tags_1[0]), /* 1 */
@@ -130,18 +120,8 @@ static const ber_tlv_tag_t asn_DEF_Int2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int2 = {
 	"Int2",
 	"Int2",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	Int2_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int2_tags_1,
 	sizeof(asn_DEF_Int2_tags_1)
 		/sizeof(asn_DEF_Int2_tags_1[0]), /* 1 */
@@ -225,18 +205,8 @@ static const ber_tlv_tag_t asn_DEF_Int3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int3 = {
 	"Int3",
 	"Int3",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	Int3_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int3_tags_1,
 	sizeof(asn_DEF_Int3_tags_1)
 		/sizeof(asn_DEF_Int3_tags_1[0]), /* 1 */
@@ -320,18 +290,8 @@ static const ber_tlv_tag_t asn_DEF_Int4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int4 = {
 	"Int4",
 	"Int4",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	Int4_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int4_tags_1,
 	sizeof(asn_DEF_Int4_tags_1)
 		/sizeof(asn_DEF_Int4_tags_1[0]), /* 1 */
@@ -415,18 +375,8 @@ static const ber_tlv_tag_t asn_DEF_Int5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Int5 = {
 	"Int5",
 	"Int5",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	Int5_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Int5_tags_1,
 	sizeof(asn_DEF_Int5_tags_1)
 		/sizeof(asn_DEF_Int5_tags_1[0]), /* 1 */
@@ -509,18 +459,8 @@ static const ber_tlv_tag_t asn_DEF_ExtensibleExtensions_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_ExtensibleExtensions = {
 	"ExtensibleExtensions",
 	"ExtensibleExtensions",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	ExtensibleExtensions_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_ExtensibleExtensions_tags_1,
 	sizeof(asn_DEF_ExtensibleExtensions_tags_1)
 		/sizeof(asn_DEF_ExtensibleExtensions_tags_1[0]), /* 1 */
@@ -570,18 +510,8 @@ static const ber_tlv_tag_t asn_DEF_Str1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Str1 = {
 	"Str1",
 	"Str1",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	IA5String_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	IA5String_decode_uper,
-	IA5String_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Str1_tags_1,
 	sizeof(asn_DEF_Str1_tags_1)
 		/sizeof(asn_DEF_Str1_tags_1[0]), /* 1 */
@@ -683,18 +613,8 @@ static const ber_tlv_tag_t asn_DEF_Str2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Str2 = {
 	"Str2",
 	"Str2",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	Str2_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	IA5String_decode_uper,
-	IA5String_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Str2_tags_1,
 	sizeof(asn_DEF_Str2_tags_1)
 		/sizeof(asn_DEF_Str2_tags_1[0]), /* 1 */
@@ -820,18 +740,8 @@ static const ber_tlv_tag_t asn_DEF_Str3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Str3 = {
 	"Str3",
 	"Str3",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	Str3_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	IA5String_decode_uper,
-	IA5String_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Str3_tags_1,
 	sizeof(asn_DEF_Str3_tags_1)
 		/sizeof(asn_DEF_Str3_tags_1[0]), /* 1 */
@@ -929,18 +839,8 @@ static const ber_tlv_tag_t asn_DEF_Str4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Str4 = {
 	"Str4",
 	"Str4",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	Str4_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	IA5String_decode_uper,
-	IA5String_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Str4_tags_1,
 	sizeof(asn_DEF_Str4_tags_1)
 		/sizeof(asn_DEF_Str4_tags_1[0]), /* 1 */
@@ -1039,18 +939,8 @@ static const ber_tlv_tag_t asn_DEF_PER_Visible_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_PER_Visible = {
 	"PER-Visible",
 	"PER-Visible",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	PER_Visible_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	IA5String_decode_uper,
-	IA5String_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_PER_Visible_tags_1,
 	sizeof(asn_DEF_PER_Visible_tags_1)
 		/sizeof(asn_DEF_PER_Visible_tags_1[0]), /* 1 */
@@ -1148,18 +1038,8 @@ static const ber_tlv_tag_t asn_DEF_PER_Visible_2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_PER_Visible_2 = {
 	"PER-Visible-2",
 	"PER-Visible-2",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	PER_Visible_2_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	IA5String_decode_uper,
-	IA5String_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_PER_Visible_2_tags_1,
 	sizeof(asn_DEF_PER_Visible_2_tags_1)
 		/sizeof(asn_DEF_PER_Visible_2_tags_1[0]), /* 1 */
@@ -1257,18 +1137,8 @@ static const ber_tlv_tag_t asn_DEF_Not_PER_Visible_1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Not_PER_Visible_1 = {
 	"Not-PER-Visible-1",
 	"Not-PER-Visible-1",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	Not_PER_Visible_1_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	IA5String_decode_uper,
-	IA5String_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Not_PER_Visible_1_tags_1,
 	sizeof(asn_DEF_Not_PER_Visible_1_tags_1)
 		/sizeof(asn_DEF_Not_PER_Visible_1_tags_1[0]), /* 1 */
@@ -1366,18 +1236,8 @@ static const ber_tlv_tag_t asn_DEF_Not_PER_Visible_2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Not_PER_Visible_2 = {
 	"Not-PER-Visible-2",
 	"Not-PER-Visible-2",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	Not_PER_Visible_2_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	IA5String_decode_uper,
-	IA5String_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Not_PER_Visible_2_tags_1,
 	sizeof(asn_DEF_Not_PER_Visible_2_tags_1)
 		/sizeof(asn_DEF_Not_PER_Visible_2_tags_1[0]), /* 1 */
@@ -1475,18 +1335,8 @@ static const ber_tlv_tag_t asn_DEF_Not_PER_Visible_3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Not_PER_Visible_3 = {
 	"Not-PER-Visible-3",
 	"Not-PER-Visible-3",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	Not_PER_Visible_3_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	IA5String_decode_uper,
-	IA5String_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Not_PER_Visible_3_tags_1,
 	sizeof(asn_DEF_Not_PER_Visible_3_tags_1)
 		/sizeof(asn_DEF_Not_PER_Visible_3_tags_1[0]), /* 1 */
@@ -1587,18 +1437,8 @@ static const ber_tlv_tag_t asn_DEF_SIZE_but_not_FROM_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_SIZE_but_not_FROM = {
 	"SIZE-but-not-FROM",
 	"SIZE-but-not-FROM",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	SIZE_but_not_FROM_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	IA5String_decode_uper,
-	IA5String_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SIZE_but_not_FROM_tags_1,
 	sizeof(asn_DEF_SIZE_but_not_FROM_tags_1)
 		/sizeof(asn_DEF_SIZE_but_not_FROM_tags_1[0]), /* 1 */
@@ -1699,18 +1539,8 @@ static const ber_tlv_tag_t asn_DEF_SIZE_and_FROM_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_SIZE_and_FROM = {
 	"SIZE-and-FROM",
 	"SIZE-and-FROM",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	SIZE_and_FROM_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	IA5String_decode_uper,
-	IA5String_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SIZE_and_FROM_tags_1,
 	sizeof(asn_DEF_SIZE_and_FROM_tags_1)
 		/sizeof(asn_DEF_SIZE_and_FROM_tags_1[0]), /* 1 */
@@ -1808,18 +1638,8 @@ static const ber_tlv_tag_t asn_DEF_Neither_SIZE_nor_FROM_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Neither_SIZE_nor_FROM = {
 	"Neither-SIZE-nor-FROM",
 	"Neither-SIZE-nor-FROM",
-	IA5String_free,
-	IA5String_print,
-	IA5String_compare,
+	&asn_OP_IA5String,
 	Neither_SIZE_nor_FROM_constraint,
-	IA5String_decode_ber,
-	IA5String_encode_der,
-	IA5String_decode_xer,
-	IA5String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	IA5String_decode_uper,
-	IA5String_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Neither_SIZE_nor_FROM_tags_1,
 	sizeof(asn_DEF_Neither_SIZE_nor_FROM_tags_1)
 		/sizeof(asn_DEF_Neither_SIZE_nor_FROM_tags_1[0]), /* 1 */
@@ -1911,18 +1731,8 @@ static const ber_tlv_tag_t asn_DEF_Utf8_4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Utf8_4 = {
 	"Utf8-4",
 	"Utf8-4",
-	UTF8String_free,
-	UTF8String_print,
-	UTF8String_compare,
+	&asn_OP_UTF8String,
 	Utf8_4_constraint,
-	UTF8String_decode_ber,
-	UTF8String_encode_der,
-	UTF8String_decode_xer,
-	UTF8String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	UTF8String_decode_uper,
-	UTF8String_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Utf8_4_tags_1,
 	sizeof(asn_DEF_Utf8_4_tags_1)
 		/sizeof(asn_DEF_Utf8_4_tags_1[0]), /* 1 */
@@ -2042,18 +1852,8 @@ static const ber_tlv_tag_t asn_DEF_Utf8_3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Utf8_3 = {
 	"Utf8-3",
 	"Utf8-3",
-	UTF8String_free,
-	UTF8String_print,
-	UTF8String_compare,
+	&asn_OP_UTF8String,
 	Utf8_3_constraint,
-	UTF8String_decode_ber,
-	UTF8String_encode_der,
-	UTF8String_decode_xer,
-	UTF8String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	UTF8String_decode_uper,
-	UTF8String_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Utf8_3_tags_1,
 	sizeof(asn_DEF_Utf8_3_tags_1)
 		/sizeof(asn_DEF_Utf8_3_tags_1[0]), /* 1 */
@@ -2144,18 +1944,8 @@ static const ber_tlv_tag_t asn_DEF_Utf8_2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Utf8_2 = {
 	"Utf8-2",
 	"Utf8-2",
-	UTF8String_free,
-	UTF8String_print,
-	UTF8String_compare,
+	&asn_OP_UTF8String,
 	Utf8_2_constraint,
-	UTF8String_decode_ber,
-	UTF8String_encode_der,
-	UTF8String_decode_xer,
-	UTF8String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	UTF8String_decode_uper,
-	UTF8String_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Utf8_2_tags_1,
 	sizeof(asn_DEF_Utf8_2_tags_1)
 		/sizeof(asn_DEF_Utf8_2_tags_1[0]), /* 1 */
@@ -2205,18 +1995,8 @@ static const ber_tlv_tag_t asn_DEF_Utf8_1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Utf8_1 = {
 	"Utf8-1",
 	"Utf8-1",
-	UTF8String_free,
-	UTF8String_print,
-	UTF8String_compare,
+	&asn_OP_UTF8String,
 	UTF8String_constraint,
-	UTF8String_decode_ber,
-	UTF8String_encode_der,
-	UTF8String_decode_xer,
-	UTF8String_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	UTF8String_decode_uper,
-	UTF8String_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Utf8_1_tags_1,
 	sizeof(asn_DEF_Utf8_1_tags_1)
 		/sizeof(asn_DEF_Utf8_1_tags_1[0]), /* 1 */
@@ -2328,18 +2108,8 @@ static const ber_tlv_tag_t asn_DEF_VisibleIdentifier_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_VisibleIdentifier = {
 	"VisibleIdentifier",
 	"VisibleIdentifier",
-	VisibleString_free,
-	VisibleString_print,
-	VisibleString_compare,
+	&asn_OP_VisibleString,
 	VisibleIdentifier_constraint,
-	VisibleString_decode_ber,
-	VisibleString_encode_der,
-	VisibleString_decode_xer,
-	VisibleString_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	VisibleString_decode_uper,
-	VisibleString_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_VisibleIdentifier_tags_1,
 	sizeof(asn_DEF_VisibleIdentifier_tags_1)
 		/sizeof(asn_DEF_VisibleIdentifier_tags_1[0]), /* 1 */
@@ -2571,18 +2341,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_enum_c_6 = {
 	"enum-c",
 	"enum-c",
-	NativeEnumerated_free,
-	NativeEnumerated_print,
-	NativeEnumerated_compare,
+	&asn_OP_NativeEnumerated,
 	NativeEnumerated_constraint,
-	NativeEnumerated_decode_ber,
-	NativeEnumerated_encode_der,
-	NativeEnumerated_decode_xer,
-	NativeEnumerated_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeEnumerated_decode_uper,
-	NativeEnumerated_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_enum_c_tags_6,
 	sizeof(asn_DEF_enum_c_tags_6)
 		/sizeof(asn_DEF_enum_c_tags_6[0]), /* 1 */
@@ -2700,18 +2460,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Sequence = {
 	"Sequence",
 	"Sequence",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	SEQUENCE_decode_uper,
-	SEQUENCE_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Sequence_tags_1,
 	sizeof(asn_DEF_Sequence_tags_1)
 		/sizeof(asn_DEF_Sequence_tags_1[0]), /* 1 */
@@ -2786,18 +2536,8 @@ static asn_SET_OF_specifics_t asn_SPC_SequenceOf_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_SequenceOf = {
 	"SequenceOf",
 	"SequenceOf",
-	SEQUENCE_OF_free,
-	SEQUENCE_OF_print,
-	SEQUENCE_OF_compare,
+	&asn_OP_SEQUENCE_OF,
 	SEQUENCE_OF_constraint,
-	SEQUENCE_OF_decode_ber,
-	SEQUENCE_OF_encode_der,
-	SEQUENCE_OF_decode_xer,
-	SEQUENCE_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	SEQUENCE_OF_decode_uper,
-	SEQUENCE_OF_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SequenceOf_tags_1,
 	sizeof(asn_DEF_SequenceOf_tags_1)
 		/sizeof(asn_DEF_SequenceOf_tags_1[0]), /* 1 */
@@ -2880,18 +2620,8 @@ static const ber_tlv_tag_t asn_DEF_Enum0_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Enum0 = {
 	"Enum0",
 	"Enum0",
-	NativeEnumerated_free,
-	NativeEnumerated_print,
-	NativeEnumerated_compare,
+	&asn_OP_NativeEnumerated,
 	NativeEnumerated_constraint,
-	NativeEnumerated_decode_ber,
-	NativeEnumerated_encode_der,
-	NativeEnumerated_decode_xer,
-	NativeEnumerated_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeEnumerated_decode_uper,
-	NativeEnumerated_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Enum0_tags_1,
 	sizeof(asn_DEF_Enum0_tags_1)
 		/sizeof(asn_DEF_Enum0_tags_1[0]), /* 1 */
@@ -2998,18 +2728,8 @@ static const ber_tlv_tag_t asn_DEF_Enum1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Enum1 = {
 	"Enum1",
 	"Enum1",
-	NativeEnumerated_free,
-	NativeEnumerated_print,
-	NativeEnumerated_compare,
+	&asn_OP_NativeEnumerated,
 	Enum1_constraint,
-	NativeEnumerated_decode_ber,
-	NativeEnumerated_encode_der,
-	NativeEnumerated_decode_xer,
-	NativeEnumerated_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeEnumerated_decode_uper,
-	NativeEnumerated_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Enum1_tags_1,
 	sizeof(asn_DEF_Enum1_tags_1)
 		/sizeof(asn_DEF_Enum1_tags_1[0]), /* 1 */
@@ -3141,18 +2861,8 @@ static const ber_tlv_tag_t asn_DEF_Identifier_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_Identifier = {
 	"Identifier",
 	"Identifier",
-	VisibleString_free,
-	VisibleString_print,
-	VisibleString_compare,
+	&asn_OP_VisibleString,
 	Identifier_constraint,
-	VisibleString_decode_ber,
-	VisibleString_encode_der,
-	VisibleString_decode_xer,
-	VisibleString_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	VisibleString_decode_uper,
-	VisibleString_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Identifier_tags_1,
 	sizeof(asn_DEF_Identifier_tags_1)
 		/sizeof(asn_DEF_Identifier_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/59-choice-extended-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/59-choice-extended-OK.asn1.-Pfwide-types
@@ -104,17 +104,8 @@ asn_CHOICE_specifics_t asn_SPC_Choice_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Choice = {
 	"Choice",
 	"Choice",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	asn_DEF_Choice_tags_1,
 	sizeof(asn_DEF_Choice_tags_1)
 		/sizeof(asn_DEF_Choice_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/60-any-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/60-any-OK.asn1.-Pfwide-types
@@ -63,17 +63,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_T1_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T1 = {
 	"T1",
 	"T1",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T1_tags_1,
 	sizeof(asn_DEF_T1_tags_1)
 		/sizeof(asn_DEF_T1_tags_1[0]), /* 1 */
@@ -153,17 +144,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_T2_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T2 = {
 	"T2",
 	"T2",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T2_tags_1,
 	sizeof(asn_DEF_T2_tags_1)
 		/sizeof(asn_DEF_T2_tags_1[0]), /* 1 */
@@ -238,17 +220,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_T3_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T3 = {
 	"T3",
 	"T3",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T3_tags_1,
 	sizeof(asn_DEF_T3_tags_1)
 		/sizeof(asn_DEF_T3_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/65-multi-tag-OK.asn1.-Pfnative-types
+++ b/tests/tests-asn1c-compiler/65-multi-tag-OK.asn1.-Pfnative-types
@@ -44,17 +44,8 @@ static const ber_tlv_tag_t asn_DEF_T1_all_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T1 = {
 	"T1",
 	"T1",
-	NativeReal_free,
-	NativeReal_print,
-	NativeReal_compare,
+	&asn_OP_NativeReal,
 	NativeReal_constraint,
-	NativeReal_decode_ber,
-	NativeReal_encode_der,
-	NativeReal_decode_xer,
-	NativeReal_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T1_tags_1,
 	sizeof(asn_DEF_T1_tags_1)
 		/sizeof(asn_DEF_T1_tags_1[0]), /* 4 */
@@ -111,17 +102,8 @@ static const ber_tlv_tag_t asn_DEF_T2_all_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T2 = {
 	"T2",
 	"T2",
-	NativeReal_free,
-	NativeReal_print,
-	NativeReal_compare,
+	&asn_OP_NativeReal,
 	NativeReal_constraint,
-	NativeReal_decode_ber,
-	NativeReal_encode_der,
-	NativeReal_decode_xer,
-	NativeReal_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T2_tags_1,
 	sizeof(asn_DEF_T2_tags_1)
 		/sizeof(asn_DEF_T2_tags_1[0]), /* 3 */
@@ -176,17 +158,8 @@ static const ber_tlv_tag_t asn_DEF_T3_all_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T3 = {
 	"T3",
 	"T3",
-	NativeReal_free,
-	NativeReal_print,
-	NativeReal_compare,
+	&asn_OP_NativeReal,
 	NativeReal_constraint,
-	NativeReal_decode_ber,
-	NativeReal_encode_der,
-	NativeReal_decode_xer,
-	NativeReal_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T3_tags_1,
 	sizeof(asn_DEF_T3_tags_1)
 		/sizeof(asn_DEF_T3_tags_1[0]), /* 2 */
@@ -236,17 +209,8 @@ static const ber_tlv_tag_t asn_DEF_T4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T4 = {
 	"T4",
 	"T4",
-	NativeReal_free,
-	NativeReal_print,
-	NativeReal_compare,
+	&asn_OP_NativeReal,
 	NativeReal_constraint,
-	NativeReal_decode_ber,
-	NativeReal_encode_der,
-	NativeReal_decode_xer,
-	NativeReal_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T4_tags_1,
 	sizeof(asn_DEF_T4_tags_1)
 		/sizeof(asn_DEF_T4_tags_1[0]) - 1, /* 2 */
@@ -295,17 +259,8 @@ static const ber_tlv_tag_t asn_DEF_T5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T5 = {
 	"T5",
 	"T5",
-	NativeReal_free,
-	NativeReal_print,
-	NativeReal_compare,
+	&asn_OP_NativeReal,
 	NativeReal_constraint,
-	NativeReal_decode_ber,
-	NativeReal_encode_der,
-	NativeReal_decode_xer,
-	NativeReal_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T5_tags_1,
 	sizeof(asn_DEF_T5_tags_1)
 		/sizeof(asn_DEF_T5_tags_1[0]) - 1, /* 1 */
@@ -353,17 +308,8 @@ static const ber_tlv_tag_t asn_DEF_T6_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T6 = {
 	"T6",
 	"T6",
-	NativeReal_free,
-	NativeReal_print,
-	NativeReal_compare,
+	&asn_OP_NativeReal,
 	NativeReal_constraint,
-	NativeReal_decode_ber,
-	NativeReal_encode_der,
-	NativeReal_decode_xer,
-	NativeReal_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T6_tags_1,
 	sizeof(asn_DEF_T6_tags_1)
 		/sizeof(asn_DEF_T6_tags_1[0]), /* 1 */
@@ -413,17 +359,8 @@ static const ber_tlv_tag_t asn_DEF_T_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
 	sizeof(asn_DEF_T_tags_1)
 		/sizeof(asn_DEF_T_tags_1[0]) - 2, /* 1 */
@@ -519,17 +456,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Ts_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Ts = {
 	"Ts",
 	"Ts",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Ts_tags_1,
 	sizeof(asn_DEF_Ts_tags_1)
 		/sizeof(asn_DEF_Ts_tags_1[0]) - 1, /* 1 */

--- a/tests/tests-asn1c-compiler/65-multi-tag-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/65-multi-tag-OK.asn1.-Pfwide-types
@@ -44,17 +44,8 @@ static const ber_tlv_tag_t asn_DEF_T1_all_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T1 = {
 	"T1",
 	"T1",
-	REAL_free,
-	REAL_print,
-	REAL_compare,
+	&asn_OP_REAL,
 	REAL_constraint,
-	REAL_decode_ber,
-	REAL_encode_der,
-	REAL_decode_xer,
-	REAL_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T1_tags_1,
 	sizeof(asn_DEF_T1_tags_1)
 		/sizeof(asn_DEF_T1_tags_1[0]), /* 4 */
@@ -111,17 +102,8 @@ static const ber_tlv_tag_t asn_DEF_T2_all_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T2 = {
 	"T2",
 	"T2",
-	REAL_free,
-	REAL_print,
-	REAL_compare,
+	&asn_OP_REAL,
 	REAL_constraint,
-	REAL_decode_ber,
-	REAL_encode_der,
-	REAL_decode_xer,
-	REAL_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T2_tags_1,
 	sizeof(asn_DEF_T2_tags_1)
 		/sizeof(asn_DEF_T2_tags_1[0]), /* 3 */
@@ -176,17 +158,8 @@ static const ber_tlv_tag_t asn_DEF_T3_all_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T3 = {
 	"T3",
 	"T3",
-	REAL_free,
-	REAL_print,
-	REAL_compare,
+	&asn_OP_REAL,
 	REAL_constraint,
-	REAL_decode_ber,
-	REAL_encode_der,
-	REAL_decode_xer,
-	REAL_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T3_tags_1,
 	sizeof(asn_DEF_T3_tags_1)
 		/sizeof(asn_DEF_T3_tags_1[0]), /* 2 */
@@ -236,17 +209,8 @@ static const ber_tlv_tag_t asn_DEF_T4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T4 = {
 	"T4",
 	"T4",
-	REAL_free,
-	REAL_print,
-	REAL_compare,
+	&asn_OP_REAL,
 	REAL_constraint,
-	REAL_decode_ber,
-	REAL_encode_der,
-	REAL_decode_xer,
-	REAL_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T4_tags_1,
 	sizeof(asn_DEF_T4_tags_1)
 		/sizeof(asn_DEF_T4_tags_1[0]) - 1, /* 2 */
@@ -295,17 +259,8 @@ static const ber_tlv_tag_t asn_DEF_T5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T5 = {
 	"T5",
 	"T5",
-	REAL_free,
-	REAL_print,
-	REAL_compare,
+	&asn_OP_REAL,
 	REAL_constraint,
-	REAL_decode_ber,
-	REAL_encode_der,
-	REAL_decode_xer,
-	REAL_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T5_tags_1,
 	sizeof(asn_DEF_T5_tags_1)
 		/sizeof(asn_DEF_T5_tags_1[0]) - 1, /* 1 */
@@ -353,17 +308,8 @@ static const ber_tlv_tag_t asn_DEF_T6_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T6 = {
 	"T6",
 	"T6",
-	REAL_free,
-	REAL_print,
-	REAL_compare,
+	&asn_OP_REAL,
 	REAL_constraint,
-	REAL_decode_ber,
-	REAL_encode_der,
-	REAL_decode_xer,
-	REAL_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T6_tags_1,
 	sizeof(asn_DEF_T6_tags_1)
 		/sizeof(asn_DEF_T6_tags_1[0]), /* 1 */
@@ -413,17 +359,8 @@ static const ber_tlv_tag_t asn_DEF_T_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
 	sizeof(asn_DEF_T_tags_1)
 		/sizeof(asn_DEF_T_tags_1[0]) - 2, /* 1 */
@@ -519,17 +456,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Ts_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Ts = {
 	"Ts",
 	"Ts",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Ts_tags_1,
 	sizeof(asn_DEF_Ts_tags_1)
 		/sizeof(asn_DEF_Ts_tags_1[0]) - 1, /* 1 */

--- a/tests/tests-asn1c-compiler/66-ref-simple-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/66-ref-simple-OK.asn1.-Pfwide-types
@@ -44,17 +44,8 @@ static asn_SET_OF_specifics_t asn_SPC_T_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
 	sizeof(asn_DEF_T_tags_1)
 		/sizeof(asn_DEF_T_tags_1[0]), /* 1 */
@@ -131,17 +122,8 @@ static const ber_tlv_tag_t asn_DEF_SimpleType_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_SimpleType = {
 	"SimpleType",
 	"SimpleType",
-	ENUMERATED_free,
-	ENUMERATED_print,
-	ENUMERATED_compare,
+	&asn_OP_ENUMERATED,
 	ENUMERATED_constraint,
-	ENUMERATED_decode_ber,
-	ENUMERATED_encode_der,
-	ENUMERATED_decode_xer,
-	ENUMERATED_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SimpleType_tags_1,
 	sizeof(asn_DEF_SimpleType_tags_1)
 		/sizeof(asn_DEF_SimpleType_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/69-reserved-words-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/69-reserved-words-OK.asn1.-Pfwide-types
@@ -97,17 +97,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_class_4 = {
 	"class",
 	"class",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_class_tags_4,
 	sizeof(asn_DEF_class_tags_4)
 		/sizeof(asn_DEF_class_tags_4[0]), /* 1 */
@@ -187,17 +178,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_T_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
 	sizeof(asn_DEF_T_tags_1)
 		/sizeof(asn_DEF_T_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/70-xer-test-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/70-xer-test-OK.asn1.-Pfwide-types
@@ -274,17 +274,8 @@ static asn_CHOICE_specifics_t asn_SPC_PDU_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_PDU = {
 	"PDU",
 	"PDU",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -399,17 +390,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Sequence = {
 	"Sequence",
 	"Sequence",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Sequence_tags_1,
 	sizeof(asn_DEF_Sequence_tags_1)
 		/sizeof(asn_DEF_Sequence_tags_1[0]), /* 1 */
@@ -511,17 +493,8 @@ asn_SET_specifics_t asn_SPC_Set_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Set = {
 	"Set",
 	"Set",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Set_tags_1,
 	sizeof(asn_DEF_Set_tags_1)
 		/sizeof(asn_DEF_Set_tags_1[0]), /* 1 */
@@ -616,17 +589,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_enum_4 = {
 	"enum",
 	"enum",
-	ENUMERATED_free,
-	ENUMERATED_print,
-	ENUMERATED_compare,
+	&asn_OP_ENUMERATED,
 	ENUMERATED_constraint,
-	ENUMERATED_decode_ber,
-	ENUMERATED_encode_der,
-	ENUMERATED_decode_xer,
-	ENUMERATED_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_enum_tags_4,
 	sizeof(asn_DEF_enum_tags_4)
 		/sizeof(asn_DEF_enum_tags_4[0]) - 1, /* 1 */
@@ -687,17 +651,8 @@ asn_SET_specifics_t asn_SPC_ExtensibleSet_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_ExtensibleSet = {
 	"ExtensibleSet",
 	"ExtensibleSet",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_ExtensibleSet_tags_1,
 	sizeof(asn_DEF_ExtensibleSet_tags_1)
 		/sizeof(asn_DEF_ExtensibleSet_tags_1[0]), /* 1 */
@@ -797,17 +752,8 @@ asn_SEQUENCE_specifics_t asn_SPC_ExtensibleSequence_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_ExtensibleSequence = {
 	"ExtensibleSequence",
 	"ExtensibleSequence",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_ExtensibleSequence_tags_1,
 	sizeof(asn_DEF_ExtensibleSequence_tags_1)
 		/sizeof(asn_DEF_ExtensibleSequence_tags_1[0]), /* 1 */
@@ -893,17 +839,8 @@ asn_SEQUENCE_specifics_t asn_SPC_ExtensibleSequence2_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_ExtensibleSequence2 = {
 	"ExtensibleSequence2",
 	"ExtensibleSequence2",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_ExtensibleSequence2_tags_1,
 	sizeof(asn_DEF_ExtensibleSequence2_tags_1)
 		/sizeof(asn_DEF_ExtensibleSequence2_tags_1[0]), /* 1 */
@@ -965,17 +902,8 @@ asn_SET_OF_specifics_t asn_SPC_SetOfNULL_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_SetOfNULL = {
 	"SetOfNULL",
 	"SetOfNULL",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SetOfNULL_tags_1,
 	sizeof(asn_DEF_SetOfNULL_tags_1)
 		/sizeof(asn_DEF_SetOfNULL_tags_1[0]), /* 1 */
@@ -1037,17 +965,8 @@ asn_SET_OF_specifics_t asn_SPC_SetOfREAL_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_SetOfREAL = {
 	"SetOfREAL",
 	"SetOfREAL",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SetOfREAL_tags_1,
 	sizeof(asn_DEF_SetOfREAL_tags_1)
 		/sizeof(asn_DEF_SetOfREAL_tags_1[0]), /* 1 */
@@ -1124,17 +1043,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_Member_2 = {
 	"ENUMERATED",
 	"ENUMERATED",
-	ENUMERATED_free,
-	ENUMERATED_print,
-	ENUMERATED_compare,
+	&asn_OP_ENUMERATED,
 	ENUMERATED_constraint,
-	ENUMERATED_decode_ber,
-	ENUMERATED_encode_der,
-	ENUMERATED_decode_xer,
-	ENUMERATED_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Member_tags_2,
 	sizeof(asn_DEF_Member_tags_2)
 		/sizeof(asn_DEF_Member_tags_2[0]), /* 1 */
@@ -1171,17 +1081,8 @@ asn_SET_OF_specifics_t asn_SPC_SetOfEnums_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_SetOfEnums = {
 	"SetOfEnums",
 	"SetOfEnums",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SetOfEnums_tags_1,
 	sizeof(asn_DEF_SetOfEnums_tags_1)
 		/sizeof(asn_DEF_SetOfEnums_tags_1[0]), /* 1 */
@@ -1243,17 +1144,8 @@ asn_SET_OF_specifics_t asn_SPC_NamedSetOfNULL_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_NamedSetOfNULL = {
 	"NamedSetOfNULL",
 	"NamedSetOfNULL",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NamedSetOfNULL_tags_1,
 	sizeof(asn_DEF_NamedSetOfNULL_tags_1)
 		/sizeof(asn_DEF_NamedSetOfNULL_tags_1[0]), /* 1 */
@@ -1315,17 +1207,8 @@ asn_SET_OF_specifics_t asn_SPC_NamedSetOfREAL_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_NamedSetOfREAL = {
 	"NamedSetOfREAL",
 	"NamedSetOfREAL",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NamedSetOfREAL_tags_1,
 	sizeof(asn_DEF_NamedSetOfREAL_tags_1)
 		/sizeof(asn_DEF_NamedSetOfREAL_tags_1[0]), /* 1 */
@@ -1402,17 +1285,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_name_2 = {
 	"ENUMERATED",
 	"ENUMERATED",
-	ENUMERATED_free,
-	ENUMERATED_print,
-	ENUMERATED_compare,
+	&asn_OP_ENUMERATED,
 	ENUMERATED_constraint,
-	ENUMERATED_decode_ber,
-	ENUMERATED_encode_der,
-	ENUMERATED_decode_xer,
-	ENUMERATED_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_name_tags_2,
 	sizeof(asn_DEF_name_tags_2)
 		/sizeof(asn_DEF_name_tags_2[0]), /* 1 */
@@ -1449,17 +1323,8 @@ asn_SET_OF_specifics_t asn_SPC_NamedSetOfEnums_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_NamedSetOfEnums = {
 	"NamedSetOfEnums",
 	"NamedSetOfEnums",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NamedSetOfEnums_tags_1,
 	sizeof(asn_DEF_NamedSetOfEnums_tags_1)
 		/sizeof(asn_DEF_NamedSetOfEnums_tags_1[0]), /* 1 */
@@ -1521,17 +1386,8 @@ asn_SET_OF_specifics_t asn_SPC_SequenceOf_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_SequenceOf = {
 	"SequenceOf",
 	"SequenceOf",
-	SEQUENCE_OF_free,
-	SEQUENCE_OF_print,
-	SEQUENCE_OF_compare,
+	&asn_OP_SEQUENCE_OF,
 	SEQUENCE_OF_constraint,
-	SEQUENCE_OF_decode_ber,
-	SEQUENCE_OF_encode_der,
-	SEQUENCE_OF_decode_xer,
-	SEQUENCE_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SequenceOf_tags_1,
 	sizeof(asn_DEF_SequenceOf_tags_1)
 		/sizeof(asn_DEF_SequenceOf_tags_1[0]), /* 1 */
@@ -1593,17 +1449,8 @@ asn_SET_OF_specifics_t asn_SPC_SeqOfZuka_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_SeqOfZuka = {
 	"SeqOfZuka",
 	"SeqOfZuka",
-	SEQUENCE_OF_free,
-	SEQUENCE_OF_print,
-	SEQUENCE_OF_compare,
+	&asn_OP_SEQUENCE_OF,
 	SEQUENCE_OF_constraint,
-	SEQUENCE_OF_decode_ber,
-	SEQUENCE_OF_encode_der,
-	SEQUENCE_OF_decode_xer,
-	SEQUENCE_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SeqOfZuka_tags_1,
 	sizeof(asn_DEF_SeqOfZuka_tags_1)
 		/sizeof(asn_DEF_SeqOfZuka_tags_1[0]), /* 1 */
@@ -1672,17 +1519,8 @@ asn_SET_OF_specifics_t asn_SPC_SetOfChoice_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_SetOfChoice = {
 	"SetOfChoice",
 	"SetOfChoice",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_SetOfChoice_tags_1,
 	sizeof(asn_DEF_SetOfChoice_tags_1)
 		/sizeof(asn_DEF_SetOfChoice_tags_1[0]), /* 1 */
@@ -1751,17 +1589,8 @@ asn_SET_OF_specifics_t asn_SPC_NamedSetOfChoice_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_NamedSetOfChoice = {
 	"NamedSetOfChoice",
 	"NamedSetOfChoice",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NamedSetOfChoice_tags_1,
 	sizeof(asn_DEF_NamedSetOfChoice_tags_1)
 		/sizeof(asn_DEF_NamedSetOfChoice_tags_1[0]), /* 1 */
@@ -1852,17 +1681,8 @@ asn_CHOICE_specifics_t asn_SPC_SimpleChoice_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_SimpleChoice = {
 	"SimpleChoice",
 	"SimpleChoice",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */

--- a/tests/tests-asn1c-compiler/72-same-names-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/72-same-names-OK.asn1.-Pfwide-types
@@ -77,17 +77,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_Member_2 = {
 	"SEQUENCE",
 	"SEQUENCE",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Member_tags_2,
 	sizeof(asn_DEF_Member_tags_2)
 		/sizeof(asn_DEF_Member_tags_2[0]), /* 1 */
@@ -125,17 +116,8 @@ static asn_SET_OF_specifics_t asn_SPC_Type_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Type = {
 	"Type",
 	"Type",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Type_tags_1,
 	sizeof(asn_DEF_Type_tags_1)
 		/sizeof(asn_DEF_Type_tags_1[0]), /* 1 */
@@ -238,17 +220,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_another_name_3 = {
 	"another-name",
 	"another-name",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_another_name_tags_3,
 	sizeof(asn_DEF_another_name_tags_3)
 		/sizeof(asn_DEF_another_name_tags_3[0]), /* 1 */
@@ -292,17 +265,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_one_name_2 = {
 	"one-name",
 	"one-name",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -345,17 +309,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Type1_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Type1 = {
 	"Type1",
 	"Type1",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Type1_tags_1,
 	sizeof(asn_DEF_Type1_tags_1)
 		/sizeof(asn_DEF_Type1_tags_1[0]), /* 1 */
@@ -555,17 +510,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_another_name_3 = {
 	"another-name",
 	"another-name",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_another_name_tags_3,
 	sizeof(asn_DEF_another_name_tags_3)
 		/sizeof(asn_DEF_another_name_tags_3[0]), /* 1 */
@@ -611,17 +557,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_one_name_2 = {
 	"one-name",
 	"one-name",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_one_name_tags_2,
 	sizeof(asn_DEF_one_name_tags_2)
 		/sizeof(asn_DEF_one_name_tags_2[0]), /* 1 */
@@ -679,17 +616,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_another_name_8 = {
 	"another-name",
 	"another-name",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_another_name_tags_8,
 	sizeof(asn_DEF_another_name_tags_8)
 		/sizeof(asn_DEF_another_name_tags_8[0]), /* 1 */
@@ -741,17 +669,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_two_name_7 = {
 	"two-name",
 	"two-name",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_two_name_tags_7,
 	sizeof(asn_DEF_two_name_tags_7)
 		/sizeof(asn_DEF_two_name_tags_7[0]), /* 1 */
@@ -806,17 +725,8 @@ asn_CHOICE_specifics_t asn_SPC_Type2_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Type2 = {
 	"Type2",
 	"Type2",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */

--- a/tests/tests-asn1c-compiler/73-circular-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/73-circular-OK.asn1.-Pfwide-types
@@ -60,17 +60,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_data_2 = {
 	"data",
 	"data",
-	SEQUENCE_OF_free,
-	SEQUENCE_OF_print,
-	SEQUENCE_OF_compare,
+	&asn_OP_SEQUENCE_OF,
 	SEQUENCE_OF_constraint,
-	SEQUENCE_OF_decode_ber,
-	SEQUENCE_OF_encode_der,
-	SEQUENCE_OF_decode_xer,
-	SEQUENCE_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_data_tags_2,
 	sizeof(asn_DEF_data_tags_2)
 		/sizeof(asn_DEF_data_tags_2[0]), /* 1 */
@@ -115,17 +106,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Type_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Type = {
 	"Type",
 	"Type",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Type_tags_1,
 	sizeof(asn_DEF_Type_tags_1)
 		/sizeof(asn_DEF_Type_tags_1[0]), /* 1 */
@@ -174,17 +156,8 @@ static const ber_tlv_tag_t asn_DEF_EpytRef_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_EpytRef = {
 	"EpytRef",
 	"EpytRef",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_EpytRef_tags_1,
 	sizeof(asn_DEF_EpytRef_tags_1)
 		/sizeof(asn_DEF_EpytRef_tags_1[0]), /* 1 */
@@ -264,17 +237,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_stype_2 = {
 	"stype",
 	"stype",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_stype_tags_2,
 	sizeof(asn_DEF_stype_tags_2)
 		/sizeof(asn_DEF_stype_tags_2[0]), /* 1 */
@@ -343,17 +307,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Epyt_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Epyt = {
 	"Epyt",
 	"Epyt",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Epyt_tags_1,
 	sizeof(asn_DEF_Epyt_tags_1)
 		/sizeof(asn_DEF_Epyt_tags_1[0]), /* 1 */
@@ -554,17 +509,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_senums_4 = {
 	"senums",
 	"senums",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_senums_tags_4,
 	sizeof(asn_DEF_senums_tags_4)
 		/sizeof(asn_DEF_senums_tags_4[0]), /* 1 */
@@ -662,17 +608,8 @@ asn_SET_specifics_t asn_SPC_Ypet_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Ypet = {
 	"Ypet",
 	"Ypet",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Ypet_tags_1,
 	sizeof(asn_DEF_Ypet_tags_1)
 		/sizeof(asn_DEF_Ypet_tags_1[0]), /* 1 */
@@ -746,17 +683,8 @@ static const ber_tlv_tag_t asn_DEF_EnumType_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_EnumType = {
 	"EnumType",
 	"EnumType",
-	ENUMERATED_free,
-	ENUMERATED_print,
-	ENUMERATED_compare,
+	&asn_OP_ENUMERATED,
 	ENUMERATED_constraint,
-	ENUMERATED_decode_ber,
-	ENUMERATED_encode_der,
-	ENUMERATED_decode_xer,
-	ENUMERATED_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_EnumType_tags_1,
 	sizeof(asn_DEF_EnumType_tags_1)
 		/sizeof(asn_DEF_EnumType_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/84-param-tags-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/84-param-tags-OK.asn1.-Pfwide-types
@@ -108,17 +108,8 @@ asn_SEQUENCE_specifics_t asn_SPC_TestType_16P0_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_TestType_16P0 = {
 	"TestType",
 	"TestType",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_TestType_16P0_tags_1,
 	sizeof(asn_DEF_TestType_16P0_tags_1)
 		/sizeof(asn_DEF_TestType_16P0_tags_1[0]), /* 1 */
@@ -181,17 +172,8 @@ asn_SEQUENCE_specifics_t asn_SPC_TestType_16P1_specs_3 = {
 asn_TYPE_descriptor_t asn_DEF_TestType_16P1 = {
 	"TestType",
 	"TestType",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_TestType_16P1_tags_3,
 	sizeof(asn_DEF_TestType_16P1_tags_3)
 		/sizeof(asn_DEF_TestType_16P1_tags_3[0]), /* 1 */
@@ -279,17 +261,8 @@ static asn_CHOICE_specifics_t asn_SPC_TestChoice_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_TestChoice = {
 	"TestChoice",
 	"TestChoice",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -418,17 +391,8 @@ asn_SEQUENCE_specifics_t asn_SPC_AutoType_34P0_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_AutoType_34P0 = {
 	"AutoType",
 	"AutoType",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_AutoType_34P0_tags_1,
 	sizeof(asn_DEF_AutoType_34P0_tags_1)
 		/sizeof(asn_DEF_AutoType_34P0_tags_1[0]), /* 1 */
@@ -473,17 +437,8 @@ asn_SEQUENCE_specifics_t asn_SPC_AutoType_34P1_specs_3 = {
 asn_TYPE_descriptor_t asn_DEF_AutoType_34P1 = {
 	"AutoType",
 	"AutoType",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_AutoType_34P1_tags_3,
 	sizeof(asn_DEF_AutoType_34P1_tags_3)
 		/sizeof(asn_DEF_AutoType_34P1_tags_3[0]), /* 1 */
@@ -571,17 +526,8 @@ static asn_CHOICE_specifics_t asn_SPC_AutoChoice_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_AutoChoice = {
 	"AutoChoice",
 	"AutoChoice",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */

--- a/tests/tests-asn1c-compiler/88-integer-enum-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/88-integer-enum-OK.asn1.-Pfwide-types
@@ -40,17 +40,8 @@ static const ber_tlv_tag_t asn_DEF_T_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	INTEGER_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_T_tags_1,
 	sizeof(asn_DEF_T_tags_1)
 		/sizeof(asn_DEF_T_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/89-bit-string-enum-OK.asn1.-Pfcompound-names
+++ b/tests/tests-asn1c-compiler/89-bit-string-enum-OK.asn1.-Pfcompound-names
@@ -62,17 +62,8 @@ static asn_CHOICE_specifics_t asn_SPC_T_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */

--- a/tests/tests-asn1c-compiler/89-bit-string-enum-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/89-bit-string-enum-OK.asn1.-Pfwide-types
@@ -62,17 +62,8 @@ static asn_CHOICE_specifics_t asn_SPC_T_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_T = {
 	"T",
 	"T",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */

--- a/tests/tests-asn1c-compiler/90-cond-int-type-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/90-cond-int-type-OK.asn1.-P
@@ -33,17 +33,8 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerUnlimited_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerUnlimited = {
 	"CN-IntegerUnlimited",
 	"CN-IntegerUnlimited",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NativeInteger_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerUnlimited_tags_1,
 	sizeof(asn_DEF_CN_IntegerUnlimited_tags_1)
 		/sizeof(asn_DEF_CN_IntegerUnlimited_tags_1[0]), /* 1 */
@@ -95,8 +86,7 @@ CN_IntegerMinMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	}
 	
 	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
+	return td->op->check_constraints(td, sptr, ctfailcb, app_key);
 }
 
 /*
@@ -112,17 +102,8 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerMinMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerMinMax = {
 	"CN-IntegerMinMax",
 	"CN-IntegerMinMax",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	CN_IntegerMinMax_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerMinMax_tags_1,
 	sizeof(asn_DEF_CN_IntegerMinMax_tags_1)
 		/sizeof(asn_DEF_CN_IntegerMinMax_tags_1[0]), /* 1 */
@@ -195,17 +176,8 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerMinLow_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerMinLow = {
 	"CN-IntegerMinLow",
 	"CN-IntegerMinLow",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	CN_IntegerMinLow_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerMinLow_tags_1,
 	sizeof(asn_DEF_CN_IntegerMinLow_tags_1)
 		/sizeof(asn_DEF_CN_IntegerMinLow_tags_1[0]), /* 1 */
@@ -284,17 +256,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerMinHigh_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerMinHigh = {
 	"NO-IntegerMinHigh",
 	"NO-IntegerMinHigh",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	NO_IntegerMinHigh_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerMinHigh_tags_1,
 	sizeof(asn_DEF_NO_IntegerMinHigh_tags_1)
 		/sizeof(asn_DEF_NO_IntegerMinHigh_tags_1[0]), /* 1 */
@@ -372,17 +335,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerLowHigh_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerLowHigh = {
 	"NO-IntegerLowHigh",
 	"NO-IntegerLowHigh",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NO_IntegerLowHigh_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerLowHigh_tags_1,
 	sizeof(asn_DEF_NO_IntegerLowHigh_tags_1)
 		/sizeof(asn_DEF_NO_IntegerLowHigh_tags_1[0]), /* 1 */
@@ -455,17 +409,8 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerLowMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerLowMax = {
 	"CN-IntegerLowMax",
 	"CN-IntegerLowMax",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	CN_IntegerLowMax_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerLowMax_tags_1,
 	sizeof(asn_DEF_CN_IntegerLowMax_tags_1)
 		/sizeof(asn_DEF_CN_IntegerLowMax_tags_1[0]), /* 1 */
@@ -544,17 +489,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerHighMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerHighMax = {
 	"NO-IntegerHighMax",
 	"NO-IntegerHighMax",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	NO_IntegerHighMax_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerHighMax_tags_1,
 	sizeof(asn_DEF_NO_IntegerHighMax_tags_1)
 		/sizeof(asn_DEF_NO_IntegerHighMax_tags_1[0]), /* 1 */
@@ -633,17 +569,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerLowestMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerLowestMax = {
 	"NO-IntegerLowestMax",
 	"NO-IntegerLowestMax",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	NO_IntegerLowestMax_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerLowestMax_tags_1,
 	sizeof(asn_DEF_NO_IntegerLowestMax_tags_1)
 		/sizeof(asn_DEF_NO_IntegerLowestMax_tags_1[0]), /* 1 */
@@ -721,17 +648,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerOutRange_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerOutRange = {
 	"NO-IntegerOutRange",
 	"NO-IntegerOutRange",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NO_IntegerOutRange_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerOutRange_tags_1,
 	sizeof(asn_DEF_NO_IntegerOutRange_tags_1)
 		/sizeof(asn_DEF_NO_IntegerOutRange_tags_1[0]), /* 1 */
@@ -809,17 +727,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerOutValue_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerOutValue = {
 	"NO-IntegerOutValue",
 	"NO-IntegerOutValue",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NO_IntegerOutValue_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerOutValue_tags_1,
 	sizeof(asn_DEF_NO_IntegerOutValue_tags_1)
 		/sizeof(asn_DEF_NO_IntegerOutValue_tags_1[0]), /* 1 */
@@ -892,17 +801,8 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange1 = {
 	"OK-IntegerInRange1",
 	"OK-IntegerInRange1",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	OK_IntegerInRange1_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange1_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange1_tags_1)
 		/sizeof(asn_DEF_OK_IntegerInRange1_tags_1[0]), /* 1 */
@@ -975,17 +875,8 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange2 = {
 	"OK-IntegerInRange2",
 	"OK-IntegerInRange2",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	OK_IntegerInRange2_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange2_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange2_tags_1)
 		/sizeof(asn_DEF_OK_IntegerInRange2_tags_1[0]), /* 1 */
@@ -1058,17 +949,8 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange3 = {
 	"OK-IntegerInRange3",
 	"OK-IntegerInRange3",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	OK_IntegerInRange3_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange3_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange3_tags_1)
 		/sizeof(asn_DEF_OK_IntegerInRange3_tags_1[0]), /* 1 */
@@ -1141,17 +1023,8 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange4 = {
 	"OK-IntegerInRange4",
 	"OK-IntegerInRange4",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	OK_IntegerInRange4_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange4_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange4_tags_1)
 		/sizeof(asn_DEF_OK_IntegerInRange4_tags_1[0]), /* 1 */
@@ -1224,17 +1097,8 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange5 = {
 	"OK-IntegerInRange5",
 	"OK-IntegerInRange5",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	OK_IntegerInRange5_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange5_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange5_tags_1)
 		/sizeof(asn_DEF_OK_IntegerInRange5_tags_1[0]), /* 1 */
@@ -1303,17 +1167,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerInRange6_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerInRange6 = {
 	"NO-IntegerInRange6",
 	"NO-IntegerInRange6",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NO_IntegerInRange6_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerInRange6_tags_1,
 	sizeof(asn_DEF_NO_IntegerInRange6_tags_1)
 		/sizeof(asn_DEF_NO_IntegerInRange6_tags_1[0]), /* 1 */
@@ -1368,17 +1223,8 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerEnumerated1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerEnumerated1 = {
 	"CN-IntegerEnumerated1",
 	"CN-IntegerEnumerated1",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NativeInteger_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerEnumerated1_tags_1,
 	sizeof(asn_DEF_CN_IntegerEnumerated1_tags_1)
 		/sizeof(asn_DEF_CN_IntegerEnumerated1_tags_1[0]), /* 1 */
@@ -1433,17 +1279,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerEnumerated2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerEnumerated2 = {
 	"NO-IntegerEnumerated2",
 	"NO-IntegerEnumerated2",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	INTEGER_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerEnumerated2_tags_1,
 	sizeof(asn_DEF_NO_IntegerEnumerated2_tags_1)
 		/sizeof(asn_DEF_NO_IntegerEnumerated2_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/90-cond-int-type-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/90-cond-int-type-OK.asn1.-Pfwide-types
@@ -33,17 +33,8 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerUnlimited_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerUnlimited = {
 	"CN-IntegerUnlimited",
 	"CN-IntegerUnlimited",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	INTEGER_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerUnlimited_tags_1,
 	sizeof(asn_DEF_CN_IntegerUnlimited_tags_1)
 		/sizeof(asn_DEF_CN_IntegerUnlimited_tags_1[0]), /* 1 */
@@ -97,8 +88,7 @@ CN_IntegerMinMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	}
 	
 	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_INTEGER.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
+	return td->op->check_constraints(td, sptr, ctfailcb, app_key);
 }
 
 /*
@@ -114,17 +104,8 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerMinMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerMinMax = {
 	"CN-IntegerMinMax",
 	"CN-IntegerMinMax",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	CN_IntegerMinMax_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerMinMax_tags_1,
 	sizeof(asn_DEF_CN_IntegerMinMax_tags_1)
 		/sizeof(asn_DEF_CN_IntegerMinMax_tags_1[0]), /* 1 */
@@ -203,17 +184,8 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerMinLow_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerMinLow = {
 	"CN-IntegerMinLow",
 	"CN-IntegerMinLow",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	CN_IntegerMinLow_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerMinLow_tags_1,
 	sizeof(asn_DEF_CN_IntegerMinLow_tags_1)
 		/sizeof(asn_DEF_CN_IntegerMinLow_tags_1[0]), /* 1 */
@@ -292,17 +264,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerMinHigh_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerMinHigh = {
 	"NO-IntegerMinHigh",
 	"NO-IntegerMinHigh",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	NO_IntegerMinHigh_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerMinHigh_tags_1,
 	sizeof(asn_DEF_NO_IntegerMinHigh_tags_1)
 		/sizeof(asn_DEF_NO_IntegerMinHigh_tags_1[0]), /* 1 */
@@ -380,17 +343,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerLowHigh_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerLowHigh = {
 	"NO-IntegerLowHigh",
 	"NO-IntegerLowHigh",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NO_IntegerLowHigh_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerLowHigh_tags_1,
 	sizeof(asn_DEF_NO_IntegerLowHigh_tags_1)
 		/sizeof(asn_DEF_NO_IntegerLowHigh_tags_1[0]), /* 1 */
@@ -469,17 +423,8 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerLowMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerLowMax = {
 	"CN-IntegerLowMax",
 	"CN-IntegerLowMax",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	CN_IntegerLowMax_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerLowMax_tags_1,
 	sizeof(asn_DEF_CN_IntegerLowMax_tags_1)
 		/sizeof(asn_DEF_CN_IntegerLowMax_tags_1[0]), /* 1 */
@@ -558,17 +503,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerHighMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerHighMax = {
 	"NO-IntegerHighMax",
 	"NO-IntegerHighMax",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	NO_IntegerHighMax_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerHighMax_tags_1,
 	sizeof(asn_DEF_NO_IntegerHighMax_tags_1)
 		/sizeof(asn_DEF_NO_IntegerHighMax_tags_1[0]), /* 1 */
@@ -647,17 +583,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerLowestMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerLowestMax = {
 	"NO-IntegerLowestMax",
 	"NO-IntegerLowestMax",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	NO_IntegerLowestMax_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerLowestMax_tags_1,
 	sizeof(asn_DEF_NO_IntegerLowestMax_tags_1)
 		/sizeof(asn_DEF_NO_IntegerLowestMax_tags_1[0]), /* 1 */
@@ -735,17 +662,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerOutRange_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerOutRange = {
 	"NO-IntegerOutRange",
 	"NO-IntegerOutRange",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NO_IntegerOutRange_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerOutRange_tags_1,
 	sizeof(asn_DEF_NO_IntegerOutRange_tags_1)
 		/sizeof(asn_DEF_NO_IntegerOutRange_tags_1[0]), /* 1 */
@@ -823,17 +741,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerOutValue_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerOutValue = {
 	"NO-IntegerOutValue",
 	"NO-IntegerOutValue",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NO_IntegerOutValue_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerOutValue_tags_1,
 	sizeof(asn_DEF_NO_IntegerOutValue_tags_1)
 		/sizeof(asn_DEF_NO_IntegerOutValue_tags_1[0]), /* 1 */
@@ -906,17 +815,8 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange1 = {
 	"OK-IntegerInRange1",
 	"OK-IntegerInRange1",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	OK_IntegerInRange1_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange1_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange1_tags_1)
 		/sizeof(asn_DEF_OK_IntegerInRange1_tags_1[0]), /* 1 */
@@ -989,17 +889,8 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange2 = {
 	"OK-IntegerInRange2",
 	"OK-IntegerInRange2",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	OK_IntegerInRange2_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange2_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange2_tags_1)
 		/sizeof(asn_DEF_OK_IntegerInRange2_tags_1[0]), /* 1 */
@@ -1072,17 +963,8 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange3 = {
 	"OK-IntegerInRange3",
 	"OK-IntegerInRange3",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	OK_IntegerInRange3_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange3_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange3_tags_1)
 		/sizeof(asn_DEF_OK_IntegerInRange3_tags_1[0]), /* 1 */
@@ -1155,17 +1037,8 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange4 = {
 	"OK-IntegerInRange4",
 	"OK-IntegerInRange4",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	OK_IntegerInRange4_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange4_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange4_tags_1)
 		/sizeof(asn_DEF_OK_IntegerInRange4_tags_1[0]), /* 1 */
@@ -1244,17 +1117,8 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange5 = {
 	"OK-IntegerInRange5",
 	"OK-IntegerInRange5",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	OK_IntegerInRange5_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange5_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange5_tags_1)
 		/sizeof(asn_DEF_OK_IntegerInRange5_tags_1[0]), /* 1 */
@@ -1323,17 +1187,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerInRange6_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerInRange6 = {
 	"NO-IntegerInRange6",
 	"NO-IntegerInRange6",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NO_IntegerInRange6_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerInRange6_tags_1,
 	sizeof(asn_DEF_NO_IntegerInRange6_tags_1)
 		/sizeof(asn_DEF_NO_IntegerInRange6_tags_1[0]), /* 1 */
@@ -1388,17 +1243,8 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerEnumerated1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerEnumerated1 = {
 	"CN-IntegerEnumerated1",
 	"CN-IntegerEnumerated1",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	INTEGER_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerEnumerated1_tags_1,
 	sizeof(asn_DEF_CN_IntegerEnumerated1_tags_1)
 		/sizeof(asn_DEF_CN_IntegerEnumerated1_tags_1[0]), /* 1 */
@@ -1453,17 +1299,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerEnumerated2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerEnumerated2 = {
 	"NO-IntegerEnumerated2",
 	"NO-IntegerEnumerated2",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	INTEGER_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerEnumerated2_tags_1,
 	sizeof(asn_DEF_NO_IntegerEnumerated2_tags_1)
 		/sizeof(asn_DEF_NO_IntegerEnumerated2_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/90-cond-int-type-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/90-cond-int-type-OK.asn1.-Pgen-PER
@@ -35,18 +35,8 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerUnlimited_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerUnlimited = {
 	"CN-IntegerUnlimited",
 	"CN-IntegerUnlimited",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NativeInteger_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerUnlimited_tags_1,
 	sizeof(asn_DEF_CN_IntegerUnlimited_tags_1)
 		/sizeof(asn_DEF_CN_IntegerUnlimited_tags_1[0]), /* 1 */
@@ -100,8 +90,7 @@ CN_IntegerMinMax_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	}
 	
 	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
+	return td->op->check_constraints(td, sptr, ctfailcb, app_key);
 }
 
 /*
@@ -125,18 +114,8 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerMinMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerMinMax = {
 	"CN-IntegerMinMax",
 	"CN-IntegerMinMax",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	CN_IntegerMinMax_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerMinMax_tags_1,
 	sizeof(asn_DEF_CN_IntegerMinMax_tags_1)
 		/sizeof(asn_DEF_CN_IntegerMinMax_tags_1[0]), /* 1 */
@@ -219,18 +198,8 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerMinLow_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerMinLow = {
 	"CN-IntegerMinLow",
 	"CN-IntegerMinLow",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	CN_IntegerMinLow_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerMinLow_tags_1,
 	sizeof(asn_DEF_CN_IntegerMinLow_tags_1)
 		/sizeof(asn_DEF_CN_IntegerMinLow_tags_1[0]), /* 1 */
@@ -319,18 +288,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerMinHigh_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerMinHigh = {
 	"NO-IntegerMinHigh",
 	"NO-IntegerMinHigh",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	NO_IntegerMinHigh_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	INTEGER_decode_uper,
-	INTEGER_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerMinHigh_tags_1,
 	sizeof(asn_DEF_NO_IntegerMinHigh_tags_1)
 		/sizeof(asn_DEF_NO_IntegerMinHigh_tags_1[0]), /* 1 */
@@ -418,18 +377,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerLowHigh_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerLowHigh = {
 	"NO-IntegerLowHigh",
 	"NO-IntegerLowHigh",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NO_IntegerLowHigh_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerLowHigh_tags_1,
 	sizeof(asn_DEF_NO_IntegerLowHigh_tags_1)
 		/sizeof(asn_DEF_NO_IntegerLowHigh_tags_1[0]), /* 1 */
@@ -512,18 +461,8 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerLowMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerLowMax = {
 	"CN-IntegerLowMax",
 	"CN-IntegerLowMax",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	CN_IntegerLowMax_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerLowMax_tags_1,
 	sizeof(asn_DEF_CN_IntegerLowMax_tags_1)
 		/sizeof(asn_DEF_CN_IntegerLowMax_tags_1[0]), /* 1 */
@@ -612,18 +551,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerHighMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerHighMax = {
 	"NO-IntegerHighMax",
 	"NO-IntegerHighMax",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	NO_IntegerHighMax_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	INTEGER_decode_uper,
-	INTEGER_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerHighMax_tags_1,
 	sizeof(asn_DEF_NO_IntegerHighMax_tags_1)
 		/sizeof(asn_DEF_NO_IntegerHighMax_tags_1[0]), /* 1 */
@@ -712,18 +641,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerLowestMax_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerLowestMax = {
 	"NO-IntegerLowestMax",
 	"NO-IntegerLowestMax",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	NO_IntegerLowestMax_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	INTEGER_decode_uper,
-	INTEGER_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerLowestMax_tags_1,
 	sizeof(asn_DEF_NO_IntegerLowestMax_tags_1)
 		/sizeof(asn_DEF_NO_IntegerLowestMax_tags_1[0]), /* 1 */
@@ -811,18 +730,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerOutRange_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerOutRange = {
 	"NO-IntegerOutRange",
 	"NO-IntegerOutRange",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NO_IntegerOutRange_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerOutRange_tags_1,
 	sizeof(asn_DEF_NO_IntegerOutRange_tags_1)
 		/sizeof(asn_DEF_NO_IntegerOutRange_tags_1[0]), /* 1 */
@@ -910,18 +819,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerOutValue_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerOutValue = {
 	"NO-IntegerOutValue",
 	"NO-IntegerOutValue",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NO_IntegerOutValue_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerOutValue_tags_1,
 	sizeof(asn_DEF_NO_IntegerOutValue_tags_1)
 		/sizeof(asn_DEF_NO_IntegerOutValue_tags_1[0]), /* 1 */
@@ -1004,18 +903,8 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange1 = {
 	"OK-IntegerInRange1",
 	"OK-IntegerInRange1",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	OK_IntegerInRange1_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange1_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange1_tags_1)
 		/sizeof(asn_DEF_OK_IntegerInRange1_tags_1[0]), /* 1 */
@@ -1098,18 +987,8 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange2 = {
 	"OK-IntegerInRange2",
 	"OK-IntegerInRange2",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	OK_IntegerInRange2_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange2_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange2_tags_1)
 		/sizeof(asn_DEF_OK_IntegerInRange2_tags_1[0]), /* 1 */
@@ -1192,18 +1071,8 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange3 = {
 	"OK-IntegerInRange3",
 	"OK-IntegerInRange3",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	OK_IntegerInRange3_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange3_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange3_tags_1)
 		/sizeof(asn_DEF_OK_IntegerInRange3_tags_1[0]), /* 1 */
@@ -1286,18 +1155,8 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange4 = {
 	"OK-IntegerInRange4",
 	"OK-IntegerInRange4",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	OK_IntegerInRange4_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange4_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange4_tags_1)
 		/sizeof(asn_DEF_OK_IntegerInRange4_tags_1[0]), /* 1 */
@@ -1380,18 +1239,8 @@ static const ber_tlv_tag_t asn_DEF_OK_IntegerInRange5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_IntegerInRange5 = {
 	"OK-IntegerInRange5",
 	"OK-IntegerInRange5",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	OK_IntegerInRange5_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_IntegerInRange5_tags_1,
 	sizeof(asn_DEF_OK_IntegerInRange5_tags_1)
 		/sizeof(asn_DEF_OK_IntegerInRange5_tags_1[0]), /* 1 */
@@ -1470,18 +1319,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerInRange6_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerInRange6 = {
 	"NO-IntegerInRange6",
 	"NO-IntegerInRange6",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NO_IntegerInRange6_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerInRange6_tags_1,
 	sizeof(asn_DEF_NO_IntegerInRange6_tags_1)
 		/sizeof(asn_DEF_NO_IntegerInRange6_tags_1[0]), /* 1 */
@@ -1538,18 +1377,8 @@ static const ber_tlv_tag_t asn_DEF_CN_IntegerEnumerated1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_CN_IntegerEnumerated1 = {
 	"CN-IntegerEnumerated1",
 	"CN-IntegerEnumerated1",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NativeInteger_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	NativeInteger_decode_uper,
-	NativeInteger_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_CN_IntegerEnumerated1_tags_1,
 	sizeof(asn_DEF_CN_IntegerEnumerated1_tags_1)
 		/sizeof(asn_DEF_CN_IntegerEnumerated1_tags_1[0]), /* 1 */
@@ -1606,18 +1435,8 @@ static const ber_tlv_tag_t asn_DEF_NO_IntegerEnumerated2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_IntegerEnumerated2 = {
 	"NO-IntegerEnumerated2",
 	"NO-IntegerEnumerated2",
-	INTEGER_free,
-	INTEGER_print,
-	INTEGER_compare,
+	&asn_OP_INTEGER,
 	INTEGER_constraint,
-	INTEGER_decode_ber,
-	INTEGER_encode_der,
-	INTEGER_decode_xer,
-	INTEGER_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	INTEGER_decode_uper,
-	INTEGER_encode_uper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_IntegerEnumerated2_tags_1,
 	sizeof(asn_DEF_NO_IntegerEnumerated2_tags_1)
 		/sizeof(asn_DEF_NO_IntegerEnumerated2_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/91-cond-int-blessSize-OK.asn1.-Pfbless-SIZE
+++ b/tests/tests-asn1c-compiler/91-cond-int-blessSize-OK.asn1.-Pfbless-SIZE
@@ -37,8 +37,7 @@ OK_Integer1_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	}
 	
 	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
+	return td->op->check_constraints(td, sptr, ctfailcb, app_key);
 }
 
 /*
@@ -54,17 +53,8 @@ static const ber_tlv_tag_t asn_DEF_OK_Integer1_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_Integer1 = {
 	"OK-Integer1",
 	"OK-Integer1",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	OK_Integer1_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_Integer1_tags_1,
 	sizeof(asn_DEF_OK_Integer1_tags_1)
 		/sizeof(asn_DEF_OK_Integer1_tags_1[0]), /* 1 */
@@ -116,8 +106,7 @@ OK_Integer2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	}
 	
 	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
+	return td->op->check_constraints(td, sptr, ctfailcb, app_key);
 }
 
 /*
@@ -133,17 +122,8 @@ static const ber_tlv_tag_t asn_DEF_OK_Integer2_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_Integer2 = {
 	"OK-Integer2",
 	"OK-Integer2",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	OK_Integer2_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_Integer2_tags_1,
 	sizeof(asn_DEF_OK_Integer2_tags_1)
 		/sizeof(asn_DEF_OK_Integer2_tags_1[0]), /* 1 */
@@ -195,8 +175,7 @@ OK_Integer3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	}
 	
 	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
+	return td->op->check_constraints(td, sptr, ctfailcb, app_key);
 }
 
 /*
@@ -212,17 +191,8 @@ static const ber_tlv_tag_t asn_DEF_OK_Integer3_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_Integer3 = {
 	"OK-Integer3",
 	"OK-Integer3",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	OK_Integer3_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_Integer3_tags_1,
 	sizeof(asn_DEF_OK_Integer3_tags_1)
 		/sizeof(asn_DEF_OK_Integer3_tags_1[0]), /* 1 */
@@ -274,8 +244,7 @@ OK_Integer4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	}
 	
 	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
+	return td->op->check_constraints(td, sptr, ctfailcb, app_key);
 }
 
 /*
@@ -291,17 +260,8 @@ static const ber_tlv_tag_t asn_DEF_OK_Integer4_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_OK_Integer4 = {
 	"OK-Integer4",
 	"OK-Integer4",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	OK_Integer4_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OK_Integer4_tags_1,
 	sizeof(asn_DEF_OK_Integer4_tags_1)
 		/sizeof(asn_DEF_OK_Integer4_tags_1[0]), /* 1 */
@@ -353,8 +313,7 @@ NO_Integer5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 	}
 	
 	/* Replace with underlying type checker */
-	td->check_constraints = asn_DEF_NativeInteger.check_constraints;
-	return td->check_constraints(td, sptr, ctfailcb, app_key);
+	return td->op->check_constraints(td, sptr, ctfailcb, app_key);
 }
 
 /*
@@ -370,17 +329,8 @@ static const ber_tlv_tag_t asn_DEF_NO_Integer5_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_NO_Integer5 = {
 	"NO-Integer5",
 	"NO-Integer5",
-	NativeInteger_free,
-	NativeInteger_print,
-	NativeInteger_compare,
+	&asn_OP_NativeInteger,
 	NO_Integer5_constraint,
-	NativeInteger_decode_ber,
-	NativeInteger_encode_der,
-	NativeInteger_decode_xer,
-	NativeInteger_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_NO_Integer5_tags_1,
 	sizeof(asn_DEF_NO_Integer5_tags_1)
 		/sizeof(asn_DEF_NO_Integer5_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/92-circular-loops-OK.asn1.-Pfindirect-choice
+++ b/tests/tests-asn1c-compiler/92-circular-loops-OK.asn1.-Pfindirect-choice
@@ -187,17 +187,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Everything_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Everything = {
 	"Everything",
 	"Everything",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Everything_tags_1,
 	sizeof(asn_DEF_Everything_tags_1)
 		/sizeof(asn_DEF_Everything_tags_1[0]), /* 1 */
@@ -299,17 +290,8 @@ asn_CHOICE_specifics_t asn_SPC_Choice1_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Choice1 = {
 	"Choice1",
 	"Choice1",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -411,17 +393,8 @@ asn_CHOICE_specifics_t asn_SPC_Choice2_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Choice2 = {
 	"Choice2",
 	"Choice2",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -525,17 +498,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_a_2 = {
 	"a",
 	"a",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_a_tags_2,
 	sizeof(asn_DEF_a_tags_2)
 		/sizeof(asn_DEF_a_tags_2[0]) - 1, /* 1 */
@@ -575,17 +539,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_c_5 = {
 	"c",
 	"c",
-	SEQUENCE_OF_free,
-	SEQUENCE_OF_print,
-	SEQUENCE_OF_compare,
+	&asn_OP_SEQUENCE_OF,
 	SEQUENCE_OF_constraint,
-	SEQUENCE_OF_decode_ber,
-	SEQUENCE_OF_encode_der,
-	SEQUENCE_OF_decode_xer,
-	SEQUENCE_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_c_tags_5,
 	sizeof(asn_DEF_c_tags_5)
 		/sizeof(asn_DEF_c_tags_5[0]) - 1, /* 1 */
@@ -652,17 +607,8 @@ asn_CHOICE_specifics_t asn_SPC_Choice3_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Choice3 = {
 	"Choice3",
 	"Choice3",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -806,17 +752,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_Member_2 = {
 	"SEQUENCE",
 	"SEQUENCE",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Member_tags_2,
 	sizeof(asn_DEF_Member_tags_2)
 		/sizeof(asn_DEF_Member_tags_2[0]), /* 1 */
@@ -854,17 +791,8 @@ asn_SET_OF_specifics_t asn_SPC_Set_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Set = {
 	"Set",
 	"Set",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Set_tags_1,
 	sizeof(asn_DEF_Set_tags_1)
 		/sizeof(asn_DEF_Set_tags_1[0]), /* 1 */
@@ -985,17 +913,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Sequence = {
 	"Sequence",
 	"Sequence",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Sequence_tags_1,
 	sizeof(asn_DEF_Sequence_tags_1)
 		/sizeof(asn_DEF_Sequence_tags_1[0]), /* 1 */
@@ -1044,17 +963,8 @@ static const ber_tlv_tag_t asn_DEF_TypeRef_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_TypeRef = {
 	"TypeRef",
 	"TypeRef",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_TypeRef_tags_1,
 	sizeof(asn_DEF_TypeRef_tags_1)
 		/sizeof(asn_DEF_TypeRef_tags_1[0]), /* 1 */
@@ -1137,17 +1047,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_b_3 = {
 	"b",
 	"b",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_b_tags_3,
 	sizeof(asn_DEF_b_tags_3)
 		/sizeof(asn_DEF_b_tags_3[0]) - 1, /* 1 */
@@ -1204,17 +1105,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Alpha_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Alpha = {
 	"Alpha",
 	"Alpha",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Alpha_tags_1,
 	sizeof(asn_DEF_Alpha_tags_1)
 		/sizeof(asn_DEF_Alpha_tags_1[0]), /* 1 */
@@ -1304,17 +1196,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Beta_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Beta = {
 	"Beta",
 	"Beta",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Beta_tags_1,
 	sizeof(asn_DEF_Beta_tags_1)
 		/sizeof(asn_DEF_Beta_tags_1[0]), /* 1 */
@@ -1419,17 +1302,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Gamma_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Gamma = {
 	"Gamma",
 	"Gamma",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Gamma_tags_1,
 	sizeof(asn_DEF_Gamma_tags_1)
 		/sizeof(asn_DEF_Gamma_tags_1[0]), /* 1 */
@@ -1523,17 +1397,8 @@ asn_SET_specifics_t asn_SPC_OneTwo_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_OneTwo = {
 	"OneTwo",
 	"OneTwo",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OneTwo_tags_1,
 	sizeof(asn_DEF_OneTwo_tags_1)
 		/sizeof(asn_DEF_OneTwo_tags_1[0]), /* 1 */
@@ -1627,17 +1492,8 @@ asn_SET_specifics_t asn_SPC_TwoThree_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_TwoThree = {
 	"TwoThree",
 	"TwoThree",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_TwoThree_tags_1,
 	sizeof(asn_DEF_TwoThree_tags_1)
 		/sizeof(asn_DEF_TwoThree_tags_1[0]), /* 1 */
@@ -1747,17 +1603,8 @@ asn_SET_specifics_t asn_SPC_ThreeOne_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_ThreeOne = {
 	"ThreeOne",
 	"ThreeOne",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_ThreeOne_tags_1,
 	sizeof(asn_DEF_ThreeOne_tags_1)
 		/sizeof(asn_DEF_ThreeOne_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/92-circular-loops-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/92-circular-loops-OK.asn1.-Pfwide-types
@@ -187,17 +187,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Everything_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Everything = {
 	"Everything",
 	"Everything",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Everything_tags_1,
 	sizeof(asn_DEF_Everything_tags_1)
 		/sizeof(asn_DEF_Everything_tags_1[0]), /* 1 */
@@ -299,17 +290,8 @@ asn_CHOICE_specifics_t asn_SPC_Choice1_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Choice1 = {
 	"Choice1",
 	"Choice1",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -410,17 +392,8 @@ asn_CHOICE_specifics_t asn_SPC_Choice2_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Choice2 = {
 	"Choice2",
 	"Choice2",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -524,17 +497,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_a_2 = {
 	"a",
 	"a",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_a_tags_2,
 	sizeof(asn_DEF_a_tags_2)
 		/sizeof(asn_DEF_a_tags_2[0]) - 1, /* 1 */
@@ -574,17 +538,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_c_5 = {
 	"c",
 	"c",
-	SEQUENCE_OF_free,
-	SEQUENCE_OF_print,
-	SEQUENCE_OF_compare,
+	&asn_OP_SEQUENCE_OF,
 	SEQUENCE_OF_constraint,
-	SEQUENCE_OF_decode_ber,
-	SEQUENCE_OF_encode_der,
-	SEQUENCE_OF_decode_xer,
-	SEQUENCE_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_c_tags_5,
 	sizeof(asn_DEF_c_tags_5)
 		/sizeof(asn_DEF_c_tags_5[0]) - 1, /* 1 */
@@ -651,17 +606,8 @@ asn_CHOICE_specifics_t asn_SPC_Choice3_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Choice3 = {
 	"Choice3",
 	"Choice3",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -805,17 +751,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_Member_2 = {
 	"SEQUENCE",
 	"SEQUENCE",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Member_tags_2,
 	sizeof(asn_DEF_Member_tags_2)
 		/sizeof(asn_DEF_Member_tags_2[0]), /* 1 */
@@ -853,17 +790,8 @@ asn_SET_OF_specifics_t asn_SPC_Set_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Set = {
 	"Set",
 	"Set",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Set_tags_1,
 	sizeof(asn_DEF_Set_tags_1)
 		/sizeof(asn_DEF_Set_tags_1[0]), /* 1 */
@@ -984,17 +912,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Sequence = {
 	"Sequence",
 	"Sequence",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Sequence_tags_1,
 	sizeof(asn_DEF_Sequence_tags_1)
 		/sizeof(asn_DEF_Sequence_tags_1[0]), /* 1 */
@@ -1043,17 +962,8 @@ static const ber_tlv_tag_t asn_DEF_TypeRef_tags_1[] = {
 asn_TYPE_descriptor_t asn_DEF_TypeRef = {
 	"TypeRef",
 	"TypeRef",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_TypeRef_tags_1,
 	sizeof(asn_DEF_TypeRef_tags_1)
 		/sizeof(asn_DEF_TypeRef_tags_1[0]), /* 1 */
@@ -1136,17 +1046,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_b_3 = {
 	"b",
 	"b",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_b_tags_3,
 	sizeof(asn_DEF_b_tags_3)
 		/sizeof(asn_DEF_b_tags_3[0]) - 1, /* 1 */
@@ -1203,17 +1104,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Alpha_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Alpha = {
 	"Alpha",
 	"Alpha",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Alpha_tags_1,
 	sizeof(asn_DEF_Alpha_tags_1)
 		/sizeof(asn_DEF_Alpha_tags_1[0]), /* 1 */
@@ -1303,17 +1195,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Beta_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Beta = {
 	"Beta",
 	"Beta",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Beta_tags_1,
 	sizeof(asn_DEF_Beta_tags_1)
 		/sizeof(asn_DEF_Beta_tags_1[0]), /* 1 */
@@ -1418,17 +1301,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Gamma_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Gamma = {
 	"Gamma",
 	"Gamma",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Gamma_tags_1,
 	sizeof(asn_DEF_Gamma_tags_1)
 		/sizeof(asn_DEF_Gamma_tags_1[0]), /* 1 */
@@ -1522,17 +1396,8 @@ asn_SET_specifics_t asn_SPC_OneTwo_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_OneTwo = {
 	"OneTwo",
 	"OneTwo",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_OneTwo_tags_1,
 	sizeof(asn_DEF_OneTwo_tags_1)
 		/sizeof(asn_DEF_OneTwo_tags_1[0]), /* 1 */
@@ -1626,17 +1491,8 @@ asn_SET_specifics_t asn_SPC_TwoThree_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_TwoThree = {
 	"TwoThree",
 	"TwoThree",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_TwoThree_tags_1,
 	sizeof(asn_DEF_TwoThree_tags_1)
 		/sizeof(asn_DEF_TwoThree_tags_1[0]), /* 1 */
@@ -1746,17 +1602,8 @@ asn_SET_specifics_t asn_SPC_ThreeOne_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_ThreeOne = {
 	"ThreeOne",
 	"ThreeOne",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_ThreeOne_tags_1,
 	sizeof(asn_DEF_ThreeOne_tags_1)
 		/sizeof(asn_DEF_ThreeOne_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/93-asn1c-controls-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/93-asn1c-controls-OK.asn1.-Pfwide-types
@@ -65,17 +65,8 @@ asn_SEQUENCE_specifics_t asn_SPC_Sequence_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Sequence = {
 	"Sequence",
 	"Sequence",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Sequence_tags_1,
 	sizeof(asn_DEF_Sequence_tags_1)
 		/sizeof(asn_DEF_Sequence_tags_1[0]), /* 1 */
@@ -183,17 +174,8 @@ asn_SET_specifics_t asn_SPC_Set_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Set = {
 	"Set",
 	"Set",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Set_tags_1,
 	sizeof(asn_DEF_Set_tags_1)
 		/sizeof(asn_DEF_Set_tags_1[0]), /* 1 */
@@ -284,17 +266,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_setof_2 = {
 	"setof",
 	"setof",
-	SET_OF_free,
-	SET_OF_print,
-	SET_OF_compare,
+	&asn_OP_SET_OF,
 	SET_OF_constraint,
-	SET_OF_decode_ber,
-	SET_OF_encode_der,
-	SET_OF_decode_xer,
-	SET_OF_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_setof_tags_2,
 	sizeof(asn_DEF_setof_tags_2)
 		/sizeof(asn_DEF_setof_tags_2[0]) - 1, /* 1 */
@@ -361,17 +334,8 @@ static asn_CHOICE_specifics_t asn_SPC_Choice_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Choice = {
 	"Choice",
 	"Choice",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */

--- a/tests/tests-asn1c-compiler/94-set-optionals-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/94-set-optionals-OK.asn1.-P
@@ -201,17 +201,8 @@ asn_SET_specifics_t asn_SPC_TestSet_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_TestSet = {
 	"TestSet",
 	"TestSet",
-	SET_free,
-	SET_print,
-	SET_compare,
+	&asn_OP_SET,
 	SET_constraint,
-	SET_decode_ber,
-	SET_encode_der,
-	SET_decode_xer,
-	SET_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_TestSet_tags_1,
 	sizeof(asn_DEF_TestSet_tags_1)
 		/sizeof(asn_DEF_TestSet_tags_1[0]), /* 1 */

--- a/tests/tests-asn1c-compiler/95-choice-per-order-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/95-choice-per-order-OK.asn1.-Pfwide-types
@@ -100,17 +100,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_ch_4 = {
 	"ch",
 	"ch",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -188,17 +179,8 @@ static asn_CHOICE_specifics_t asn_SPC_Choice_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Choice = {
 	"Choice",
 	"Choice",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -285,17 +267,8 @@ static asn_CHOICE_specifics_t asn_SPC_Choice2_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Choice2 = {
 	"Choice2",
 	"Choice2",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */

--- a/tests/tests-asn1c-compiler/95-choice-per-order-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/95-choice-per-order-OK.asn1.-Pgen-PER
@@ -114,18 +114,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_ch_4 = {
 	"ch",
 	"ch",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	CHOICE_decode_uper,
-	CHOICE_encode_uper,
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -204,18 +194,8 @@ static asn_CHOICE_specifics_t asn_SPC_Choice_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Choice = {
 	"Choice",
 	"Choice",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	CHOICE_decode_uper,
-	CHOICE_encode_uper,
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -310,18 +290,8 @@ static asn_CHOICE_specifics_t asn_SPC_Choice2_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Choice2 = {
 	"Choice2",
 	"Choice2",
-	CHOICE_free,
-	CHOICE_print,
-	CHOICE_compare,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	CHOICE_decode_uper,
-	CHOICE_encode_uper,
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */

--- a/tests/tests-asn1c-compiler/98-attribute-class-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/98-attribute-class-OK.asn1.-P
@@ -99,17 +99,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_Attribute_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_Attribute = {
 	"Attribute",
 	"Attribute",
-	SEQUENCE_free,
-	SEQUENCE_print,
-	SEQUENCE_compare,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	0, 0,	/* No OER support, use "-gen-OER" to enable */
-	0, 0,	/* No PER support, use "-gen-PER" to enable */
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_Attribute_tags_1,
 	sizeof(asn_DEF_Attribute_tags_1)
 		/sizeof(asn_DEF_Attribute_tags_1[0]), /* 1 */

--- a/tests/tests-c-compiler/check-src/check-119.-fwide-types.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-119.-fwide-types.-gen-PER.c
@@ -129,7 +129,7 @@ load_object_from(const char *fname, enum expectation expectation, unsigned char 
 			" chunks %zd\n",
 			size, fname, how==AS_PER?"PER":"XER", csize);
 
-		if(st) asn_DEF_PDU.free_struct(&asn_DEF_PDU, st, 0);
+		if(st) ASN_STRUCT_FREE(asn_DEF_PDU, st);
 		st = 0;
 
 		do {
@@ -200,7 +200,7 @@ load_object_from(const char *fname, enum expectation expectation, unsigned char 
 		} else {
 			assert(rval.code != RC_OK);
 			fprintf(stderr, "Failed, but this was expected\n");
-			asn_DEF_PDU.free_struct(&asn_DEF_PDU, st, 0);
+			ASN_STRUCT_FREE(asn_DEF_PDU, st);
 			st = 0;	/* ignore leak for now */
 		}
 	}
@@ -289,7 +289,7 @@ process_XER_data(const char *fname, enum expectation expectation, unsigned char 
 		break;
 	}
 
-	asn_DEF_PDU.free_struct(&asn_DEF_PDU, st, 0);
+	ASN_STRUCT_FREE(asn_DEF_PDU, st);
 }
 
 /*

--- a/tests/tests-c-compiler/check-src/check-119.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-119.-gen-PER.c
@@ -129,7 +129,7 @@ load_object_from(const char *fname, enum expectation expectation, unsigned char 
 			" chunks %zd\n",
 			size, fname, how==AS_PER?"PER":"XER", csize);
 
-		if(st) asn_DEF_PDU.free_struct(&asn_DEF_PDU, st, 0);
+		if(st) ASN_STRUCT_FREE(asn_DEF_PDU, st);
 		st = 0;
 
 		do {
@@ -200,7 +200,7 @@ load_object_from(const char *fname, enum expectation expectation, unsigned char 
 		} else {
 			assert(rval.code != RC_OK);
 			fprintf(stderr, "Failed, but this was expected\n");
-			asn_DEF_PDU.free_struct(&asn_DEF_PDU, st, 0);
+			ASN_STRUCT_FREE(asn_DEF_PDU, st);
 			st = 0;	/* ignore leak for now */
 		}
 	}
@@ -291,7 +291,7 @@ process_XER_data(const char *fname, enum expectation expectation, unsigned char 
 		break;
 	}
 
-	asn_DEF_PDU.free_struct(&asn_DEF_PDU, st, 0);
+	ASN_STRUCT_FREE(asn_DEF_PDU, st);
 }
 
 /*

--- a/tests/tests-c-compiler/check-src/check-126.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-126.-gen-PER.c
@@ -110,7 +110,7 @@ load_object_from(const char *fname, unsigned char *fbuf, size_t size, enum encty
 			" chunks %zd\n",
 			size, fname, how==AS_PER?"PER":"XER", csize);
 
-		if(st) asn_DEF_PDU.free_struct(&asn_DEF_PDU, st, 0);
+		if(st) ASN_STRUCT_FREE(asn_DEF_PDU, st);
 		st = 0;
 
 		do {
@@ -308,7 +308,7 @@ process_XER_data(const char *fname, unsigned char *fbuf, size_t size) {
 	else
 		assert(xer_encoding_equal((char *)fbuf, size, (char *)buf, buf_offset));
 
-	asn_DEF_PDU.free_struct(&asn_DEF_PDU, st, 0);
+	ASN_STRUCT_FREE(asn_DEF_PDU, st);
 }
 
 /*

--- a/tests/tests-c-compiler/check-src/check-25.-fwide-types.c
+++ b/tests/tests-c-compiler/check-src/check-25.-fwide-types.c
@@ -136,7 +136,7 @@ check(int is_ok, uint8_t *buf, size_t size, size_t consumed) {
 		assert(rval.consumed <= consumed);
 	}
 
-	asn_DEF_T.free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 }
 
 static void
@@ -237,7 +237,7 @@ partial_read(uint8_t *buf, size_t size) {
 			assert(rval.code == RC_OK);
 			assert(rval.consumed == size3);
 
-			asn_DEF_T.free_struct(&asn_DEF_T, &t, 1);
+			ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 		}
 	}
 }

--- a/tests/tests-c-compiler/check-src/check-31.-fwide-types.c
+++ b/tests/tests-c-compiler/check-src/check-31.-fwide-types.c
@@ -138,7 +138,7 @@ check(int is_ok, uint8_t *buf, size_t size, size_t consumed) {
 	asn_fprint(stderr, &asn_DEF_Forest, &t);
 	xer_fprint(stderr, &asn_DEF_Forest, &t);
 
-	asn_DEF_Forest.free_struct(&asn_DEF_Forest, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_Forest, &t);
 }
 
 static char xer_buf[512];

--- a/tests/tests-c-compiler/check-src/check-35.c
+++ b/tests/tests-c-compiler/check-src/check-35.c
@@ -265,7 +265,7 @@ partial_read(uint8_t *data, size_t size) {
 			assert(rval.code == RC_OK);
 			assert(rval.consumed == size3);
 
-			asn_DEF_T.free_struct(&asn_DEF_T, &t, 1);
+			ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 		}
 	}
 }
@@ -315,12 +315,12 @@ main(int ac, char **av) {
 
 	check(&t, buf1, sizeof(buf1) + 10, sizeof(buf1));
 	compare(&t, buf1_reconstr, sizeof(buf1_reconstr));
-	asn_DEF_T.free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 	check_xer(buf1, sizeof(buf1), "<T><c><false/></c><b><b2>z</b2></b><a>=&lt;&amp;&gt;</a><d><r-oid>85.79</r-oid></d></T>");
 
 	check(&t, buf2, sizeof(buf2) + 10, sizeof(buf2));
 	compare(&t, buf2_reconstr, sizeof(buf2_reconstr));
-	asn_DEF_T.free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 	check_xer(buf2, sizeof(buf2), "<T><c><true/></c><b><b1>z</b1></b><a>=&lt;&amp;&gt;</a><d><oid>2.1</oid></d></T>");
 
 	/* Split the buffer in parts and check decoder restartability */

--- a/tests/tests-c-compiler/check-src/check-41.-fwide-types.c
+++ b/tests/tests-c-compiler/check-src/check-41.-fwide-types.c
@@ -281,7 +281,7 @@ partial_read(uint8_t *data, size_t size) {
 			assert(rval.code == RC_OK);
 			assert(rval.consumed == size3);
 
-			asn_DEF_T.free_struct(&asn_DEF_T, &t, 1);
+			ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 		}
 	}
 }
@@ -293,27 +293,27 @@ main() {
 	/* Check exact buf0 */
 	check(&t, buf0, sizeof(buf0), sizeof(buf0));
 	compare(&t, buf0_reconstr, sizeof(buf0_reconstr));
-	asn_DEF_T.free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 
 	/* Check exact buf1 */
 	check(&t, buf1, sizeof(buf1), sizeof(buf1));
 	compare(&t, buf1_reconstr, sizeof(buf1_reconstr));
-	asn_DEF_T.free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 
 	/* Check slightly more than buf1 */
 	check(&t, buf1, sizeof(buf1) + 10, sizeof(buf1));
 	compare(&t, buf1_reconstr, sizeof(buf1_reconstr));
-	asn_DEF_T.free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 
 	/* Check exact buf2 */
 	check(&t, buf2, sizeof(buf2), sizeof(buf2));
 	compare(&t, buf2_reconstr, sizeof(buf2_reconstr));
-	asn_DEF_T.free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 
 	/* Check slightly more than buf2 */
 	check(&t, buf2, sizeof(buf2) + 10, sizeof(buf2));
 	compare(&t, buf2_reconstr, sizeof(buf2_reconstr));
-	asn_DEF_T.free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 
 	/* Split the buffer in parts and check decoder restartability */
 	partial_read(buf0, sizeof(buf0));

--- a/tests/tests-c-compiler/check-src/check-41.c
+++ b/tests/tests-c-compiler/check-src/check-41.c
@@ -188,7 +188,7 @@ partial_read(uint8_t *buf_0, size_t size) {
 			assert(rval.code == RC_OK);
 			assert(rval.consumed == size3);
 
-			asn_DEF_T.free_struct(&asn_DEF_T, &t, 1);
+			ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 		}
 	}
 }
@@ -204,13 +204,13 @@ main(int ac, char **av) {
 	check(&t, buf1, sizeof(buf1), sizeof(buf1));
 	compare(&t, buf1_reconstr, sizeof(buf1_reconstr));
 	asn_fprint(stderr, &asn_DEF_T, &t);
-	asn_DEF_T.free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 
 	/* Check slightly more than buf1 */
 	check(&t, buf1, sizeof(buf1) + 10, sizeof(buf1));
 	compare(&t, buf1_reconstr, sizeof(buf1_reconstr));
 	asn_fprint(stderr, &asn_DEF_T, &t);
-	asn_DEF_T.free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 
 	/* Split the buffer in parts and check decoder restartability */
 	partial_read(buf1, sizeof(buf1));

--- a/tests/tests-c-compiler/check-src/check-42.c
+++ b/tests/tests-c-compiler/check-src/check-42.c
@@ -66,7 +66,7 @@ check(LogLine_t *tp, uint8_t *ptr, size_t size, size_t consumed) {
 	assert(rval.code == RC_OK);
 	assert(rval.consumed == consumed);
 	asn_fprint(stderr, &asn_DEF_LogLine, tp);
-	asn_DEF_LogLine.free_struct(&asn_DEF_LogLine, tp, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_LogLine, tp);
 }
 
 uint8_t *buf;

--- a/tests/tests-c-compiler/check-src/check-62.c
+++ b/tests/tests-c-compiler/check-src/check-62.c
@@ -78,7 +78,7 @@ load_object(enum expectation expectation, unsigned char *fbuf, size_t size) {
 		int fbuf_left = size;
 		int fbuf_chunk = csize;
 
-		if(st) asn_DEF_T.free_struct(&asn_DEF_T, st, 0);
+		if(st) ASN_STRUCT_FREE(asn_DEF_T, st);
 		st = 0;
 
 		do {
@@ -102,7 +102,7 @@ load_object(enum expectation expectation, unsigned char *fbuf, size_t size) {
 		} else {
 			assert(rval.code != RC_OK);
 			fprintf(stderr, "Failed, but this was expected\n");
-			asn_DEF_T.free_struct(&asn_DEF_T, st, 0);
+			ASN_STRUCT_FREE(asn_DEF_T, st);
 			st = 0;	/* ignore leak for now */
 		}
 	}
@@ -142,7 +142,7 @@ process_data(enum expectation expectation, unsigned char *fbuf, ssize_t size) {
 		break;
 	}
 
-	asn_DEF_T.free_struct(&asn_DEF_T, st, 0);
+	ASN_STRUCT_FREE(asn_DEF_T, st);
 }
 
 /*

--- a/tests/tests-c-compiler/check-src/check-70.-fwide-types.c
+++ b/tests/tests-c-compiler/check-src/check-70.-fwide-types.c
@@ -121,7 +121,7 @@ load_object_from(enum expectation expectation, unsigned char *fbuf, size_t size,
 		fprintf(stderr, "LOADING OBJECT OF SIZE %zd, chunks %zd\n",
 			size, csize);
 
-		if(st) asn_DEF_PDU.free_struct(&asn_DEF_PDU, st, 0);
+		if(st) ASN_STRUCT_FREE(asn_DEF_PDU, st);
 		st = 0;
 
 		do {
@@ -165,7 +165,7 @@ load_object_from(enum expectation expectation, unsigned char *fbuf, size_t size,
 		} else {
 			assert(rval.code != RC_OK);
 			fprintf(stderr, "Failed, but this was expected\n");
-			asn_DEF_PDU.free_struct(&asn_DEF_PDU, st, 0);
+			ASN_STRUCT_FREE(asn_DEF_PDU, st);
 			st = 0;	/* ignore leak for now */
 		}
 	}
@@ -252,7 +252,7 @@ process_XER_data(enum expectation expectation, unsigned char *fbuf, size_t size)
 		break;
 	}
 
-	asn_DEF_PDU.free_struct(&asn_DEF_PDU, st, 0);
+	ASN_STRUCT_FREE(asn_DEF_PDU, st);
 }
 
 /*

--- a/tests/tests-c-compiler/check-src/check-70.c
+++ b/tests/tests-c-compiler/check-src/check-70.c
@@ -110,7 +110,7 @@ load_object_from(enum expectation expectation, unsigned char *fbuf, size_t size,
 		fprintf(stderr, "LOADING OBJECT OF SIZE %zd, chunks %zd\n",
 			size, csize);
 
-		if(st) asn_DEF_PDU.free_struct(&asn_DEF_PDU, st, 0);
+		if(st) ASN_STRUCT_FREE(asn_DEF_PDU, st);
 		st = 0;
 
 		do {
@@ -154,7 +154,7 @@ load_object_from(enum expectation expectation, unsigned char *fbuf, size_t size,
 		} else {
 			assert(rval.code != RC_OK);
 			fprintf(stderr, "Failed, but this was expected\n");
-			asn_DEF_PDU.free_struct(&asn_DEF_PDU, st, 0);
+			ASN_STRUCT_FREE(asn_DEF_PDU, st);
 			st = 0;	/* ignore leak for now */
 		}
 	}
@@ -228,7 +228,7 @@ process_XER_data(enum expectation expectation, unsigned char *fbuf, size_t size)
 		break;
 	}
 
-	asn_DEF_PDU.free_struct(&asn_DEF_PDU, st, 0);
+	ASN_STRUCT_FREE(asn_DEF_PDU, st);
 }
 
 /*


### PR DESCRIPTION
Every type has free, print, check_constraints, ber_decoder, der_encoder, xer_decoder, xer_encoder, uper_decoder, uper_encoder ...  functions and outmost_tag. We can move them out to a separate structure asn_TYPE_operation_t.

```
typedef struct asn_TYPE_operation_s {
	asn_struct_free_f  *free_struct;	/* Free the structure */
	asn_struct_print_f *print_struct;	/* Human readable output */
	asn_struct_compare_f *compare_struct;	/* Compare two structures */
	asn_constr_check_f *check_constraints;	/* Constraints validator */ <-- see Note
	ber_type_decoder_f *ber_decoder;	/* Generic BER decoder */
	der_type_encoder_f *der_encoder;	/* Canonical DER encoder */
	xer_type_decoder_f *xer_decoder;	/* Generic XER decoder */
	xer_type_encoder_f *xer_encoder;	/* [Canonical] XER encoder */
	oer_type_decoder_f *oer_decoder;	/* Generic OER decoder */
	oer_type_encoder_f *oer_encoder;	/* Canonical OER encoder */
	per_type_decoder_f *uper_decoder;	/* Unaligned PER decoder */
	per_type_encoder_f *uper_encoder;	/* Unaligned PER encoder */
	asn_outmost_tag_f  *outmost_tag;	/* <optional, internal> */
} asn_TYPE_operation_t;

typedef struct asn_TYPE_descriptor_s {
	....
	/*
	 * Generalized functions for dealing with the specific type.
	 * May be directly invoked by applications.
	 */
	asn_TYPE_operation_t *op;
	asn_constr_check_f *check_constraints;	/* Constraints validator */ <-- see Note
	....

} asn_TYPE_descriptor_t;

Note : check_constraints of asn_TYPE_descriptor_t is type specific constraint check function 
       check_constraints of asn_TYPE_operation_t is base type specific constraint check function.
```

Combined with previous logic simplification #93, these operations are based
on ASN.1 basic types, constructed types and string types. So we can
reduce the space occupied by asn_TYPE_descriptor_t variables.

For example, by applying this pr, rrc-dump is reduced from 7399160 bytes to 6308584 bytes, 85.2 % of original file size.

Moreover, we can further implement conditionally compilation of various codecs. 
For example, we only need UPER codec to decoding RRC message, so we can try to remove BER/XER ... codec dictionary and code to reduce program size.

It is important for embedded device with limited memory.