### PR TITLE
Generate Makefile.am.libasn1codec compatible with non-recursive Makef…

### DIFF
--- a/libasn1compiler/asn1c_compat.c
+++ b/libasn1compiler/asn1c_compat.c
@@ -40,7 +40,7 @@ int mkstemp(char *template) {
 #endif
 
 FILE *
-asn1c_open_file(const char *name, const char *ext, char **opt_tmpname) {
+asn1c_open_file(const char* destdir, const char *name, const char *ext, char **opt_tmpname) {
 	char fname[PATH_MAX];
 	int created = 1;
 #ifndef	_WIN32
@@ -53,7 +53,9 @@ asn1c_open_file(const char *name, const char *ext, char **opt_tmpname) {
 	/*
 	 * Compute filenames.
 	 */
-    ret = snprintf(fname, sizeof(fname), "%s%s%s", name, ext,
+    ret = snprintf(fname, sizeof(fname), "%s%s%s%s",
+                   opt_tmpname ? "" : destdir,
+                   name, ext,
                    opt_tmpname ? ".XXXXXX" : "");
     assert(ret > 0 && ret < (ssize_t)sizeof(fname));
 
@@ -128,14 +130,20 @@ asn1c_open_file(const char *name, const char *ext, char **opt_tmpname) {
 }
 
 const char *
-a1c_basename(const char *path) {
+a1c_basename(const char *path, const char *destdir) {
 	static char strbuf[PATH_MAX];
 	const char *pend;
 	const char *name;
+	char *sbuf = strbuf;
 
+	if(destdir) {
+		strncpy(strbuf, destdir, PATH_MAX - 1);
+		strbuf[PATH_MAX - 1] = '\0';
+		sbuf = strbuf + strlen(strbuf);
+	}
 	pend = path + strlen(path);
 	if(pend == path) {
-		strcpy(strbuf, ".");
+		strcpy(sbuf, ".");
 		return strbuf;
 	}
 
@@ -143,7 +151,7 @@ a1c_basename(const char *path) {
 	for(pend--; pend > path && *pend == '/'; pend--);
 
 	if(pend == path && *path == '/') {
-		strcpy(strbuf, "/");
+		strcpy(sbuf, "/");
 		return strbuf;
 	}
 
@@ -154,8 +162,8 @@ a1c_basename(const char *path) {
 		return 0;
 	}
 
-	memcpy(strbuf, name, pend - name + 1);
-	strbuf[pend - name + 1] = '\0';
+	memcpy(sbuf, name, pend - name + 1);
+	sbuf[pend - name + 1] = '\0';
 
 	return strbuf;
 }

--- a/libasn1compiler/asn1c_compat.h
+++ b/libasn1compiler/asn1c_compat.h
@@ -7,14 +7,14 @@
  * its name returned in (*opt_tmpname).
  * The (*opt_tmpname) should then be subsequently freed by free(3).
  */
-FILE *asn1c_open_file(const char *base_part, const char *extension,
+FILE *asn1c_open_file(const char *destdir, const char *base_part, const char *extension,
 	char **opt_tmpname);
 
 /*
  * Obtain base name and directory name of a path.
  * Some systems have them in <libgen.h> as dirname(3) and basename(3).
  */
-const char *a1c_basename(const char *path);
+const char *a1c_basename(const char *path, const char* destdir);
 const char *a1c_dirname(const char *path);
 
 #endif	/* ASN1C_COMPAT_H */

--- a/libasn1compiler/asn1c_save.h
+++ b/libasn1compiler/asn1c_save.h
@@ -1,7 +1,7 @@
 #ifndef	ASN1C_SAVE_H
 #define	ASN1C_SAVE_H
 
-int asn1c_save_compiled_output(arg_t *arg, const char *datadir,
+int asn1c_save_compiled_output(arg_t *arg, const char *datadir, const char* destdir,
 	int argc, int optc, char **argv);
 
 #endif	/* ASN1C_SAVE_H */

--- a/libasn1compiler/asn1compiler.c
+++ b/libasn1compiler/asn1compiler.c
@@ -11,7 +11,7 @@ static int asn1c_attach_streams(asn1p_expr_t *expr);
 static int asn1c_detach_streams(asn1p_expr_t *expr);
 
 int
-asn1_compile(asn1p_t *asn, const char *datadir, enum asn1c_flags flags,
+asn1_compile(asn1p_t *asn, const char *datadir, const char *destdir, enum asn1c_flags flags,
 		int argc, int optc, char **argv) {
 	arg_t arg_s;
 	arg_t *arg = &arg_s;
@@ -84,7 +84,7 @@ asn1_compile(asn1p_t *asn, const char *datadir, enum asn1c_flags flags,
 	/*
 	 * Save or print out the compiled result.
 	 */
-	if(asn1c_save_compiled_output(arg, datadir, argc, optc, argv))
+	if(asn1c_save_compiled_output(arg, datadir, destdir, argc, optc, argv))
 		return -1;
 
 	TQ_FOR(mod, &(asn->modules), mod_next) {

--- a/libasn1compiler/asn1compiler.h
+++ b/libasn1compiler/asn1compiler.h
@@ -87,13 +87,17 @@ enum asn1c_flags {
 	/*
 	 * Generate converter-example.c and Makefile.am.example
 	 */
-	A1C_GEN_EXAMPLE     = 0x100000,
+	A1C_GEN_EXAMPLE			= 0x100000,
+	/*
+	 * Generate top-level configure.ac and Makefile.am example
+	 */
+	A1C_GEN_AUTOTOOLS_EXAMPLE	= 0x200000,
 };
 
 /*
  * Compile the ASN.1 specification.
  */
-int asn1_compile(asn1p_t *asn, const char *datadir, enum asn1c_flags,
+int asn1_compile(asn1p_t *asn, const char *datadir, const char *destdir, enum asn1c_flags,
 	int argc, int optc, char **argv);
 
 void asn1c__add_pdu_type(const char *typename);


### PR DESCRIPTION
…ile.am

The fact that the existing code creates files with names like:
  Makefile.am.libasncodec
  Makefile.am.example

leads me to believe that there is an attempt to create automake compatible
Makefile.am files. However, there are some things that are wrong with the
example generated files. For example, ASN_MODULES_SOURCES variable can't
be used because all *_SOURCES variables are expected to be either a
bin_PROGRAM or lib_LTLIBRARIES, and of course, there is neither:
  bin_PROGRAMS += ASN_MODULES
or
  lib_LTLIBRARIES += ASN_MODULES

This patch does the following:
1) correct the invalid variable names for use with autotools
2) cleanly separate the library generation from an example as1convert prog
3) Add a new option -D <destdir> that will write the generated files to the
   specified directory, and the generated Makefile.am.* will be compatible
   with a non-recursive Makefile.am schema
4) Add a new option -gen-autotools which will create (if they don't exist) a minimal
   example configure.ac and Makefile.am

This will make it much easier to integrate the generated asn1 source files with a larger project