### PR TITLE
Do not build 32bit skeletons lib and check-converter

### DIFF
--- a/skeletons/Makefile.am
+++ b/skeletons/Makefile.am
@@ -20,13 +20,13 @@ uninstall-local:
 
 check_LTLIBRARIES =             \
     libasn1cskeletons.la        \
-    libasn1cskeletons_c89.la    \
-    libasn1cskeletons_c89_32.la
+    libasn1cskeletons_c89.la
 
 libasn1cskeletons_c89_la_CFLAGS = $(SKELETONS_CFLAGS)
 libasn1cskeletons_c89_la_SOURCES = $(libasn1cskeletons_la_SOURCES)
 
 if EXPLICIT_M32
+check_LTLIBRARIES += libasn1cskeletons_c89_32.la
 libasn1cskeletons_c89_32_la_CFLAGS = $(SKELETONS_CFLAGS) $(CFLAGS_M32) -Wno-format
 libasn1cskeletons_c89_32_la_SOURCES = $(libasn1cskeletons_la_SOURCES)
 endif
@@ -103,8 +103,7 @@ libasn1cskeletons_la_SOURCES =                  \
 
 check_PROGRAMS =                    \
     check-converter_example         \
-    check-converter_c89_example     \
-    check-converter_c89_32_example
+    check-converter_c89_example
 LDADD = -lm
 
 check_converter_example_CFLAGS = -DNO_ASN_PDU
@@ -115,7 +114,10 @@ check_converter_c89_example_CFLAGS = $(SKELETON_CFLAGS) -DNO_ASN_PDU
 check_converter_c89_example_SOURCES = converter-example.c
 check_converter_c89_example_LDADD = libasn1cskeletons_c89.la
 
+if EXPLICIT_M32
+check_PROGRAMS += check-converter_c89_32_example
 check_converter_c89_32_example_CFLAGS = $(SKELETON_CFLAGS) $(CFLAGS_M32) -DNO_ASN_PDU
 check_converter_c89_32_example_SOURCES = converter-example.c
 check_converter_c89_32_example_LDADD = libasn1cskeletons_c89_32.la
+endif
 

--- a/skeletons/constr_SEQUENCE_OF.c
+++ b/skeletons/constr_SEQUENCE_OF.c
@@ -183,6 +183,14 @@ SEQUENCE_OF_encode_uper(const asn_TYPE_descriptor_t *td,
                                 ct->effective_bits))
                 ASN__ENCODE_FAILED;
         }
+    } else if (list->count == 0) {
+        /* When the list is empty add only the length determinant
+         * X.691, #20.6 and #11.9.4.1
+         */
+        if (uper_put_length(po, 0, 0)) {
+            ASN__ENCODE_FAILED;
+        }
+        ASN__ENCODED_OK(er);
     }
 
 

--- a/skeletons/constr_SET_OF.c
+++ b/skeletons/constr_SET_OF.c
@@ -1054,7 +1054,7 @@ SET_OF_encode_uper(const asn_TYPE_descriptor_t *td,
 
     for(encoded_edx = 0; (ssize_t)encoded_edx < list->count;) {
         ssize_t may_encode;
-        ssize_t edx;
+        size_t edx;
         int need_eom = 0;
 
         if(ct && ct->effective_bits >= 0) {
@@ -1065,7 +1065,7 @@ SET_OF_encode_uper(const asn_TYPE_descriptor_t *td,
             if(may_encode < 0) ASN__ENCODE_FAILED;
         }
 
-        for(edx = 0; edx < may_encode; edx++) {
+        for(edx = encoded_edx; edx < encoded_edx + may_encode; edx++) {
             const struct _el_buffer *el = &encoded_els[edx];
             if(asn_put_many_bits(po, el->buf,
                                  (8 * el->length) - el->bits_unused) < 0) {


### PR DESCRIPTION
when the 32bit build is dislabed.

On MacOS with Xcode 9.0 the make check fails because the ar
cannot build empty static libraries

Fixes #228