### PR TITLE
Correctly report the required output buffer size for PER encoding

### DIFF
--- a/skeletons/asn_bit_data.c
+++ b/skeletons/asn_bit_data.c
@@ -217,7 +217,7 @@ asn_put_few_bits(asn_bit_outp_t *po, uint32_t bits, int obits) {
 		complete_bytes = (po->buffer - po->tmpspace);
 		ASN_DEBUG("[PER output %ld complete + %ld]",
 			(long)complete_bytes, (long)po->flushed_bytes);
-		if(po->output(po->tmpspace, complete_bytes, po->op_key) < 0)
+		if(po->output && po->output(po->tmpspace, complete_bytes, po->op_key) < 0)
 			return -1;
 		if(po->nboff)
 			po->tmpspace[0] = po->buffer[0];

--- a/skeletons/per_encoder.c
+++ b/skeletons/per_encoder.c
@@ -152,6 +152,9 @@ _uper_encode_flush_outp(asn_per_outp_t *po) {
 		buf++;
 	}
 
-	return po->output(po->tmpspace, buf - po->tmpspace, po->op_key);
+        if (po->output) {
+                return po->output(po->tmpspace, buf - po->tmpspace, po->op_key);
+        }
+        return 0;
 }
 


### PR DESCRIPTION
This avoids application code crashing with SEGV upon attempt to learn the required size of the output buffer for PER encoding.

Resolves #231 