### PR TITLE
fix issue #220: implicit declaration of function ‘isatty’

### DIFF
--- a/skeletons/converter-example.c
+++ b/skeletons/converter-example.c
@@ -18,7 +18,7 @@
 #include <string.h>    /* for strerror(3) */
 #include <sysexits.h>    /* for EX_* exit codes */
 #include <errno.h>    /* for errno */
-
+#include <unistd.h>    /* for isatty(3) */
 #include <asn_application.h>
 #include <asn_internal.h>    /* for ASN__DEFAULT_STACK_MAX */
 


### PR DESCRIPTION
This addresses issue #220 

Fixes warning:
converter-example.c: In function ‘main’:
converter-example.c:400:8: warning: implicit declaration of function ‘isatty’ [-Wimplicit-function-declaration]
     if(isatty(1)) {
        ^