### PR TITLE
Fix stack overflow for asn_REAL2double

### DIFF
--- a/skeletons/REAL.c
+++ b/skeletons/REAL.c
@@ -518,7 +518,7 @@ asn_REAL2double(const REAL_t *st, double *dbl_value) {
 		 * However, strtod() can't always deal with COMMA.
 		 * So her we fix both by reallocating, copying and fixing.
 		 */
-		if(st->buf[st->size] || memchr(st->buf, ',', st->size)) {
+		if(st->buf[st->size-1] || memchr(st->buf, ',', st->size)) {
 			uint8_t *p, *end;
 			char *b;
 			if(st->size > 100) {


### PR DESCRIPTION
While finding a fix for #179 I found an another bug in 0.9.28 using asan:
```
384: Checking -nan->["<NOT-A-NUMBER/>"] against ["<NOT-A-NUMBER/>"] (canonical follows...)
384: Checking -nan->["<NOT-A-NUMBER/>"] against ["<NOT-A-NUMBER/>"] (canonical)
=================================================================
==25075==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fff5f05e552 at pc 0x556c0d14bb67 bp 0x7fff5f05dae0 sp 0x7fff5f05dad8
READ of size 1 at 0x7fff5f05e552 thread T0
    #0 0x556c0d14bb66 in asn_REAL2double skeletons/REAL.c:460
    #1 0x556c0d141751 in check_ber_buffer_twoway skeletons/tests/check-REAL.c:180
    #2 0x556c0d142ff3 in check_ber_encoding skeletons/tests/check-REAL.c:389
    #3 0x556c0d1401da in main skeletons/tests/check-REAL.c:621
    #4 0x7f6db60f72e0 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x202e0)
    #5 0x556c0d140ba9 in _start (/build/asn1c-0.9.28+dfsg/skeletons/tests/check-REAL+0x7ba9)

Address 0x7fff5f05e552 is located in stack of thread T0 at offset 2018 in frame
    #0 0x556c0d141f9f in check_ber_encoding skeletons/tests/check-REAL.c:344
```
Could you please review and accept this fix?