### PR TITLE
Optionally disable the use of alloca

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -246,6 +246,14 @@ AC_CHECK_FUNCS(timegm)
 AC_CHECK_DECLS(alloca strcasecmp)
 AC_TRY_LINK_FUNC([symlink],[AC_DEFINE([HAVE_SYMLINK], 1, [Define to 1 if you have the symlink function.])])
 
+AC_ARG_ENABLE([alloca],
+    AC_HELP_STRING([--enable-alloca],[whether to enable the use of alloca() [default=yes]]),
+    [AS_IF([test "x$enable_alloca" = "xno"],
+        [AC_DEFINE([DISABLE_ALLOCA], [], [Disable the use of alloca])]
+    )],
+    []
+)
+
 dnl Use pandoc to generate manual pages.
 AC_PATH_PROG([PANDOC], pandoc)
 AM_CONDITIONAL([HAVE_PANDOC], [test -n "$PANDOC"])

--- a/skeletons/NativeEnumerated.c
+++ b/skeletons/NativeEnumerated.c
@@ -74,11 +74,22 @@ NativeEnumerated_encode_xer(asn_TYPE_descriptor_t *td, void *sptr, int ilevel,
     el = INTEGER_map_value2enum(specs, *native);
     if(el) {
         size_t srcsize = el->enum_len + 5;
+        int src_used_malloc = 0;
+#ifndef DISABLE_ALLOCA
         char *src = (char *)alloca(srcsize);
+#else
+        char *src = (char *)MALLOC(srcsize);
+        src_used_malloc = 1;
+#endif
+        if (!src) ASN__ENCODE_FAILED;
 
         er.encoded = snprintf(src, srcsize, "<%s/>", el->enum_name);
         assert(er.encoded > 0 && (size_t)er.encoded < srcsize);
-        if(cb(src, er.encoded, app_key) < 0) ASN__ENCODE_FAILED;
+        if(cb(src, er.encoded, app_key) < 0) {
+            if(src_used_malloc) FREEMEM(src);
+            ASN__ENCODE_FAILED;
+        }
+        if(src_used_malloc) FREEMEM(src);
         ASN__ENCODED_OK(er);
     } else {
         ASN_DEBUG(

--- a/skeletons/NativeEnumerated.c
+++ b/skeletons/NativeEnumerated.c
@@ -81,7 +81,7 @@ NativeEnumerated_encode_xer(asn_TYPE_descriptor_t *td, void *sptr, int ilevel,
         char *src = (char *)MALLOC(srcsize);
         src_used_malloc = 1;
 #endif
-        if (!src) ASN__ENCODE_FAILED;
+        if(!src) ASN__ENCODE_FAILED;
 
         er.encoded = snprintf(src, srcsize, "<%s/>", el->enum_name);
         assert(er.encoded > 0 && (size_t)er.encoded < srcsize);

--- a/skeletons/REAL.c
+++ b/skeletons/REAL.c
@@ -532,14 +532,18 @@ asn_REAL2double(const REAL_t *st, double *dbl_value) {
 		if(st->buf[st->size] != '\0' || memchr(st->buf, ',', st->size)) {
 			uint8_t *p, *end;
 			char *b;
+#ifndef DISABLE_ALLOCA
 			if(st->size > 100) {
+#endif
 				/* Avoid malicious stack overflow in alloca() */
 				buf = (char *)MALLOC(st->size);
-				if(!buf) return -1;
 				used_malloc = 1;
+#ifndef DISABLE_ALLOCA
 			} else {
 				buf = alloca(st->size);
 			}
+#endif
+			if(!buf) return -1;
 			b = buf;
 			/* Copy without the first byte and with 0-termination */
 			for(p = st->buf + 1, end = st->buf + st->size;

--- a/skeletons/der_encoder.c
+++ b/skeletons/der_encoder.c
@@ -86,7 +86,7 @@ der_write_tags(asn_TYPE_descriptor_t *sd,
 	ssize_t *lens;
 	int lens_used_malloc = 0;
 	int i;
-	ber_tlv_tag_t *tags_buf = NULL;
+	ber_tlv_tag_t *tags_buf;
 	int tags_buf_used_malloc = 0;
 
 	ASN_DEBUG("Writing tags (%s, tm=%d, tc=%d, tag=%s, mtc=%d)",


### PR DESCRIPTION
I'm using asn1c in a project where a hard requirement is not using alloca. This pull request makes the use of alloca in the generated C files optional (but enabled by default).

I tried to follow the existing code style.
