### PR TITLE
suppress warning in x64

### DIFF
--- a/skeletons/converter-sample.c
+++ b/skeletons/converter-sample.c
@@ -106,7 +106,7 @@ ats_simple_name(enum asn_transfer_syntax syntax) {
 }
 
 
-#define OP_OFFSET(fname)  (unsigned)(&(((asn_TYPE_operation_t *)0)->fname))
+#define OP_OFFSET(fname)  (size_t)(&(((asn_TYPE_operation_t *)0)->fname))
 typedef struct {
     const char *name;
     enum asn_transfer_syntax syntax;

--- a/skeletons/converter-sample.c
+++ b/skeletons/converter-sample.c
@@ -106,7 +106,7 @@ ats_simple_name(enum asn_transfer_syntax syntax) {
 }
 
 
-#define OP_OFFSET(fname)  (size_t)(&(((asn_TYPE_operation_t *)0)->fname))
+#define OP_OFFSET(fname)  (ptrdiff_t)(&(((asn_TYPE_operation_t *)0)->fname))
 typedef struct {
     const char *name;
     enum asn_transfer_syntax syntax;


### PR DESCRIPTION
suppress warning in x64 where (unsigned) is 32 bits and pointer is 64. The size_t looks better here.