### PR TITLE
Fix s1ap code generation

### DIFF
--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -2625,8 +2625,10 @@ emit_member_type_selector(arg_t *arg, asn1p_expr_t *expr, asn1c_ioc_table_and_ob
     if(expr->meta_type != AMT_TYPEREF
        || expr->expr_type != A1TC_REFERENCE
        || expr->reference->comp_count != 2
-       || expr->reference->components[1].lex_type
-              != RLT_AmpUppercase) {
+       || ((expr->reference->components[1].lex_type
+              != RLT_AmpUppercase)
+            && (expr->reference->components[1].lex_type
+                   != RLT_Amplowercase))) {
         FATAL(
             "Does not look like %s is a CLASS field reference (%s) denoting a type on line "
             "%d",

--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -2662,10 +2662,10 @@ emit_member_type_selector(arg_t *arg, asn1p_expr_t *expr, asn1c_ioc_table_and_ob
         return -1;
     }
 
-
     REDIR(OT_CODE);
     OUT("static asn_type_selector_result_t\n");
-    OUT("select_%s_type(const asn_TYPE_descriptor_t *parent_type, const void *parent_sptr) {\n", c_name(arg).compound_name);
+    OUT("select_%s_", c_name(arg).compound_name);
+    OUT("%s_type(const asn_TYPE_descriptor_t *parent_type, const void *parent_sptr) {\n", MKID(expr));
     INDENT(+1);
 
     OUT("asn_type_selector_result_t result = {0, 0};\n");
@@ -2723,7 +2723,8 @@ emit_member_type_selector(arg_t *arg, asn1p_expr_t *expr, asn1c_ioc_table_and_ob
     OUT("\n");
 
     REDIR(save_target);
-    OUT("select_%s_type", c_name(arg).compound_name);
+    OUT("select_%s_", c_name(arg).compound_name);
+    OUT("%s_type", MKID(expr));
 
     return 0;
 }

--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -1070,6 +1070,8 @@ asn1c_lang_C_OpenType(arg_t *arg, asn1c_ioc_table_and_objset_t *opt_ioc,
         struct asn1p_ioc_cell_s *cell =
             &opt_ioc->ioct->row[row]->column[column_index];
 
+        if(!cell->value) continue;
+
         asn1p_expr_t *m = asn1p_expr_clone(cell->value, 0);
         asn1p_expr_add(open_type_choice, m);
     }

--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -2642,7 +2642,7 @@ emit_member_type_selector(arg_t *arg, asn1p_expr_t *expr, asn1c_ioc_table_and_ob
     const char *for_field = expr->reference->components[1].name;
 
     ssize_t for_column = -1;
-    for(size_t cn = 0; cn < opt_ioc->ioct->rows ? opt_ioc->ioct->row[0]->columns : 0;
+    for(size_t cn = 0; cn < (opt_ioc->ioct->rows ? opt_ioc->ioct->row[0]->columns : 0);
         cn++) {
         if(strcmp(for_field,
                   opt_ioc->ioct->row[0]->column[cn].field->Identifier)

--- a/libasn1compiler/asn1c_ioc.c
+++ b/libasn1compiler/asn1c_ioc.c
@@ -213,7 +213,9 @@ static int
 emit_ioc_cell(arg_t *arg, struct asn1p_ioc_cell_s *cell) {
     OUT("{ \"%s\", ", cell->field->Identifier);
 
-    if(cell->value->meta_type == AMT_VALUE) {
+    if(!cell->value) {
+        /* Ignore */
+    } else if(cell->value->meta_type == AMT_VALUE) {
         GEN_INCLUDE(asn1c_type_name(arg, cell->value, TNF_INCLUDE));
         OUT("aioc__value, ");
         OUT("&asn_DEF_%s, ", asn1c_type_name(arg, cell->value, TNF_SAFE));

--- a/libasn1compiler/asn1c_naming.c
+++ b/libasn1compiler/asn1c_naming.c
@@ -173,8 +173,11 @@ c_name_impl(arg_t *arg, asn1p_expr_t *expr, int avoid_keywords) {
     construct_base_name(&b_as_member, expr, 0, 1);
 
     static abuf tmp_compoundable_part_name;
+    static abuf compound_part_name;
     abuf_clear(&tmp_compoundable_part_name);
+    abuf_clear(&compound_part_name);
     construct_base_name(&tmp_compoundable_part_name, expr, compound_names, 0);
+    construct_base_name(&compound_part_name, expr, 1, 0);
 
     if(!expr->_anonymous_type) {
         if(arg->embed) {
@@ -204,6 +207,7 @@ c_name_impl(arg_t *arg, asn1p_expr_t *expr, int avoid_keywords) {
     names.presence_name = b_presence_name.buffer;
     names.members_enum = b_members_enum.buffer;
     names.members_name = b_members_name.buffer;
+    names.compound_name = compound_part_name.buffer;
 
     /* A _subset_ of names is checked against being globally unique */
     register_global_name(expr, names.base_name);

--- a/libasn1compiler/asn1c_naming.h
+++ b/libasn1compiler/asn1c_naming.h
@@ -23,6 +23,7 @@ struct c_names {
     const char *presence_name; /* "foo_PR" */
     const char *members_enum;  /* "enum foo" */
     const char *members_name;  /* "e_foo" */
+    const char *compound_name; /* always contain "parent_foo" */
 };
 
 struct c_names c_name(arg_t *);

--- a/libasn1compiler/asn1compiler.c
+++ b/libasn1compiler/asn1compiler.c
@@ -120,7 +120,8 @@ asn1c_compile_expr(arg_t *arg, const asn1c_ioc_table_and_objset_t *opt_ioc) {
 			DEBUG("Parameterized type %s at line %d: %s (%d)",
 				expr->Identifier, expr->_lineno,
 				expr->specializations.pspecs_count
-				? "compiling" : "unused, skipping");
+				? "compiling" : "unused, skipping",
+				expr->specializations.pspecs_count);
 			for(i = 0; i<expr->specializations.pspecs_count; i++) {
 				arg->expr = expr->specializations
 						.pspec[i].my_clone;

--- a/libasn1fix/asn1fix.c
+++ b/libasn1fix/asn1fix.c
@@ -263,6 +263,12 @@ asn1f_fix_module__phase_2(arg_t *arg) {
 		RET2RVAL(ret, rvalue);
 
 		/*
+		 * Resolve references in constraints (the second pass).
+		 */
+		ret = asn1f_recurse_expr(arg, asn1f_resolve_constraints);
+		RET2RVAL(ret, rvalue);
+
+		/*
 		 * Check semantic validity of constraints.
 		 */
 		ret = asn1f_recurse_expr(arg, asn1f_check_constraints);

--- a/libasn1fix/asn1fix_cws.c
+++ b/libasn1fix/asn1fix_cws.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+#include <stdlib.h>
 #include "asn1fix_internal.h"
 #include "asn1fix_cws.h"
 
@@ -195,6 +197,8 @@ _asn1f_foreach_unparsed(arg_t *arg, const asn1p_constraint_t *ct,
         return _asn1f_foreach_unparsed_union(ct, process, keyp);
     case ACT_CA_CSV:    /* , */
         break;
+    case ACT_EL_VALUE:
+        return 0;
     }
 
     for(size_t i = 0; i < ct->el_count; i++) {
@@ -407,7 +411,7 @@ _asn1f_assign_cell_value(arg_t *arg, struct asn1p_ioc_cell_s *cell,
 
 	/* This value 100 should be larger than following formatting string */
 	psize = bend - buf + 100;
-	pp = malloc(psize);
+	pp = calloc(1, psize);
 	if(pp == NULL) {
 		free(mivr);
 		return -1;

--- a/libasn1fix/asn1fix_param.c
+++ b/libasn1fix/asn1fix_param.c
@@ -112,7 +112,7 @@ resolve_expr(asn1p_expr_t *expr_to_resolve, void *resolver_arg) {
 				expr_to_resolve->reference);
 		if(!expr) return NULL;
 	} else if(expr_to_resolve->meta_type == AMT_VALUE) {
-		assert(expr_to_resolve->value);
+		if(!expr_to_resolve->value) return NULL;
 		expr = find_target_specialization_bystr(rarg,
 				expr_to_resolve->Identifier);
 		if(!expr) return NULL;
@@ -155,7 +155,7 @@ static asn1p_expr_t *
 find_target_specialization_byvalueset(resolver_arg_t *rarg, asn1p_constraint_t *ct) {
 	asn1p_ref_t *ref;
 
-	assert(ct->type == ACT_EL_TYPE);
+	if (ct->type != ACT_EL_TYPE) return NULL;
 
 	ref = ct->containedSubtype->value.v_type->reference;
 

--- a/libasn1parser/asn1p_class.c
+++ b/libasn1parser/asn1p_class.c
@@ -26,6 +26,16 @@ asn1p_ioc_table_add(asn1p_ioc_table_t *it, asn1p_ioc_row_t *row) {
 }
 
 void
+asn1p_ioc_table_append(asn1p_ioc_table_t *it, asn1p_ioc_table_t *src) {
+
+    if(!src) return;
+
+    for(size_t i = 0; i < src->rows; i++) {
+        asn1p_ioc_table_add(it, asn1p_ioc_row_clone(src->row[i]));
+    }
+}
+
+void
 asn1p_ioc_table_free(asn1p_ioc_table_t *it) {
     if(it) {
         for(size_t i = 0; i < it->rows; i++) {
@@ -88,6 +98,29 @@ asn1p_ioc_row_new(asn1p_expr_t *oclass) {
 		row->column[columns].field = field;
 		row->column[columns].value = NULL;
 		columns++;
+	}
+
+	return row;
+}
+
+asn1p_ioc_row_t *
+asn1p_ioc_row_clone(asn1p_ioc_row_t *src) {
+	asn1p_ioc_row_t *row;
+
+	row = calloc(1, sizeof *row);
+	if(!row) return NULL;
+
+	row->column = calloc(src->columns, sizeof *src->column);
+	if(!row->column) {
+		free(row);
+		return NULL;
+	}
+	row->columns = src->columns;
+
+	for(size_t i = 0; i < src->columns; i++) {
+		row->column[i].field = src->column[i].field;
+		row->column[i].value = src->column[i].value ? asn1p_expr_clone(src->column[i].value, 0) : 0;
+		row->column[i].new_ref = 1;
 	}
 
 	return row;

--- a/libasn1parser/asn1p_class.h
+++ b/libasn1parser/asn1p_class.h
@@ -16,6 +16,7 @@ typedef struct asn1p_ioc_row_s {
 } asn1p_ioc_row_t;
 
 asn1p_ioc_row_t *asn1p_ioc_row_new(struct asn1p_expr_s *oclass);
+asn1p_ioc_row_t *asn1p_ioc_row_clone(asn1p_ioc_row_t *src);
 size_t asn1p_ioc_row_max_identifier_length(asn1p_ioc_row_t *);
 void asn1p_ioc_row_delete(asn1p_ioc_row_t *);
 
@@ -27,6 +28,7 @@ typedef struct asn1p_ioc_table_s {
 
 asn1p_ioc_table_t *asn1p_ioc_table_new(void);
 void asn1p_ioc_table_add(asn1p_ioc_table_t *, asn1p_ioc_row_t *row);
+void asn1p_ioc_table_append(asn1p_ioc_table_t *it, asn1p_ioc_table_t *src);
 size_t asn1p_ioc_table_max_identifier_length(asn1p_ioc_table_t *);
 void asn1p_ioc_table_free(asn1p_ioc_table_t *);
 

--- a/libasn1parser/asn1p_expr.c
+++ b/libasn1parser/asn1p_expr.c
@@ -30,6 +30,10 @@ asn1p_expr_set_source(asn1p_expr_t *expr, asn1p_module_t *module, int lineno) {
 
 int
 asn1p_expr_compare(const asn1p_expr_t *a, const asn1p_expr_t *b) {
+    if((a && !b) || (!a && b)) {
+        return -1;
+    }
+
     if(a->meta_type != b->meta_type || a->expr_type != b->expr_type) {
         return -1;
     }
@@ -185,6 +189,8 @@ asn1p_expr_clone_impl(asn1p_expr_t *expr, int skip_extensions, asn1p_expr_t *(*r
 	CLCOPY(tag);
 	CLCOPY(marker.flags);		/* OPTIONAL/DEFAULT */
 	CLCOPY(_mark);
+	CLCOPY(parent_expr);
+	CLCOPY(_type_unique_index);
 
 	clone->data = 0;	/* Do not clone this */
 	clone->data_free = 0;	/* Do not clone this */
@@ -303,6 +309,23 @@ asn1p_expr_add_many(asn1p_expr_t *to, asn1p_expr_t *from_what) {
 	TQ_CONCAT(&(to->members), &(from_what->members), next);
 }
 
+/*
+ * Lookup a child by its name.
+ */
+asn1p_expr_t *
+asn1p_lookup_child(asn1p_expr_t *tc, const char *name) {
+	asn1p_expr_t *child_tc;
+
+	TQ_FOR(child_tc, &(tc->members), next) {
+		if(child_tc->Identifier
+		&& strcmp(child_tc->Identifier, name) == 0) {
+			return child_tc;
+		}
+	}
+
+	errno = ESRCH;
+	return NULL;
+}
 
 /*
  * Destruct the types collection structure.

--- a/libasn1parser/asn1p_expr.h
+++ b/libasn1parser/asn1p_expr.h
@@ -251,7 +251,9 @@ typedef struct asn1p_expr_s {
 	  TM_BROKEN	= (1<<1), /* A warning was already issued */
 	  TM_PERFROMCT	= (1<<2), /* PER FROM() constraint tables emitted */
 	  TM_NAMECLASH	= (1<<3),  /* Name clash found, need to add module name to resolve */
-	  TM_NAMEGIVEN  = (1<<4)  /* The expression has already yielded a name */
+	  TM_NAMEGIVEN  = (1<<4),  /* The expression has already yielded a name */
+	  TM_SKIPinUNION  = (1<<5) /* Do not include this identifier in union again due to name duplication,
+                                      especially for OPENTYPE. */
 	} _mark;
 
 	/*
@@ -280,6 +282,7 @@ asn1p_expr_t *asn1p_expr_clone_with_resolver(asn1p_expr_t *,
 	void *resolver_arg);
 void asn1p_expr_add(asn1p_expr_t *to, asn1p_expr_t *what);
 void asn1p_expr_add_many(asn1p_expr_t *to, asn1p_expr_t *from_what);
+asn1p_expr_t *asn1p_lookup_child(asn1p_expr_t *tc, const char *name);
 int asn1p_expr_compare(const asn1p_expr_t *, const asn1p_expr_t *);
 void asn1p_expr_free(asn1p_expr_t *expr);
 void asn1p_expr_set_source(asn1p_expr_t *, asn1p_module_t *, int lineno);

--- a/tests/tests-asn1c-compiler/139-component-relation-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/139-component-relation-OK.asn1.-P
@@ -24,7 +24,7 @@ typedef struct Frame {
 	long	 ident;
 	struct value {
 		value_PR present;
-		union value_u {
+		union Frame__value_u {
 			PrimitiveMessage_t	 PrimitiveMessage;
 			ComplexMessage_t	 ComplexMessage;
 		} choice;
@@ -81,7 +81,7 @@ memb_ident_constraint_1(const asn_TYPE_descriptor_t *td, const void *sptr,
 }
 
 static asn_type_selector_result_t
-select_value_type(const asn_TYPE_descriptor_t *parent_type, const void *parent_sptr) {
+select_Frame_value_type(const asn_TYPE_descriptor_t *parent_type, const void *parent_sptr) {
 	asn_type_selector_result_t result = {0, 0};
 	const asn_ioc_set_t *itable = asn_IOS_FrameTypes_1;
 	size_t constraining_column = 0; /* &id */
@@ -188,7 +188,7 @@ static asn_TYPE_member_t asn_MBR_Frame_1[] = {
 		.tag = -1 /* Ambiguous tag (ANY?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_value_3,
-		.type_selector = select_value_type,
+		.type_selector = select_Frame_value_type,
 		{ .oer_constraints = 0, .per_constraints = 0, .general_constraints =  memb_value_constraint_1 },
 		0, 0, /* No default value */
 		.name = "value"

--- a/tests/tests-asn1c-compiler/140-component-relation-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/140-component-relation-OK.asn1.-P
@@ -24,7 +24,7 @@ typedef struct Frame {
 	long	 ident;
 	struct value {
 		value_PR present;
-		union value_u {
+		union Frame__value_u {
 			PrimitiveMessage_t	 PrimitiveMessage;
 			ComplexMessage_t	 ComplexMessage;
 		} choice;
@@ -81,7 +81,7 @@ memb_ident_constraint_1(const asn_TYPE_descriptor_t *td, const void *sptr,
 }
 
 static asn_type_selector_result_t
-select_value_type(const asn_TYPE_descriptor_t *parent_type, const void *parent_sptr) {
+select_Frame_value_type(const asn_TYPE_descriptor_t *parent_type, const void *parent_sptr) {
 	asn_type_selector_result_t result = {0, 0};
 	const asn_ioc_set_t *itable = asn_IOS_FrameTypes_1;
 	size_t constraining_column = 0; /* &id */
@@ -188,7 +188,7 @@ static asn_TYPE_member_t asn_MBR_Frame_1[] = {
 		.tag = -1 /* Ambiguous tag (ANY?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_value_3,
-		.type_selector = select_value_type,
+		.type_selector = select_Frame_value_type,
 		{ .oer_constraints = 0, .per_constraints = 0, .general_constraints =  memb_value_constraint_1 },
 		0, 0, /* No default value */
 		.name = "value"

--- a/tests/tests-asn1c-compiler/141-component-relation-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/141-component-relation-OK.asn1.-P
@@ -24,7 +24,7 @@ typedef struct Frame {
 	ConstrainedInteger_t	 ident;
 	struct value {
 		value_PR present;
-		union value_u {
+		union Frame__value_u {
 			PrimitiveMessage_t	 PrimitiveMessage;
 			ComplexMessage_t	 ComplexMessage;
 		} choice;
@@ -87,7 +87,7 @@ memb_ident_constraint_1(const asn_TYPE_descriptor_t *td, const void *sptr,
 }
 
 static asn_type_selector_result_t
-select_value_type(const asn_TYPE_descriptor_t *parent_type, const void *parent_sptr) {
+select_Frame_value_type(const asn_TYPE_descriptor_t *parent_type, const void *parent_sptr) {
 	asn_type_selector_result_t result = {0, 0};
 	const asn_ioc_set_t *itable = asn_IOS_FrameTypes_1;
 	size_t constraining_column = 0; /* &id */
@@ -194,7 +194,7 @@ static asn_TYPE_member_t asn_MBR_Frame_1[] = {
 		.tag = (ASN_TAG_CLASS_CONTEXT | (1 << 2)),
 		.tag_mode = +1,	/* EXPLICIT tag at current level */
 		.type = &asn_DEF_value_3,
-		.type_selector = select_value_type,
+		.type_selector = select_Frame_value_type,
 		{ .oer_constraints = 0, .per_constraints = 0, .general_constraints =  memb_value_constraint_1 },
 		0, 0, /* No default value */
 		.name = "value"

--- a/tests/tests-asn1c-compiler/144-ios-parameterization-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/144-ios-parameterization-OK.asn1.-P
@@ -86,7 +86,7 @@ typedef struct SpecializedContent_30P0 {
 	long	 id;
 	struct value {
 		value_PR present;
-		union value_u {
+		union SpecializedContent_30P0__value_u {
 			long	 INTEGER;
 			BOOLEAN_t	 BOOLEAN;
 		} choice;
@@ -141,7 +141,7 @@ memb_id_constraint_1(const asn_TYPE_descriptor_t *td, const void *sptr,
 }
 
 static asn_type_selector_result_t
-select_value_type(const asn_TYPE_descriptor_t *parent_type, const void *parent_sptr) {
+select_SpecializedContent_30P0_value_type(const asn_TYPE_descriptor_t *parent_type, const void *parent_sptr) {
 	asn_type_selector_result_t result = {0, 0};
 	const asn_ioc_set_t *itable = asn_IOS_RegionalExtension_1;
 	size_t constraining_column = 0; /* &id */
@@ -248,7 +248,7 @@ asn_TYPE_member_t asn_MBR_SpecializedContent_30P0_1[] = {
 		.tag = -1 /* Ambiguous tag (ANY?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_value_3,
-		.type_selector = select_value_type,
+		.type_selector = select_SpecializedContent_30P0_value_type,
 		{ .oer_constraints = 0, .per_constraints = 0, .general_constraints =  memb_value_constraint_1 },
 		0, 0, /* No default value */
 		.name = "value"

--- a/tests/tests-asn1c-compiler/146-ios-parameterization-per-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/146-ios-parameterization-per-OK.asn1.-Pgen-PER
@@ -86,7 +86,7 @@ typedef struct SpecializedContent_30P0 {
 	long	 id;
 	struct value {
 		value_PR present;
-		union value_u {
+		union SpecializedContent_30P0__value_u {
 			long	 INTEGER;
 			BOOLEAN_t	 BOOLEAN;
 		} choice;
@@ -141,7 +141,7 @@ memb_id_constraint_1(const asn_TYPE_descriptor_t *td, const void *sptr,
 }
 
 static asn_type_selector_result_t
-select_value_type(const asn_TYPE_descriptor_t *parent_type, const void *parent_sptr) {
+select_SpecializedContent_30P0_value_type(const asn_TYPE_descriptor_t *parent_type, const void *parent_sptr) {
 	asn_type_selector_result_t result = {0, 0};
 	const asn_ioc_set_t *itable = asn_IOS_RegionalExtension_1;
 	size_t constraining_column = 0; /* &id */
@@ -264,7 +264,7 @@ asn_TYPE_member_t asn_MBR_SpecializedContent_30P0_1[] = {
 		.tag = -1 /* Ambiguous tag (ANY?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_value_3,
-		.type_selector = select_value_type,
+		.type_selector = select_SpecializedContent_30P0_value_type,
 		{ .oer_constraints = 0, .per_constraints = &asn_PER_memb_value_constr_3, .general_constraints =  memb_value_constraint_1 },
 		0, 0, /* No default value */
 		.name = "value"

--- a/tests/tests-asn1c-compiler/155-parameterization-more-than-two-level-OK.asn1
+++ b/tests/tests-asn1c-compiler/155-parameterization-more-than-two-level-OK.asn1
@@ -1,0 +1,58 @@
+
+-- OK: Everything is fine
+
+-- iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+-- .spelio.software.asn1c.test (9363.1.5.1)
+-- .155
+
+ModuleParameterizationMoreThanTwoLevel
+	{ iso org(3) dod(6) internet(1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 155 }
+DEFINITIONS ::= BEGIN
+
+    id-TYPE1 PacketId ::= 1
+
+    PacketId ::= INTEGER (0..65535)
+
+    Color ::= ENUMERATED { red(0), green, blue }
+
+    Valid ::= ENUMERATED { crc-nok, crc-ok(1) }
+
+    PACKET ::= CLASS {
+	&id             PacketId     UNIQUE,
+	&color          Color,
+	&Value,
+	&valid          Valid
+    }
+    WITH SYNTAX {
+        ID              &id
+        COLOR           &color
+        TYPE            &Value
+        VALID           &valid
+    }
+
+    ClassItem PACKET ::= {
+        { ID id-TYPE1   COLOR blue   TYPE OCTET STRING VALID crc-ok },
+        ...
+    }
+
+    Packet-List ::= UpperLayer-List { {ClassItem} }
+
+    UpperLayer-List {PACKET : Param} ::= LowerLayer-List { 1, max-items, {Param} }
+
+    LowerLayer-List {INTEGER : low, INTEGER : high, PACKET : Param} ::=
+        SEQUENCE (SIZE (low..high)) OF
+        SinglePacket {{Param}}
+
+    SinglePacket {PACKET : Param} ::=
+        Packet {{Param}}
+
+    Packet {PACKET : Param} ::= SEQUENCE {
+        id      PACKET.&id     ({Param}),
+        color   PACKET.&color  ({Param}{@id}),
+        value   PACKET.&Value  ({Param}{@id})
+    }
+
+    max-items INTEGER ::= 256
+
+END

--- a/tests/tests-asn1c-compiler/155-parameterization-more-than-two-level-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/155-parameterization-more-than-two-level-OK.asn1.-Pgen-PER
@@ -1,0 +1,768 @@
+
+/*** <<< INCLUDES [PacketId] >>> ***/
+
+#include <NativeInteger.h>
+
+/*** <<< TYPE-DECLS [PacketId] >>> ***/
+
+typedef long	 PacketId_t;
+
+/*** <<< FUNC-DECLS [PacketId] >>> ***/
+
+extern asn_per_constraints_t asn_PER_type_PacketId_constr_1;
+extern asn_TYPE_descriptor_t asn_DEF_PacketId;
+asn_struct_free_f PacketId_free;
+asn_struct_print_f PacketId_print;
+asn_constr_check_f PacketId_constraint;
+ber_type_decoder_f PacketId_decode_ber;
+der_type_encoder_f PacketId_encode_der;
+xer_type_decoder_f PacketId_decode_xer;
+xer_type_encoder_f PacketId_encode_xer;
+per_type_decoder_f PacketId_decode_uper;
+per_type_encoder_f PacketId_encode_uper;
+
+/*** <<< CODE [PacketId] >>> ***/
+
+int
+PacketId_constraint(const asn_TYPE_descriptor_t *td, const void *sptr,
+			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
+	long value;
+	
+	if(!sptr) {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: value not given (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+	
+	value = *(const long *)sptr;
+	
+	if((value >= 0 && value <= 65535)) {
+		/* Constraint check succeeded */
+		return 0;
+	} else {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: constraint failed (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+}
+
+/*
+ * This type is implemented using NativeInteger,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< CTDEFS [PacketId] >>> ***/
+
+asn_per_constraints_t asn_PER_type_PacketId_constr_1 CC_NOTUSED = {
+	{ APC_CONSTRAINED,	 16,  16,  0,  65535 }	/* (0..65535) */,
+	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
+	0, 0	/* No PER value map */
+};
+
+/*** <<< STAT-DEFS [PacketId] >>> ***/
+
+static const ber_tlv_tag_t asn_DEF_PacketId_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (2 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_PacketId = {
+	"PacketId",
+	"PacketId",
+	&asn_OP_NativeInteger,
+	asn_DEF_PacketId_tags_1,
+	sizeof(asn_DEF_PacketId_tags_1)
+		/sizeof(asn_DEF_PacketId_tags_1[0]), /* 1 */
+	asn_DEF_PacketId_tags_1,	/* Same as above */
+	sizeof(asn_DEF_PacketId_tags_1)
+		/sizeof(asn_DEF_PacketId_tags_1[0]), /* 1 */
+	{ 0, &asn_PER_type_PacketId_constr_1, PacketId_constraint },
+	0, 0,	/* No members */
+	0	/* No specifics */
+};
+
+
+/*** <<< INCLUDES [Color] >>> ***/
+
+#include <NativeEnumerated.h>
+
+/*** <<< DEPS [Color] >>> ***/
+
+typedef enum Color {
+	Color_red	= 0,
+	Color_green	= 1,
+	Color_blue	= 2
+} e_Color;
+
+/*** <<< TYPE-DECLS [Color] >>> ***/
+
+typedef long	 Color_t;
+
+/*** <<< FUNC-DECLS [Color] >>> ***/
+
+extern asn_per_constraints_t asn_PER_type_Color_constr_1;
+extern asn_TYPE_descriptor_t asn_DEF_Color;
+extern const asn_INTEGER_specifics_t asn_SPC_Color_specs_1;
+asn_struct_free_f Color_free;
+asn_struct_print_f Color_print;
+asn_constr_check_f Color_constraint;
+ber_type_decoder_f Color_decode_ber;
+der_type_encoder_f Color_encode_der;
+xer_type_decoder_f Color_decode_xer;
+xer_type_encoder_f Color_encode_xer;
+per_type_decoder_f Color_decode_uper;
+per_type_encoder_f Color_encode_uper;
+
+/*** <<< CODE [Color] >>> ***/
+
+/*
+ * This type is implemented using NativeEnumerated,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< CTDEFS [Color] >>> ***/
+
+asn_per_constraints_t asn_PER_type_Color_constr_1 CC_NOTUSED = {
+	{ APC_CONSTRAINED,	 2,  2,  0,  2 }	/* (0..2) */,
+	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
+	0, 0	/* No PER value map */
+};
+
+/*** <<< STAT-DEFS [Color] >>> ***/
+
+static const asn_INTEGER_enum_map_t asn_MAP_Color_value2enum_1[] = {
+	{ 0,	3,	"red" },
+	{ 1,	5,	"green" },
+	{ 2,	4,	"blue" }
+};
+static const unsigned int asn_MAP_Color_enum2value_1[] = {
+	2,	/* blue(2) */
+	1,	/* green(1) */
+	0	/* red(0) */
+};
+const asn_INTEGER_specifics_t asn_SPC_Color_specs_1 = {
+	asn_MAP_Color_value2enum_1,	/* "tag" => N; sorted by tag */
+	asn_MAP_Color_enum2value_1,	/* N => "tag"; sorted by N */
+	3,	/* Number of elements in the maps */
+	0,	/* Enumeration is not extensible */
+	1,	/* Strict enumeration */
+	0,	/* Native long size */
+	0
+};
+static const ber_tlv_tag_t asn_DEF_Color_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (10 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_Color = {
+	"Color",
+	"Color",
+	&asn_OP_NativeEnumerated,
+	asn_DEF_Color_tags_1,
+	sizeof(asn_DEF_Color_tags_1)
+		/sizeof(asn_DEF_Color_tags_1[0]), /* 1 */
+	asn_DEF_Color_tags_1,	/* Same as above */
+	sizeof(asn_DEF_Color_tags_1)
+		/sizeof(asn_DEF_Color_tags_1[0]), /* 1 */
+	{ 0, &asn_PER_type_Color_constr_1, NativeEnumerated_constraint },
+	0, 0,	/* Defined elsewhere */
+	&asn_SPC_Color_specs_1	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [Valid] >>> ***/
+
+#include <NativeEnumerated.h>
+
+/*** <<< DEPS [Valid] >>> ***/
+
+typedef enum Valid {
+	Valid_crc_nok	= 0,
+	Valid_crc_ok	= 1
+} e_Valid;
+
+/*** <<< TYPE-DECLS [Valid] >>> ***/
+
+typedef long	 Valid_t;
+
+/*** <<< FUNC-DECLS [Valid] >>> ***/
+
+extern asn_per_constraints_t asn_PER_type_Valid_constr_1;
+extern asn_TYPE_descriptor_t asn_DEF_Valid;
+extern const asn_INTEGER_specifics_t asn_SPC_Valid_specs_1;
+asn_struct_free_f Valid_free;
+asn_struct_print_f Valid_print;
+asn_constr_check_f Valid_constraint;
+ber_type_decoder_f Valid_decode_ber;
+der_type_encoder_f Valid_encode_der;
+xer_type_decoder_f Valid_decode_xer;
+xer_type_encoder_f Valid_encode_xer;
+per_type_decoder_f Valid_decode_uper;
+per_type_encoder_f Valid_encode_uper;
+
+/*** <<< CODE [Valid] >>> ***/
+
+/*
+ * This type is implemented using NativeEnumerated,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< CTDEFS [Valid] >>> ***/
+
+asn_per_constraints_t asn_PER_type_Valid_constr_1 CC_NOTUSED = {
+	{ APC_CONSTRAINED,	 1,  1,  0,  1 }	/* (0..1) */,
+	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
+	0, 0	/* No PER value map */
+};
+
+/*** <<< STAT-DEFS [Valid] >>> ***/
+
+static const asn_INTEGER_enum_map_t asn_MAP_Valid_value2enum_1[] = {
+	{ 0,	7,	"crc-nok" },
+	{ 1,	6,	"crc-ok" }
+};
+static const unsigned int asn_MAP_Valid_enum2value_1[] = {
+	0,	/* crc-nok(0) */
+	1	/* crc-ok(1) */
+};
+const asn_INTEGER_specifics_t asn_SPC_Valid_specs_1 = {
+	asn_MAP_Valid_value2enum_1,	/* "tag" => N; sorted by tag */
+	asn_MAP_Valid_enum2value_1,	/* N => "tag"; sorted by N */
+	2,	/* Number of elements in the maps */
+	0,	/* Enumeration is not extensible */
+	1,	/* Strict enumeration */
+	0,	/* Native long size */
+	0
+};
+static const ber_tlv_tag_t asn_DEF_Valid_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (10 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_Valid = {
+	"Valid",
+	"Valid",
+	&asn_OP_NativeEnumerated,
+	asn_DEF_Valid_tags_1,
+	sizeof(asn_DEF_Valid_tags_1)
+		/sizeof(asn_DEF_Valid_tags_1[0]), /* 1 */
+	asn_DEF_Valid_tags_1,	/* Same as above */
+	sizeof(asn_DEF_Valid_tags_1)
+		/sizeof(asn_DEF_Valid_tags_1[0]), /* 1 */
+	{ 0, &asn_PER_type_Valid_constr_1, NativeEnumerated_constraint },
+	0, 0,	/* Defined elsewhere */
+	&asn_SPC_Valid_specs_1	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [Packet-List] >>> ***/
+
+#include "UpperLayer-List.h"
+
+/*** <<< TYPE-DECLS [Packet-List] >>> ***/
+
+typedef UpperLayer_List_41P0_t	 Packet_List_t;
+
+/*** <<< FUNC-DECLS [Packet-List] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_Packet_List;
+asn_struct_free_f Packet_List_free;
+asn_struct_print_f Packet_List_print;
+asn_constr_check_f Packet_List_constraint;
+ber_type_decoder_f Packet_List_decode_ber;
+der_type_encoder_f Packet_List_encode_der;
+xer_type_decoder_f Packet_List_decode_xer;
+xer_type_encoder_f Packet_List_encode_xer;
+per_type_decoder_f Packet_List_decode_uper;
+per_type_encoder_f Packet_List_encode_uper;
+
+/*** <<< CODE [Packet-List] >>> ***/
+
+int
+Packet_List_constraint(const asn_TYPE_descriptor_t *td, const void *sptr,
+			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
+	size_t size;
+	
+	if(!sptr) {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: value not given (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+	
+	/* Determine the number of elements */
+	size = _A_CSEQUENCE_FROM_VOID(sptr)->count;
+	
+	if((size >= 1 && size <= 256)) {
+		/* Perform validation of the inner elements */
+		return td->encoding_constraints.general_constraints(td, sptr, ctfailcb, app_key);
+	} else {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: constraint failed (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+}
+
+/*
+ * This type is implemented using UpperLayer_List_41P0,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< CTDEFS [Packet-List] >>> ***/
+
+static asn_per_constraints_t asn_PER_type_Packet_List_constr_1 CC_NOTUSED = {
+	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
+	{ APC_CONSTRAINED,	 8,  8,  1,  256 }	/* (SIZE(1..256)) */,
+	0, 0	/* No PER value map */
+};
+
+/*** <<< STAT-DEFS [Packet-List] >>> ***/
+
+static const ber_tlv_tag_t asn_DEF_Packet_List_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_Packet_List = {
+	"Packet-List",
+	"Packet-List",
+	&asn_OP_SEQUENCE_OF,
+	asn_DEF_Packet_List_tags_1,
+	sizeof(asn_DEF_Packet_List_tags_1)
+		/sizeof(asn_DEF_Packet_List_tags_1[0]), /* 1 */
+	asn_DEF_Packet_List_tags_1,	/* Same as above */
+	sizeof(asn_DEF_Packet_List_tags_1)
+		/sizeof(asn_DEF_Packet_List_tags_1[0]), /* 1 */
+	{ 0, &asn_PER_type_Packet_List_constr_1, Packet_List_constraint },
+	asn_MBR_LowerLayer_List_45P0_1,
+	1,	/* Single element */
+	&asn_SPC_LowerLayer_List_45P0_specs_1	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [UpperLayer-List] >>> ***/
+
+#include "LowerLayer-List.h"
+
+/*** <<< TYPE-DECLS [UpperLayer-List] >>> ***/
+
+typedef LowerLayer_List_45P0_t	 UpperLayer_List_41P0_t;
+
+/*** <<< FUNC-DECLS [UpperLayer-List] >>> ***/
+
+extern asn_per_constraints_t asn_PER_type_UpperLayer_List_41P0_constr_1;
+extern asn_TYPE_descriptor_t asn_DEF_UpperLayer_List_41P0;
+asn_struct_free_f UpperLayer_List_41P0_free;
+asn_struct_print_f UpperLayer_List_41P0_print;
+asn_constr_check_f UpperLayer_List_41P0_constraint;
+ber_type_decoder_f UpperLayer_List_41P0_decode_ber;
+der_type_encoder_f UpperLayer_List_41P0_encode_der;
+xer_type_decoder_f UpperLayer_List_41P0_decode_xer;
+xer_type_encoder_f UpperLayer_List_41P0_encode_xer;
+per_type_decoder_f UpperLayer_List_41P0_decode_uper;
+per_type_encoder_f UpperLayer_List_41P0_encode_uper;
+
+/*** <<< CODE [UpperLayer-List] >>> ***/
+
+int
+UpperLayer_List_41P0_constraint(const asn_TYPE_descriptor_t *td, const void *sptr,
+			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
+	size_t size;
+	
+	if(!sptr) {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: value not given (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+	
+	/* Determine the number of elements */
+	size = _A_CSEQUENCE_FROM_VOID(sptr)->count;
+	
+	if((size >= 1 && size <= 256)) {
+		/* Perform validation of the inner elements */
+		return td->encoding_constraints.general_constraints(td, sptr, ctfailcb, app_key);
+	} else {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: constraint failed (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+}
+
+/*
+ * This type is implemented using LowerLayer_List_45P0,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< CTDEFS [UpperLayer-List] >>> ***/
+
+asn_per_constraints_t asn_PER_type_UpperLayer_List_41P0_constr_1 CC_NOTUSED = {
+	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
+	{ APC_CONSTRAINED,	 8,  8,  1,  256 }	/* (SIZE(1..256)) */,
+	0, 0	/* No PER value map */
+};
+
+/*** <<< STAT-DEFS [UpperLayer-List] >>> ***/
+
+static const ber_tlv_tag_t asn_DEF_UpperLayer_List_41P0_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_UpperLayer_List_41P0 = {
+	"UpperLayer-List",
+	"UpperLayer-List",
+	&asn_OP_SEQUENCE_OF,
+	asn_DEF_UpperLayer_List_41P0_tags_1,
+	sizeof(asn_DEF_UpperLayer_List_41P0_tags_1)
+		/sizeof(asn_DEF_UpperLayer_List_41P0_tags_1[0]), /* 1 */
+	asn_DEF_UpperLayer_List_41P0_tags_1,	/* Same as above */
+	sizeof(asn_DEF_UpperLayer_List_41P0_tags_1)
+		/sizeof(asn_DEF_UpperLayer_List_41P0_tags_1[0]), /* 1 */
+	{ 0, &asn_PER_type_UpperLayer_List_41P0_constr_1, UpperLayer_List_41P0_constraint },
+	asn_MBR_LowerLayer_List_45P0_1,
+	1,	/* Single element */
+	&asn_SPC_LowerLayer_List_45P0_specs_1	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [LowerLayer-List] >>> ***/
+
+#include <asn_SEQUENCE_OF.h>
+#include <constr_SEQUENCE_OF.h>
+
+/*** <<< FWD-DECLS [LowerLayer-List] >>> ***/
+
+struct SinglePacket;
+
+/*** <<< TYPE-DECLS [LowerLayer-List] >>> ***/
+
+typedef struct LowerLayer_List_45P0 {
+	A_SEQUENCE_OF(struct SinglePacket) list;
+	
+	/* Context for parsing across buffer boundaries */
+	asn_struct_ctx_t _asn_ctx;
+} LowerLayer_List_45P0_t;
+
+/*** <<< FUNC-DECLS [LowerLayer-List] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_LowerLayer_List_45P0;
+extern asn_SET_OF_specifics_t asn_SPC_LowerLayer_List_45P0_specs_1;
+extern asn_TYPE_member_t asn_MBR_LowerLayer_List_45P0_1[1];
+extern asn_per_constraints_t asn_PER_type_LowerLayer_List_45P0_constr_1;
+
+/*** <<< POST-INCLUDE [LowerLayer-List] >>> ***/
+
+#include "SinglePacket.h"
+
+/*** <<< CTDEFS [LowerLayer-List] >>> ***/
+
+asn_per_constraints_t asn_PER_type_LowerLayer_List_45P0_constr_1 CC_NOTUSED = {
+	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
+	{ APC_CONSTRAINED,	 8,  8,  1,  256 }	/* (SIZE(1..256)) */,
+	0, 0	/* No PER value map */
+};
+
+/*** <<< STAT-DEFS [LowerLayer-List] >>> ***/
+
+asn_TYPE_member_t asn_MBR_LowerLayer_List_45P0_1[] = {
+	{ ATF_POINTER, 0, 0,
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_SinglePacket_48P0,
+		.type_selector = 0,
+		{ .oer_constraints = 0, .per_constraints = 0, .general_constraints = 0 },
+		0, 0, /* No default value */
+		.name = ""
+		},
+};
+static const ber_tlv_tag_t asn_DEF_LowerLayer_List_45P0_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+asn_SET_OF_specifics_t asn_SPC_LowerLayer_List_45P0_specs_1 = {
+	sizeof(struct LowerLayer_List_45P0),
+	offsetof(struct LowerLayer_List_45P0, _asn_ctx),
+	0,	/* XER encoding is XMLDelimitedItemList */
+};
+asn_TYPE_descriptor_t asn_DEF_LowerLayer_List_45P0 = {
+	"LowerLayer-List",
+	"LowerLayer-List",
+	&asn_OP_SEQUENCE_OF,
+	asn_DEF_LowerLayer_List_45P0_tags_1,
+	sizeof(asn_DEF_LowerLayer_List_45P0_tags_1)
+		/sizeof(asn_DEF_LowerLayer_List_45P0_tags_1[0]), /* 1 */
+	asn_DEF_LowerLayer_List_45P0_tags_1,	/* Same as above */
+	sizeof(asn_DEF_LowerLayer_List_45P0_tags_1)
+		/sizeof(asn_DEF_LowerLayer_List_45P0_tags_1[0]), /* 1 */
+	{ 0, &asn_PER_type_LowerLayer_List_45P0_constr_1, SEQUENCE_OF_constraint },
+	asn_MBR_LowerLayer_List_45P0_1,
+	1,	/* Single element */
+	&asn_SPC_LowerLayer_List_45P0_specs_1	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [SinglePacket] >>> ***/
+
+#include "Packet.h"
+
+/*** <<< TYPE-DECLS [SinglePacket] >>> ***/
+
+typedef Packet_51P0_t	 SinglePacket_48P0_t;
+
+/*** <<< FUNC-DECLS [SinglePacket] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_SinglePacket_48P0;
+asn_struct_free_f SinglePacket_48P0_free;
+asn_struct_print_f SinglePacket_48P0_print;
+asn_constr_check_f SinglePacket_48P0_constraint;
+ber_type_decoder_f SinglePacket_48P0_decode_ber;
+der_type_encoder_f SinglePacket_48P0_encode_der;
+xer_type_decoder_f SinglePacket_48P0_decode_xer;
+xer_type_encoder_f SinglePacket_48P0_encode_xer;
+per_type_decoder_f SinglePacket_48P0_decode_uper;
+per_type_encoder_f SinglePacket_48P0_encode_uper;
+
+/*** <<< CODE [SinglePacket] >>> ***/
+
+/*
+ * This type is implemented using Packet_51P0,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< STAT-DEFS [SinglePacket] >>> ***/
+
+static const ber_tlv_tag_t asn_DEF_SinglePacket_48P0_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_SinglePacket_48P0 = {
+	"SinglePacket",
+	"SinglePacket",
+	&asn_OP_SEQUENCE,
+	asn_DEF_SinglePacket_48P0_tags_1,
+	sizeof(asn_DEF_SinglePacket_48P0_tags_1)
+		/sizeof(asn_DEF_SinglePacket_48P0_tags_1[0]), /* 1 */
+	asn_DEF_SinglePacket_48P0_tags_1,	/* Same as above */
+	sizeof(asn_DEF_SinglePacket_48P0_tags_1)
+		/sizeof(asn_DEF_SinglePacket_48P0_tags_1[0]), /* 1 */
+	{ 0, 0, SEQUENCE_constraint },
+	asn_MBR_Packet_51P0_1,
+	3,	/* Elements count */
+	&asn_SPC_Packet_51P0_specs_1	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [Packet] >>> ***/
+
+#include "PacketId.h"
+#include "Color.h"
+#include <ANY.h>
+#include <asn_ioc.h>
+#include <OPEN_TYPE.h>
+#include <constr_CHOICE.h>
+#include <constr_SEQUENCE.h>
+
+/*** <<< DEPS [Packet] >>> ***/
+
+typedef enum value_PR {
+	value_PR_NOTHING,	/* No components present */
+	
+} value_PR;
+
+/*** <<< TYPE-DECLS [Packet] >>> ***/
+
+typedef struct Packet_51P0 {
+	PacketId_t	 id;
+	Color_t	 color;
+	struct value {
+		value_PR present;
+		union Packet_51P0__value_u {
+		} choice;
+		
+		/* Context for parsing across buffer boundaries */
+		asn_struct_ctx_t _asn_ctx;
+	} value;
+	
+	/* Context for parsing across buffer boundaries */
+	asn_struct_ctx_t _asn_ctx;
+} Packet_51P0_t;
+
+/*** <<< FUNC-DECLS [Packet] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_Packet_51P0;
+extern asn_SEQUENCE_specifics_t asn_SPC_Packet_51P0_specs_1;
+extern asn_TYPE_member_t asn_MBR_Packet_51P0_1[3];
+
+/*** <<< IOC-TABLES [Packet] >>> ***/
+
+static const asn_ioc_cell_t asn_IOS_ClassItem_1_rows[] = {
+	
+};
+static const asn_ioc_set_t asn_IOS_ClassItem_1[] = {
+	0, 0, asn_IOS_ClassItem_1_rows
+};
+
+/*** <<< CODE [Packet] >>> ***/
+
+static int
+memb_id_constraint_1(const asn_TYPE_descriptor_t *td, const void *sptr,
+			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
+	long value;
+	
+	if(!sptr) {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: value not given (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+	
+	value = *(const long *)sptr;
+	
+	if((value >= 0 && value <= 65535)) {
+		/* Constraint check succeeded */
+		return 0;
+	} else {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: constraint failed (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+}
+
+static int
+memb_color_constraint_1(const asn_TYPE_descriptor_t *td, const void *sptr,
+			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
+	
+	if(!sptr) {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: value not given (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+	
+	
+	if(1 /* No applicable constraints whatsoever */) {
+		/* Nothing is here. See below */
+	}
+	
+	return td->encoding_constraints.general_constraints(td, sptr, ctfailcb, app_key);
+}
+
+static int
+memb_value_constraint_1(const asn_TYPE_descriptor_t *td, const void *sptr,
+			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
+	
+	if(!sptr) {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: value not given (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+	
+	
+	if(1 /* No applicable constraints whatsoever */) {
+		/* Nothing is here. See below */
+	}
+	
+	return td->encoding_constraints.general_constraints(td, sptr, ctfailcb, app_key);
+}
+
+
+/*** <<< CTDEFS [Packet] >>> ***/
+
+static asn_per_constraints_t asn_PER_memb_id_constr_2 CC_NOTUSED = {
+	{ APC_CONSTRAINED,	 16,  16,  0,  65535 }	/* (0..65535) */,
+	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
+	0, 0	/* No PER value map */
+};
+static asn_per_constraints_t asn_PER_memb_color_constr_3 CC_NOTUSED = {
+	{ APC_CONSTRAINED,	 2,  2,  0,  2 }	/* (0..2) */,
+	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
+	0, 0	/* No PER value map */
+};
+static asn_per_constraints_t asn_PER_memb_value_constr_4 CC_NOTUSED = {
+	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
+	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
+	0, 0	/* No PER value map */
+};
+
+/*** <<< STAT-DEFS [Packet] >>> ***/
+
+static asn_CHOICE_specifics_t asn_SPC_value_specs_4 = {
+	sizeof(struct value),
+	offsetof(struct value, _asn_ctx),
+	offsetof(struct value, present),
+	sizeof(((struct value *)0)->present),
+	0,	/* No top level tags */
+	0,	/* No tags in the map */
+	0, 0,
+	.ext_start = -1	/* Extensions start */
+};
+static /* Use -fall-defs-global to expose */
+asn_TYPE_descriptor_t asn_DEF_value_4 = {
+	"value",
+	"value",
+	&asn_OP_OPEN_TYPE,
+	0,	/* No effective tags (pointer) */
+	0,	/* No effective tags (count) */
+	0,	/* No tags (pointer) */
+	0,	/* No tags (count) */
+	{ 0, 0, OPEN_TYPE_constraint },
+	0, 0,	/* No members */
+	&asn_SPC_value_specs_4	/* Additional specs */
+};
+
+asn_TYPE_member_t asn_MBR_Packet_51P0_1[] = {
+	{ ATF_NOFLAGS, 0, offsetof(struct Packet_51P0, id),
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_PacketId,
+		.type_selector = 0,
+		{ .oer_constraints = 0, .per_constraints = &asn_PER_memb_id_constr_2, .general_constraints =  memb_id_constraint_1 },
+		0, 0, /* No default value */
+		.name = "id"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct Packet_51P0, color),
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (10 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_Color,
+		.type_selector = 0,
+		{ .oer_constraints = 0, .per_constraints = &asn_PER_memb_color_constr_3, .general_constraints =  memb_color_constraint_1 },
+		0, 0, /* No default value */
+		.name = "color"
+		},
+	{ ATF_OPEN_TYPE | ATF_NOFLAGS, 0, offsetof(struct Packet_51P0, value),
+		.tag = -1 /* Ambiguous tag (ANY?) */,
+		.tag_mode = 0,
+		.type = &asn_DEF_value_4,
+		.type_selector = 0,
+		{ .oer_constraints = 0, .per_constraints = &asn_PER_memb_value_constr_4, .general_constraints =  memb_value_constraint_1 },
+		0, 0, /* No default value */
+		.name = "value"
+		},
+};
+static const ber_tlv_tag_t asn_DEF_Packet_51P0_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+static const asn_TYPE_tag2member_t asn_MAP_Packet_51P0_tag2el_1[] = {
+    { (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)), 0, 0, 0 }, /* id */
+    { (ASN_TAG_CLASS_UNIVERSAL | (10 << 2)), 1, 0, 0 } /* color */
+};
+asn_SEQUENCE_specifics_t asn_SPC_Packet_51P0_specs_1 = {
+	sizeof(struct Packet_51P0),
+	offsetof(struct Packet_51P0, _asn_ctx),
+	.tag2el = asn_MAP_Packet_51P0_tag2el_1,
+	.tag2el_count = 2,	/* Count of tags in the map */
+	0, 0, 0,	/* Optional elements (not needed) */
+	-1,	/* Start extensions */
+	-1	/* Stop extensions */
+};
+asn_TYPE_descriptor_t asn_DEF_Packet_51P0 = {
+	"Packet",
+	"Packet",
+	&asn_OP_SEQUENCE,
+	asn_DEF_Packet_51P0_tags_1,
+	sizeof(asn_DEF_Packet_51P0_tags_1)
+		/sizeof(asn_DEF_Packet_51P0_tags_1[0]), /* 1 */
+	asn_DEF_Packet_51P0_tags_1,	/* Same as above */
+	sizeof(asn_DEF_Packet_51P0_tags_1)
+		/sizeof(asn_DEF_Packet_51P0_tags_1[0]), /* 1 */
+	{ 0, 0, SEQUENCE_constraint },
+	asn_MBR_Packet_51P0_1,
+	3,	/* Elements count */
+	&asn_SPC_Packet_51P0_specs_1	/* Additional specs */
+};
+

--- a/tests/tests-asn1c-compiler/156-union-ios-OK.asn1
+++ b/tests/tests-asn1c-compiler/156-union-ios-OK.asn1
@@ -1,0 +1,62 @@
+
+-- OK: Everything is fine
+
+-- iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+-- .spelio.software.asn1c.test (9363.1.5.1)
+-- .156
+
+ModuleParameterizationMoreThanTwoLevel
+	{ iso org(3) dod(6) internet(1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 156 }
+DEFINITIONS ::= BEGIN
+
+    TOTAL-CLASS SAMPLE-CLASS ::= {
+        CLASS-1   |
+	CLASS-2,	
+	...
+    }
+
+    CLASS-1 SAMPLE-CLASS ::= {
+        item1-1                  |
+        item1-2,
+        ...,
+        item1-3
+    }
+
+    CLASS-2 SAMPLE-CLASS ::= {	
+	item2-1,
+	...,
+        item2-2  |
+        item2-3
+    }
+
+    SAMPLE-CLASS ::= CLASS {
+        &id     RELATIVE-OID UNIQUE,
+        &code   ENUMERATED { request, response, status }
+        DEFAULT request,
+        &Type   OPTIONAL
+    } WITH SYNTAX { [TYPE &Type] [WITH CODE &code] IDENTIFIED BY &id }
+
+    item1-1 SAMPLE-CLASS ::= { IDENTIFIED BY id1-1 }
+
+    item1-2 SAMPLE-CLASS ::= { WITH CODE 1 IDENTIFIED BY id1-2 }
+
+    item1-3 SAMPLE-CLASS ::= { TYPE SampleType WITH CODE 2 IDENTIFIED BY id1-3 }
+
+    item2-1 SAMPLE-CLASS ::= { IDENTIFIED BY id2-1 }
+
+    item2-2 SAMPLE-CLASS ::= { WITH CODE 1 IDENTIFIED BY id2-2 }
+
+    item2-3 SAMPLE-CLASS ::= { TYPE SampleType WITH CODE 2 IDENTIFIED BY id2-3 }
+
+    id1-1 RELATIVE-OID ::= { 1 1 }
+    id1-2 RELATIVE-OID ::= { 1 2 }
+    id1-3 RELATIVE-OID ::= { 1 3 }
+    id2-1 RELATIVE-OID ::= { 2 1 }
+    id2-2 RELATIVE-OID ::= { 2 2 }
+    id2-3 RELATIVE-OID ::= { 2 3 }
+
+    SampleType ::= SEQUENCE { ... }
+    Salt ::= SET { ... }
+
+END

--- a/tests/tests-asn1c-compiler/156-union-ios-OK.asn1.-EFprint-class-matrix
+++ b/tests/tests-asn1c-compiler/156-union-ios-OK.asn1.-EFprint-class-matrix
@@ -1,0 +1,108 @@
+ModuleParameterizationMoreThanTwoLevel { iso org(3) dod(6) internet(1)
+	private(4) enterprise(1) spelio(9363) software(1) asn1c(5) test(1)
+	156 }
+DEFINITIONS ::=
+BEGIN
+
+TOTAL-CLASS SAMPLE-CLASS ::= {({ IDENTIFIED BY id1-1 } | { WITH CODE 1 IDENTIFIED BY id1-2 }) ({ IDENTIFIED BY id1-1 } | { WITH CODE 1 IDENTIFIED BY id1-2 }) | ({ IDENTIFIED BY id2-1 }) ({ IDENTIFIED BY id2-1 }),...}
+-- Information Object Set has 4 entries:
+--    [       &id][     &code][     &Type]
+-- [1]      id1-1  <no entry>  <no entry> 
+-- [2]      id1-2           1  <no entry> 
+-- [3]      id2-2           1  <no entry> 
+-- [4]      id2-3           2  SampleType 
+
+
+CLASS-1 SAMPLE-CLASS ::= {{ IDENTIFIED BY id1-1 } | { WITH CODE 1 IDENTIFIED BY id1-2 },...,{ TYPE SampleType WITH CODE 2 IDENTIFIED BY id1-3 }}
+-- Information Object Set has 2 entries:
+--    [  &id][&code][&Type]
+-- [1] id1-1  <no entry>  <no entry> 
+-- [2] id1-2      1  <no entry> 
+-- [ ] ...
+
+
+CLASS-2 SAMPLE-CLASS ::= {{ IDENTIFIED BY id2-1 },...,{ WITH CODE 1 IDENTIFIED BY id2-2 } | { TYPE SampleType WITH CODE 2 IDENTIFIED BY id2-3 }}
+-- Information Object Set has 2 entries:
+--    [       &id][     &code][     &Type]
+-- [1]      id2-2           1  <no entry> 
+-- [2]      id2-3           2  SampleType 
+-- [ ] ...
+
+
+SAMPLE-CLASS ::= CLASS {
+    &id	 RELATIVE-OID UNIQUE,
+    &code	 ENUMERATED {
+            request(0),        
+            response(1),        
+            status(2)
+        } DEFAULT 0,
+    &Type	 OPTIONAL
+} WITH SYNTAX { [TYPE &Type] [WITH CODE &code] IDENTIFIED BY &id }
+
+-- Information Object Set has 6 entries:
+--    [       &id][     &code][     &Type]
+-- [1]      id1-1  <no entry>  <no entry> 
+-- [2]      id1-2           1  <no entry> 
+-- [3]      id2-2           1  <no entry> 
+-- [4]      id2-3           2  SampleType 
+-- [5]      id1-3           2  SampleType 
+-- [6]      id2-1  <no entry>  <no entry> 
+
+
+item1-1 SAMPLE-CLASS ::= { IDENTIFIED BY id1-1 }
+-- Information Object Set has 1 entry:
+--    [  &id][&code][&Type]
+-- [1] id1-1  <no entry>  <no entry> 
+
+
+item1-2 SAMPLE-CLASS ::= { WITH CODE 1 IDENTIFIED BY id1-2 }
+-- Information Object Set has 1 entry:
+--    [  &id][&code][&Type]
+-- [1] id1-2      1  <no entry> 
+
+
+item1-3 SAMPLE-CLASS ::= { TYPE SampleType WITH CODE 2 IDENTIFIED BY id1-3 }
+-- Information Object Set has 1 entry:
+--    [       &id][     &code][     &Type]
+-- [1]      id1-3           2  SampleType 
+
+
+item2-1 SAMPLE-CLASS ::= { IDENTIFIED BY id2-1 }
+-- Information Object Set has 1 entry:
+--    [  &id][&code][&Type]
+-- [1] id2-1  <no entry>  <no entry> 
+
+
+item2-2 SAMPLE-CLASS ::= { WITH CODE 1 IDENTIFIED BY id2-2 }
+-- Information Object Set has 1 entry:
+--    [  &id][&code][&Type]
+-- [1] id2-2      1  <no entry> 
+
+
+item2-3 SAMPLE-CLASS ::= { TYPE SampleType WITH CODE 2 IDENTIFIED BY id2-3 }
+-- Information Object Set has 1 entry:
+--    [       &id][     &code][     &Type]
+-- [1]      id2-3           2  SampleType 
+
+
+id1-1 RELATIVE-OID ::= { 1 1 }
+
+id1-2 RELATIVE-OID ::= { 1 2 }
+
+id1-3 RELATIVE-OID ::= { 1 3 }
+
+id2-1 RELATIVE-OID ::= { 2 1 }
+
+id2-2 RELATIVE-OID ::= { 2 2 }
+
+id2-3 RELATIVE-OID ::= { 2 3 }
+
+SampleType ::= SEQUENCE {
+    ...
+}
+
+Salt ::= SET {
+    ...
+}
+
+END


### PR DESCRIPTION
This series of pull requests is to add the capability of processing S1AP's ASN.1 and generate C code.
Partially solve #185. 

Due to APER is not supported in current asn1c yet, verification of S1AP codec's correctness still be pending.