### PR TITLE
gcc 7.2.1 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ compiler:
   - gcc
   - clang
 before_install:
-  - sudo apt-get install -y lcov
+  - sudo apt-get install -y lcov libasan*
   - gem install coveralls-lcov
 script:
     - autoreconf -iv

--- a/skeletons/constr_SEQUENCE.c
+++ b/skeletons/constr_SEQUENCE.c
@@ -994,6 +994,9 @@ void
 SEQUENCE_free(const asn_TYPE_descriptor_t *td, void *sptr,
               enum asn_struct_free_method method) {
     size_t edx;
+    const asn_SEQUENCE_specifics_t *specs =
+        (const asn_SEQUENCE_specifics_t *)td->specifics;
+    asn_struct_ctx_t *ctx; /* Decoder context */
 
 	if(!td || !sptr)
 		return;
@@ -1012,6 +1015,10 @@ SEQUENCE_free(const asn_TYPE_descriptor_t *td, void *sptr,
 			ASN_STRUCT_FREE_CONTENTS_ONLY(*elm->type, memb_ptr);
 		}
 	}
+
+	/* Clean parsing context */
+	ctx = (asn_struct_ctx_t *)((char *)sptr + specs->ctx_offset);
+	FREEMEM(ctx->ptr);
 
     switch(method) {
     case ASFM_FREE_EVERYTHING:

--- a/skeletons/xer_encoder.c
+++ b/skeletons/xer_encoder.c
@@ -230,6 +230,8 @@ xer_equivalent(struct asn_TYPE_descriptor_s *td, void *struct1,
         return XEQ_ROUND_TRIP_FAILED;
     }
 
-    return XEQ_SUCCESS;
+	FREEMEM(xb1.buffer);
+	FREEMEM(xb2.buffer);
+	return XEQ_SUCCESS;
 }
 

--- a/skeletons/xer_encoder.c
+++ b/skeletons/xer_encoder.c
@@ -80,7 +80,9 @@ xer__buffer_append(const void *buffer, size_t size, void *app_key) {
         size_t new_size = 2 * (xb->allocated_size ? xb->allocated_size : 64);
         char *new_buf = MALLOC(new_size);
         if(!new_buf) return -1;
-        memcpy(new_buf, xb->buffer, xb->buffer_size);
+        if (xb->buffer) {
+            memcpy(new_buf, xb->buffer, xb->buffer_size);
+        }
         FREEMEM(xb->buffer);
         xb->buffer = new_buf;
         xb->allocated_size = new_size;

--- a/tests/tests-c-compiler/Makefile.am
+++ b/tests/tests-c-compiler/Makefile.am
@@ -15,6 +15,7 @@ TESTS_ENVIRONMENT= \
 				   CXXFLAGS="${CXXFLAGS}" \
 				   LDFLAGS="${LDFLAGS}" \
 				   LIBFUZZER_CFLAGS="${LIBFUZZER_CFLAGS}" \
+				   ASAN_ENV_FLAGS="@ASAN_ENV_FLAGS@"       \
 				   srcdir=${srcdir} \
 				   abs_top_srcdir=${abs_top_srcdir} \
 				   abs_top_builddir=${abs_top_builddir} \

--- a/tests/tests-c-compiler/check-assembly.sh
+++ b/tests/tests-c-compiler/check-assembly.sh
@@ -76,6 +76,7 @@ CFLAGS += -DSRCDIR=../${srcdir}
 CXXFLAGS = \${CFLAGS} ${CXXFLAGS}
 LIBFUZZER_CFLAGS = ${LIBFUZZER_CFLAGS}
 LDFLAGS = ${LDFLAGS:-}
+ASAN_ENV_FLAGS = ${ASAN_ENV_FLAGS:-}
 
 ASN_PROGRAM = check-program
 ASN_PROGRAM_SOURCES = ${source_short}
@@ -120,7 +121,7 @@ check-succeeded: compiled-module \$(ASN_LIBRARY) ${source_short}
 	\$(MAKE) check-program
 	\$(MAKE) check-fuzzer
 	@rm -f check-succeeded
-	./check-program
+	\${ASAN_ENV_FLAGS} ./check-program
 	\$(MAKE) fuzz
 	@touch check-succeeded
 	@echo "OK: ${source_full}"

--- a/tests/tests-c-compiler/check-src/check-03.-fwide-types.c
+++ b/tests/tests-c-compiler/check-src/check-03.-fwide-types.c
@@ -45,6 +45,8 @@ check_xer(e_Enum2 eval, char *xer_string) {
 	sprintf(buf2, "<Enum2>%s</Enum2>", xer_string);
 	printf("%d -> %s == %s\n", eval, buf, buf2);
 	assert(0 == strcmp(buf, buf2));
+
+	ASN_STRUCT_FREE(asn_DEF_Enum2, e);
 }
 
 int

--- a/tests/tests-c-compiler/check-src/check-119.-fwide-types.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-119.-fwide-types.-gen-PER.c
@@ -249,6 +249,7 @@ process_XER_data(const char *fname, enum expectation expectation, unsigned char 
 
 	/* Save and re-load as PER */
 	save_object_as(st, expectation, AS_PER);
+	ASN_STRUCT_FREE(asn_DEF_PDU, st);
 	if(expectation == EXP_PER_NOCOMP)
 		return;	/* Already checked */
 	st = load_object_from("buffer", expectation, buf, buf_offset, AS_PER);

--- a/tests/tests-c-compiler/check-src/check-119.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-119.-gen-PER.c
@@ -251,6 +251,8 @@ process_XER_data(const char *fname, enum expectation expectation, unsigned char 
 
 	/* Save and re-load as PER */
 	save_object_as(st, expectation, AS_PER);
+	ASN_STRUCT_FREE(asn_DEF_PDU, st);
+
 	if(expectation == EXP_PER_NOCOMP)
 		return;	/* Already checked */
 	st = load_object_from("buffer", expectation, buf, buf_offset, AS_PER);

--- a/tests/tests-c-compiler/check-src/check-126.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-126.-gen-PER.c
@@ -150,6 +150,7 @@ load_object_from(const char *fname, unsigned char *fbuf, size_t size, enum encty
 						rval.consumed /= 8;
 						if(mustfail) {
 							fprintf(stderr, "-> (this was expected failure)\n");
+							ASN_STRUCT_FREE(asn_DEF_PDU, st);
 							return 0;
 						}
 					} else {
@@ -167,6 +168,7 @@ load_object_from(const char *fname, unsigned char *fbuf, size_t size, enum encty
 					if((mustfail?1:0) == (rval.code == RC_FAIL)) {
 						if(mustfail) {
 							fprintf(stderr, "-> (this was expected failure)\n");
+							ASN_STRUCT_FREE(asn_DEF_PDU, st);
 							return 0;
 						}
 					} else {
@@ -246,6 +248,7 @@ compare_with_data_out(const char *fname, void *datap, size_t size) {
 	FILE *f;
 	char lastChar;
 	int mustfail, compare;
+	PDU_t *st;
 
 	sprintf(outName, SRCDIR_S "/data-126/%s", fname);
 	strcpy(outName + strlen(outName) - 3, ".out");
@@ -268,7 +271,8 @@ compare_with_data_out(const char *fname, void *datap, size_t size) {
 		fclose(f);
 
 		fprintf(stderr, "Trying to decode [%s]\n", outName);
-		load_object_from(outName, fbuf, rd, AS_PER, mustfail);
+		st = load_object_from(outName, fbuf, rd, AS_PER, mustfail);
+		ASN_STRUCT_FREE(asn_DEF_PDU, st);
 		if(mustfail) return;
 
 		if(compare) {
@@ -291,6 +295,7 @@ process_XER_data(const char *fname, unsigned char *fbuf, size_t size) {
 
 	/* Save and re-load as PER */
 	save_object_as(st, AS_PER);
+	ASN_STRUCT_FREE(asn_DEF_PDU, st);
 	compare_with_data_out(fname, buf, buf_offset);
 	st = load_object_from("buffer", buf, buf_offset, AS_PER, 0);
 	assert(st);

--- a/tests/tests-c-compiler/check-src/check-127.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-127.-gen-PER.c
@@ -42,6 +42,8 @@ verify(int testNo, T_t *ti) {
 
 	xer_fprint(stderr, &asn_DEF_T, ti);
 	xer_fprint(stderr, &asn_DEF_T, to);
+
+	ASN_STRUCT_FREE(asn_DEF_T, to);
 }
 
 int main() {

--- a/tests/tests-c-compiler/check-src/check-131.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-131.-gen-PER.c
@@ -55,5 +55,6 @@ main() {
 		|| (pd.nboff == 16 && pd.buffer == &po.tmpspace[0]));
 	assert(pd.nboff + pd.nbits == 16);
 
+	ASN_STRUCT_FREE(asn_DEF_T, t2);
 	return 0;
 }

--- a/tests/tests-c-compiler/check-src/check-132.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-132.-gen-PER.c
@@ -36,6 +36,8 @@ verify(int testNo, T_t *ti) {
 
 	xer_fprint(stderr, &asn_DEF_T, ti);
 	xer_fprint(stderr, &asn_DEF_T, to);
+
+	ASN_STRUCT_FREE(asn_DEF_T, to);
 }
 
 int main() {

--- a/tests/tests-c-compiler/check-src/check-135.-gen-OER.c
+++ b/tests/tests-c-compiler/check-src/check-135.-gen-OER.c
@@ -36,6 +36,8 @@ int main() {
         return 1;
     }
 
+    ASN_STRUCT_RESET(asn_DEF_T, &source);
+    ASN_STRUCT_FREE(asn_DEF_T, decoded);
     return 0;
 }
 

--- a/tests/tests-c-compiler/check-src/check-148.c
+++ b/tests/tests-c-compiler/check-src/check-148.c
@@ -139,6 +139,8 @@ check_sequence(uint8_t *in, size_t in_size, uint8_t *expected,
   buf2_pos = 0;
   erval = der_encode(&asn_DEF_DefaultSequence, tp, buf2_fill, 0);
   compare_encoding(&erval, expected, expected_size, buf2);
+
+  ASN_STRUCT_RESET(asn_DEF_DefaultSequence, tp);
 }
 
 static void
@@ -160,6 +162,7 @@ check_set(uint8_t *in, size_t in_size, uint8_t *expected,
   buf2_pos = 0;
   erval = der_encode(&asn_DEF_DefaultSet, tp, buf2_fill, 0);
   compare_encoding(&erval, expected, expected_size, buf2);
+  ASN_STRUCT_RESET(asn_DEF_DefaultSet, tp);
 }
 
 int

--- a/tests/tests-c-compiler/check-src/check-22.-fwide-types.c
+++ b/tests/tests-c-compiler/check-src/check-22.-fwide-types.c
@@ -79,6 +79,7 @@ check(int is_ok, uint8_t *buf, size_t size, size_t consumed) {
 			);
 		}
 		assert(rval.consumed <= (size_t)consumed);
+		ASN_STRUCT_RESET(asn_DEF_T1, tp);
 		return;
 	}
 
@@ -113,6 +114,8 @@ check(int is_ok, uint8_t *buf, size_t size, size_t consumed) {
 	ret = xer_fprint(stderr, &asn_DEF_T1, tp);
 	assert(ret == 0);
 	fprintf(stderr, "=== EOF ===\n");
+
+	ASN_STRUCT_RESET(asn_DEF_T1, tp);
 }
 
 static void

--- a/tests/tests-c-compiler/check-src/check-24.-fwide-types.c
+++ b/tests/tests-c-compiler/check-src/check-24.-fwide-types.c
@@ -58,6 +58,8 @@ check(int is_ok, uint8_t *buf, size_t size, size_t consumed) {
 		}
 		assert(rval.consumed <= consumed);
 	}
+
+	ASN_STRUCT_RESET(asn_DEF_T, tp);
 }
 
 static void

--- a/tests/tests-c-compiler/check-src/check-30.-fwide-types.c
+++ b/tests/tests-c-compiler/check-src/check-30.-fwide-types.c
@@ -177,6 +177,7 @@ check(int is_ok, uint8_t *buf, size_t size, size_t consumed) {
 		}
 		assert(rval.consumed <= consumed);
 	}
+	ASN_STRUCT_RESET(asn_DEF_T, tp);
 }
 
 
@@ -212,6 +213,8 @@ check_xer(uint8_t *buf, uint8_t size, char *xer_sample) {
 	printf("[%s] vs [%s]\n", xer_buf, xer_sample);
 	assert(xer_off == xer_sample_len);
 	assert(memcmp(xer_buf, xer_sample, xer_off) == 0);
+
+	ASN_STRUCT_FREE(asn_DEF_T, tp);
 }
 
 static void

--- a/tests/tests-c-compiler/check-src/check-31.-fwide-types.c
+++ b/tests/tests-c-compiler/check-src/check-31.-fwide-types.c
@@ -124,6 +124,7 @@ check(int is_ok, uint8_t *buf, size_t size, size_t consumed) {
 			);
 		}
 		assert(rval.consumed <= consumed);
+		ASN_STRUCT_RESET(asn_DEF_Forest, &t);
 		return;
 	}
 
@@ -173,6 +174,8 @@ check_xer(uint8_t *buf, uint8_t size, char *xer_sample) {
 	printf("[%s] vs [%s]\n", xer_buf, xer_sample);
 	assert(xer_off == xer_sample_len);
 	assert(memcmp(xer_buf, xer_sample, xer_off) == 0);
+
+	ASN_STRUCT_FREE(asn_DEF_Forest, tp);
 }
 
 

--- a/tests/tests-c-compiler/check-src/check-32.c
+++ b/tests/tests-c-compiler/check-src/check-32.c
@@ -57,6 +57,7 @@ main(int ac, char **av) {
 	assert(swo->seqOfOpt != 0);
 
 	xer_fprint(stderr, &asn_DEF_SeqWithOptional, swo);
+	void *tmp = swo->seqOfOpt;
 	swo->seqOfOpt = 0;
 
 	erv = der_encode_to_buffer(&asn_DEF_SeqWithOptional,
@@ -64,10 +65,15 @@ main(int ac, char **av) {
 	assert(erv.encoded > 0);
 	buf[erv.encoded] = '\0';
 
+	swo->seqOfOpt = tmp;
+	ASN_STRUCT_RESET(asn_DEF_SeqWithMandatory, &swm);
+	ASN_STRUCT_FREE(asn_DEF_SeqWithOptional, swo);
 	swo = 0;
+
 	drv = ber_decode(0, &asn_DEF_SeqWithMandatory, (void **)&swo,
 			buf, erv.encoded);
 	assert(drv.code != RC_OK);
+	ASN_STRUCT_FREE(asn_DEF_SeqWithOptional, swo);
 	swo = 0;
 	drv = ber_decode(0, &asn_DEF_SeqWithOptional, (void **)&swo,
 			buf, erv.encoded);
@@ -76,6 +82,7 @@ main(int ac, char **av) {
 	assert(swo->seqOfOpt == 0);
 
 	xer_fprint(stderr, &asn_DEF_SeqWithOptional, swo);
+	ASN_STRUCT_FREE(asn_DEF_SeqWithOptional, swo);
 
 	printf("Finished\n");
 

--- a/tests/tests-c-compiler/check-src/check-35.c
+++ b/tests/tests-c-compiler/check-src/check-35.c
@@ -304,6 +304,8 @@ check_xer(uint8_t *data, uint8_t size, char *xer_sample) {
 	assert(er.encoded == (ssize_t)xer_off);
 	assert(xer_off == xer_sample_len);
 	assert(memcmp(xer_buf, xer_sample, xer_off) == 0);
+
+	ASN_STRUCT_FREE(asn_DEF_T, tp);
 }
 
 

--- a/tests/tests-c-compiler/check-src/check-42.c
+++ b/tests/tests-c-compiler/check-src/check-42.c
@@ -90,26 +90,23 @@ buf_fill(const void *buffer, size_t size, void *app_key) {
 static void
 check_serialize() {
 	LogLine_t ll;
-	VariablePartSet_t vps;
-	VariablePart_t vp;
-	VisibleString_t vpart;
+	VariablePartSet_t *vps;
+	VariablePart_t *vp;
+	VisibleString_t *vpart;
 	asn_enc_rval_t erval;
 	int i;
 
 	memset(&ll, 0, sizeof(ll));
-	memset(&vps, 0, sizeof(vps));
-	memset(&vp, 0, sizeof(vp));
-	memset(&vpart, 0, sizeof(vpart));
-	vpart.buf = (uint8_t *)"123";
-	vpart.size = 3;
+	vps = calloc(1, sizeof(*vps));
+	vp = calloc(1, sizeof(*vp));
+	vpart = OCTET_STRING_new_fromBuf(&asn_DEF_VisibleString, "123", 3);
 
-	vp.present = VariablePart_PR_vset;
-	ASN_SET_ADD(&vp.choice.vset, &vpart);
-	vps.resolution.accept_as = accept_as_unknown;
-	ASN_SEQUENCE_ADD(&vps.vparts, &vp);
-	ASN_SEQUENCE_ADD(&ll.varsets, &vps);
-	ll.line_digest.buf = (uint8_t *)"zzz\007";
-	ll.line_digest.size = 4;
+	vp->present = VariablePart_PR_vset;
+	ASN_SET_ADD(&vp->choice.vset, vpart);
+	vps->resolution.accept_as = accept_as_unknown;
+	ASN_SEQUENCE_ADD(&vps->vparts, vp);
+	ASN_SEQUENCE_ADD(&ll.varsets, vps);
+	OCTET_STRING_fromBuf(&ll.line_digest, "zzz\007", 4);
 
 	asn_fprint(stderr, &asn_DEF_LogLine, &ll);
 	buf_size = 128;
@@ -125,6 +122,8 @@ check_serialize() {
 	fprintf(stderr, "\n\n");
 	assert(erval.encoded == sizeof(buf0));
 	assert(memcmp(buf0, buf, sizeof(buf0)) == 0);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_LogLine, &ll);
+	return;
 }
 
 #ifdef ENABLE_LIBFUZZER

--- a/tests/tests-c-compiler/check-src/check-46.c
+++ b/tests/tests-c-compiler/check-src/check-46.c
@@ -31,6 +31,7 @@ check(uint8_t *buf, size_t size, size_t consumed) {
 
 	assert(rval.code == RC_OK);
 	assert(rval.consumed == consumed);
+	ASN_STRUCT_RESET(asn_DEF_T, tp);
 }
 
 int

--- a/tests/tests-c-compiler/check-src/check-48.c
+++ b/tests/tests-c-compiler/check-src/check-48.c
@@ -94,5 +94,7 @@ main() {
 
 	printf("OK\n");
 
+	ASN_STRUCT_RESET(asn_DEF_UserIdentifier, &user);
+	ASN_STRUCT_RESET(asn_DEF_UserIdentifier, &user_new);
 	return ret;
 }

--- a/tests/tests-c-compiler/check-src/check-60.c
+++ b/tests/tests-c-compiler/check-src/check-60.c
@@ -109,7 +109,7 @@ main() {
 	 * Test the T1 with primitive encoding.
 	 */
 	memset(&t1, 0, sizeof(t1));
-	memset(&t1_new, 0, sizeof(t1_new));
+	ASN_STRUCT_RESET(asn_DEF_T1, &t1_new);
 
 	t1.i = -112233;
 	t1.any.buf = test_any_buf2;
@@ -123,6 +123,7 @@ main() {
 	assert(t1_new.i == -112233);
 	assert(t1_new.any.size == (ssize_t)sizeof(test_any_buf2));
 	assert(memcmp(t1_new.any.buf, test_any_buf2, sizeof(test_any_buf2)) == 0);
+	ASN_STRUCT_RESET(asn_DEF_T1, &t1_new);
 
 	/*
 	 * Test the T2 empty sequence.
@@ -146,8 +147,8 @@ main() {
 	/*
 	 * Test the T2 sequence.
 	 */
-	memset(&t2, 0, sizeof(t2));
-	memset(&t2_new, 0, sizeof(t2_new));
+	ASN_STRUCT_RESET(asn_DEF_T2, &t2);
+	ASN_STRUCT_RESET(asn_DEF_T2, &t2_new);
 
 	t2.i = 332211;
 	t2.any = calloc(1, sizeof(*t2.any));
@@ -166,8 +167,10 @@ main() {
 	/*
 	 * Test the T2 sequence with primitive encoding.
 	 */
-	memset(&t2, 0, sizeof(t2));
-	memset(&t2_new, 0, sizeof(t2_new));
+	t2.any->buf = NULL;
+	t2.any->size = 0;
+	ASN_STRUCT_RESET(asn_DEF_T2, &t2);
+	ASN_STRUCT_RESET(asn_DEF_T2, &t2_new);
 
 	t2.i = 0;
 	t2.any = calloc(1, sizeof(*t2.any));
@@ -188,7 +191,7 @@ main() {
 	 */
 	free(t2.any);
 	t2.any = 0;
-	memset(&t2_new, 0, sizeof(t2_new));
+	ASN_STRUCT_RESET(asn_DEF_T2, &t2_new);
 
 	save_object(&t2, td2);
 	ret = load_object(&t2_new, td2);

--- a/tests/tests-c-compiler/check-src/check-60.c
+++ b/tests/tests-c-compiler/check-src/check-60.c
@@ -17,7 +17,9 @@ _buf_writer(const void *buffer, size_t size, void *app_key) {
 	unsigned char *b, *bend;
 	(void)app_key;
 	assert(buf_offset + size < sizeof(buf));
-	memcpy(buf + buf_offset, buffer, size);
+	if (buffer) {
+		memcpy(buf + buf_offset, buffer, size);
+	}
 	b = buf + buf_offset;
 	bend = b + size;
 	printf("=> [");

--- a/tests/tests-c-compiler/check-src/check-62.c
+++ b/tests/tests-c-compiler/check-src/check-62.c
@@ -33,7 +33,9 @@ _buf_writer(const void *buffer, size_t size, void *app_key) {
 	unsigned char *b, *bend;
 	(void)app_key;
 	assert(buf_offset + size < sizeof(buf));
-	memcpy(buf + buf_offset, buffer, size);
+	if (buffer) {
+		memcpy(buf + buf_offset, buffer, size);
+	}
 	b = buf + buf_offset;
 	bend = b + size;
 	printf("=> [");

--- a/tests/tests-c-compiler/check-src/check-65.c
+++ b/tests/tests-c-compiler/check-src/check-65.c
@@ -95,6 +95,7 @@ check_2(int is_ok, uint8_t *buf, size_t size, size_t consumed) {
 		}
 		assert(rval.consumed <= consumed);
 	}
+	ASN_STRUCT_RESET(*td, tp);
 }
 
 int

--- a/tests/tests-c-compiler/check-src/check-70.-fwide-types.c
+++ b/tests/tests-c-compiler/check-src/check-70.-fwide-types.c
@@ -190,6 +190,7 @@ process_XER_data(enum expectation expectation, unsigned char *fbuf, size_t size)
 
 	/* Save and re-load as DER */
 	save_object_as(st, ATS_DER);
+	ASN_STRUCT_FREE(asn_DEF_PDU, st);
 	st = load_object_from(expectation, buf, buf_offset, ATS_BER);
 	assert(st);
 

--- a/tests/tests-c-compiler/check-src/check-70.c
+++ b/tests/tests-c-compiler/check-src/check-70.c
@@ -184,6 +184,7 @@ process_XER_data(enum expectation expectation, unsigned char *fbuf, size_t size)
 
 	/* Save and re-load as DER */
 	save_object_as(st, ATS_DER);
+	ASN_STRUCT_FREE(asn_DEF_PDU, st);
 	st = load_object_from(expectation, buf, buf_offset, ATS_BER);
 	assert(st);
 

--- a/tests/tests-c-compiler/check-src/check64-134.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check64-134.-gen-PER.c
@@ -70,6 +70,7 @@ verify(int testNo, T_t *ti) {
 
 	xer_fprint(stderr, &asn_DEF_T, ti);
 	xer_fprint(stderr, &asn_DEF_T, to);
+	ASN_STRUCT_FREE(asn_DEF_T, to);
 }
 
 static void
@@ -95,36 +96,42 @@ int main() {
     l2i(&ti.signed33,    0);
     l2i(&ti.signed33ext, 0);
 	verify(1, &ti);
+	ASN_STRUCT_RESET(asn_DEF_T, &ti);
 
     ul2i(&ti.unsigned33,  1);
     ul2i(&ti.unsigned42,  1);
     l2i(&ti.signed33,    1);
     l2i(&ti.signed33ext, 1);
 	verify(2, &ti);
+	ASN_STRUCT_RESET(asn_DEF_T, &ti);
 
     ul2i(&ti.unsigned33,  5000000000);
     ul2i(&ti.unsigned42,  3153600000000);
     l2i(&ti.signed33,    4000000000);
     l2i(&ti.signed33ext, 4000000000);
 	verify(3, &ti);
+	ASN_STRUCT_RESET(asn_DEF_T, &ti);
 
     ul2i(&ti.unsigned33, -1);
     ul2i(&ti.unsigned42,  0);
     l2i(&ti.signed33,    0);
     l2i(&ti.signed33ext, 0);
 	NO_encode(4, &ti);
+	ASN_STRUCT_RESET(asn_DEF_T, &ti);
 
     ul2i(&ti.unsigned33,  0);
     ul2i(&ti.unsigned42, -1);
     l2i(&ti.signed33,    0);
     l2i(&ti.signed33ext, 0);
 	NO_encode(5, &ti);
+	ASN_STRUCT_RESET(asn_DEF_T, &ti);
 
     ul2i(&ti.unsigned33,  0);
     ul2i(&ti.unsigned42,  0);
     l2i(&ti.signed33,    -4000000000-1);
     l2i(&ti.signed33ext, 0);
 	NO_encode(6, &ti);
+	ASN_STRUCT_RESET(asn_DEF_T, &ti);
 
     ul2i(&ti.unsigned33,  0);
     ul2i(&ti.unsigned42,  0);
@@ -132,30 +139,35 @@ int main() {
     l2i(&ti.signed33ext, -4000000000-1);
     assert(ti.signed33ext.size == 5);
 	verify(7, &ti); /* signed33ext is extensible */
+	ASN_STRUCT_RESET(asn_DEF_T, &ti);
 
     ul2i(&ti.unsigned33,  5000000000 + 1);
     ul2i(&ti.unsigned42,  0);
     l2i(&ti.signed33,    0);
     l2i(&ti.signed33ext, 0);
 	NO_encode(8, &ti);
+	ASN_STRUCT_RESET(asn_DEF_T, &ti);
 
     ul2i(&ti.unsigned33,  0);
     ul2i(&ti.unsigned42,  3153600000000 + 1);
     l2i(&ti.signed33,    0);
     l2i(&ti.signed33ext, 0);
 	NO_encode(9, &ti);
+	ASN_STRUCT_RESET(asn_DEF_T, &ti);
 
     ul2i(&ti.unsigned33,  5000000000 - 1);
     ul2i(&ti.unsigned42,  3153600000000 - 1);
     l2i(&ti.signed33,    4000000000 - 1);
     l2i(&ti.signed33ext, 4000000000 - 1);
 	verify(10, &ti);
+	ASN_STRUCT_RESET(asn_DEF_T, &ti);
 
     ul2i(&ti.unsigned33,  0);
     ul2i(&ti.unsigned42,  0);
     l2i(&ti.signed33,    0);
     l2i(&ti.signed33ext, 4000000000 + 1);
 	verify(11, &ti);
+	ASN_STRUCT_RESET(asn_DEF_T, &ti);
 
 	return 0;
 }

--- a/tests/tests-c-compiler/check-src/check64-136.-gen-OER.c
+++ b/tests/tests-c-compiler/check-src/check64-136.-gen-OER.c
@@ -38,7 +38,8 @@ int main() {
     if(XEQ_SUCCESS != xer_equivalent(&asn_DEF_T, &source, decoded, stderr)) {
         return 1;
     }
-
+    ASN_STRUCT_RESET(asn_DEF_T, &source);
+    ASN_STRUCT_FREE(asn_DEF_T, decoded);
     return 0;
 }
 


### PR DESCRIPTION
- Include getopt.h instead of unistd.h
- Use unsigned max int type when converting integers