### PR TITLE
ASN_TAG_AMBIGUOUS

### DIFF
--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -2780,11 +2780,11 @@ emit_member_table(arg_t *arg, asn1p_expr_t *expr, asn1c_ioc_table_and_objset_t *
 	if(C99_MODE) OUT(".tag = ");
 	if(outmost_tag) {
 		if(outmost_tag->tag_value == -1)
-			OUT("-1 /* Ambiguous tag (ANY?) */");
+			OUT("ASN_TAG_AMBIGUOUS /* Ambiguous tag (ANY?) */");
 		else
 			_print_tag(arg, outmost_tag);
 	} else {
-		OUT("-1 /* Ambiguous tag (CHOICE?) */");
+		OUT("ASN_TAG_AMBIGUOUS /* Ambiguous tag (CHOICE?) */");
 	}
 
 	OUT(",\n");

--- a/skeletons/ber_tlv_tag.c
+++ b/skeletons/ber_tlv_tag.c
@@ -77,14 +77,19 @@ ber_tlv_tag_snprint(ber_tlv_tag_t tag, char *buf, size_t size) {
 	const char *type = 0;
 	int ret;
 
-	switch(tag & 0x3) {
-	case ASN_TAG_CLASS_UNIVERSAL:	type = "UNIVERSAL ";	break;
-	case ASN_TAG_CLASS_APPLICATION:	type = "APPLICATION ";	break;
-	case ASN_TAG_CLASS_CONTEXT:	type = "";		break;
-	case ASN_TAG_CLASS_PRIVATE:	type = "PRIVATE ";	break;
+	if(tag == ASN_TAG_AMBIGUOUS) {
+		ret = snprintf(buf, size, "[AMBIGUOUS]");
+	} else {
+		switch(tag & 0x3) {
+		case ASN_TAG_CLASS_UNIVERSAL:	type = "UNIVERSAL ";	break;
+		case ASN_TAG_CLASS_APPLICATION:	type = "APPLICATION ";	break;
+		case ASN_TAG_CLASS_CONTEXT:	type = "";		break;
+		case ASN_TAG_CLASS_PRIVATE:	type = "PRIVATE ";	break;
+		}
+
+		ret = snprintf(buf, size, "[%s%u]", type, ((unsigned)tag) >> 2);
 	}
 
-	ret = snprintf(buf, size, "[%s%u]", type, ((unsigned)tag) >> 2);
 	if(ret <= 0 && size) buf[0] = '\0';	/* against broken libc's */
 
 	return ret;

--- a/skeletons/ber_tlv_tag.h
+++ b/skeletons/ber_tlv_tag.h
@@ -5,6 +5,8 @@
 #ifndef	_BER_TLV_TAG_H_
 #define	_BER_TLV_TAG_H_
 
+#include <limits.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -15,7 +17,9 @@ enum asn_tag_class {
 	ASN_TAG_CLASS_CONTEXT		= 2,	/* 0b10 */
 	ASN_TAG_CLASS_PRIVATE		= 3	/* 0b11 */
 };
-typedef unsigned ber_tlv_tag_t;	/* BER TAG from Tag-Length-Value */
+typedef unsigned int ber_tlv_tag_t;	/* BER TAG from Tag-Length-Value */
+
+#define ASN_TAG_AMBIGUOUS UINT_MAX
 
 /*
  * Tag class is encoded together with tag value for optimization purposes.

--- a/skeletons/constr_CHOICE.c
+++ b/skeletons/constr_CHOICE.c
@@ -479,7 +479,7 @@ CHOICE_outmost_tag(const asn_TYPE_descriptor_t *td, const void *ptr, int tag_mod
 		return asn_TYPE_outmost_tag(elm->type, memb_ptr,
 			elm->tag_mode, elm->tag);
 	} else {
-		return (ber_tlv_tag_t)-1;
+		return ASN_TAG_AMBIGUOUS;
 	}
 }
 

--- a/skeletons/constr_SEQUENCE.c
+++ b/skeletons/constr_SEQUENCE.c
@@ -293,7 +293,7 @@ SEQUENCE_decode_ber(const asn_codec_ctx_t *opt_codec_ctx,
 				edx = n;
 				ctx->step = 1 + 2 * edx;	/* Remember! */
 				goto microphase2;
-			} else if(elements[n].tag == (ber_tlv_tag_t)-1) {
+			} else if(elements[n].tag == ASN_TAG_AMBIGUOUS) {
 				use_bsearch = 1;
 				break;
 			}

--- a/skeletons/constr_SET_OF.c
+++ b/skeletons/constr_SET_OF.c
@@ -183,7 +183,7 @@ SET_OF_decode_ber(const asn_codec_ctx_t *opt_codec_ctx,
 		}
 
 		/* Outmost tag may be unknown and cannot be fetched/compared */
-		if(elm->tag != (ber_tlv_tag_t)-1) {
+		if(elm->tag != ASN_TAG_AMBIGUOUS) {
 		    if(BER_TAGS_EQUAL(tlv_tag, elm->tag)) {
 			/*
 			 * The new list member of expected type has arrived.

--- a/tests/tests-asn1c-compiler/139-component-relation-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/139-component-relation-OK.asn1.-P
@@ -185,7 +185,7 @@ static asn_TYPE_member_t asn_MBR_Frame_1[] = {
 		.name = "ident"
 		},
 	{ ATF_OPEN_TYPE | ATF_NOFLAGS, 0, offsetof(struct Frame, value),
-		.tag = -1 /* Ambiguous tag (ANY?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (ANY?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_value_3,
 		.type_selector = select_Frame_value_type,

--- a/tests/tests-asn1c-compiler/140-component-relation-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/140-component-relation-OK.asn1.-P
@@ -185,7 +185,7 @@ static asn_TYPE_member_t asn_MBR_Frame_1[] = {
 		.name = "ident"
 		},
 	{ ATF_OPEN_TYPE | ATF_NOFLAGS, 0, offsetof(struct Frame, value),
-		.tag = -1 /* Ambiguous tag (ANY?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (ANY?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_value_3,
 		.type_selector = select_Frame_value_type,

--- a/tests/tests-asn1c-compiler/144-ios-parameterization-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/144-ios-parameterization-OK.asn1.-P
@@ -244,7 +244,7 @@ asn_TYPE_member_t asn_MBR_SpecializedContent_30P0_1[] = {
 		.name = "id"
 		},
 	{ ATF_OPEN_TYPE | ATF_NOFLAGS, 0, offsetof(struct SpecializedContent_30P0, value),
-		.tag = -1 /* Ambiguous tag (ANY?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (ANY?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_value_3,
 		.type_selector = select_SpecializedContent_30P0_value_type,

--- a/tests/tests-asn1c-compiler/146-ios-parameterization-per-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/146-ios-parameterization-per-OK.asn1.-Pgen-PER
@@ -260,7 +260,7 @@ asn_TYPE_member_t asn_MBR_SpecializedContent_30P0_1[] = {
 		.name = "id"
 		},
 	{ ATF_OPEN_TYPE | ATF_NOFLAGS, 0, offsetof(struct SpecializedContent_30P0, value),
-		.tag = -1 /* Ambiguous tag (ANY?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (ANY?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_value_3,
 		.type_selector = select_SpecializedContent_30P0_value_type,

--- a/tests/tests-asn1c-compiler/155-parameterization-more-than-two-level-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/155-parameterization-more-than-two-level-OK.asn1.-Pgen-PER
@@ -725,7 +725,7 @@ asn_TYPE_member_t asn_MBR_Packet_51P0_1[] = {
 		.name = "color"
 		},
 	{ ATF_OPEN_TYPE | ATF_NOFLAGS, 0, offsetof(struct Packet_51P0, value),
-		.tag = -1 /* Ambiguous tag (ANY?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (ANY?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_value_4,
 		.type_selector = 0,

--- a/tests/tests-asn1c-compiler/156-union-ios-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/156-union-ios-OK.asn1.-Pgen-PER
@@ -291,7 +291,7 @@ asn_TYPE_member_t asn_MBR_SpecializedContent_42P0_1[] = {
 		.name = "id"
 		},
 	{ ATF_OPEN_TYPE | ATF_NOFLAGS, 0, offsetof(struct SpecializedContent_42P0, value),
-		.tag = -1 /* Ambiguous tag (ANY?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (ANY?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_value_3,
 		.type_selector = select_SpecializedContent_42P0_value_type,

--- a/tests/tests-asn1c-compiler/31-set-of-OK.asn1.-Pfcompound-names
+++ b/tests/tests-asn1c-compiler/31-set-of-OK.asn1.-Pfcompound-names
@@ -417,7 +417,7 @@ static asn_TYPE_member_t asn_MBR_Stuff_1[] = {
 		.name = "anything"
 		},
 	{ ATF_POINTER, 1, offsetof(struct Stuff, other),
-		.tag = -1 /* Ambiguous tag (CHOICE?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (CHOICE?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_other_9,
 		.type_selector = 0,

--- a/tests/tests-asn1c-compiler/31-set-of-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/31-set-of-OK.asn1.-Pfwide-types
@@ -417,7 +417,7 @@ static asn_TYPE_member_t asn_MBR_Stuff_1[] = {
 		.name = "anything"
 		},
 	{ ATF_POINTER, 1, offsetof(struct Stuff, other),
-		.tag = -1 /* Ambiguous tag (CHOICE?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (CHOICE?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_other_9,
 		.type_selector = 0,

--- a/tests/tests-asn1c-compiler/42-real-life-OK.asn1.-PR
+++ b/tests/tests-asn1c-compiler/42-real-life-OK.asn1.-PR
@@ -222,7 +222,7 @@ memb_vparts_constraint_1(const asn_TYPE_descriptor_t *td, const void *sptr,
 
 static asn_TYPE_member_t asn_MBR_vparts_2[] = {
 	{ ATF_POINTER, 0, 0,
-		.tag = -1 /* Ambiguous tag (CHOICE?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (CHOICE?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_VariablePart,
 		.type_selector = 0,

--- a/tests/tests-asn1c-compiler/43-recursion-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/43-recursion-OK.asn1.-Pfwide-types
@@ -245,7 +245,7 @@ extern asn_TYPE_member_t asn_MBR_Choice_1_1[4];
 
 static asn_TYPE_member_t asn_MBR_or_3[] = {
 	{ ATF_POINTER, 0, 0,
-		.tag = -1 /* Ambiguous tag (CHOICE?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (CHOICE?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_Choice_1,
 		.type_selector = 0,

--- a/tests/tests-asn1c-compiler/44-choice-in-sequence-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/44-choice-in-sequence-OK.asn1.-P
@@ -188,7 +188,7 @@ static asn_TYPE_member_t asn_MBR_b_3[] = {
 		.name = "d"
 		},
 	{ ATF_NOFLAGS, 0, offsetof(struct b, choice.e),
-		.tag = -1 /* Ambiguous tag (CHOICE?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (CHOICE?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_e_6,
 		.type_selector = 0,
@@ -249,7 +249,7 @@ static asn_TYPE_member_t asn_MBR_T_1[] = {
 		.name = "a"
 		},
 	{ ATF_NOFLAGS, 0, offsetof(struct T, b),
-		.tag = -1 /* Ambiguous tag (CHOICE?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (CHOICE?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_b_3,
 		.type_selector = 0,

--- a/tests/tests-asn1c-compiler/60-any-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/60-any-OK.asn1.-Pfwide-types
@@ -32,7 +32,7 @@ static asn_TYPE_member_t asn_MBR_T1_1[] = {
 		.name = "i"
 		},
 	{ ATF_ANY_TYPE | ATF_NOFLAGS, 0, offsetof(struct T1, any),
-		.tag = -1 /* Ambiguous tag (ANY?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (ANY?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_ANY,
 		.type_selector = 0,
@@ -169,7 +169,7 @@ extern asn_TYPE_descriptor_t asn_DEF_T3;
 
 static asn_TYPE_member_t asn_MBR_T3_1[] = {
 	{ ATF_ANY_TYPE | ATF_NOFLAGS, 0, offsetof(struct T3, any1),
-		.tag = -1 /* Ambiguous tag (ANY?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (ANY?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_ANY,
 		.type_selector = 0,
@@ -178,7 +178,7 @@ static asn_TYPE_member_t asn_MBR_T3_1[] = {
 		.name = "any1"
 		},
 	{ ATF_ANY_TYPE | ATF_NOFLAGS, 0, offsetof(struct T3, any2),
-		.tag = -1 /* Ambiguous tag (ANY?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (ANY?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_ANY,
 		.type_selector = 0,

--- a/tests/tests-asn1c-compiler/70-xer-test-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/70-xer-test-OK.asn1.-Pfwide-types
@@ -1388,7 +1388,7 @@ extern asn_TYPE_member_t asn_MBR_SetOfChoice_1[1];
 
 asn_TYPE_member_t asn_MBR_SetOfChoice_1[] = {
 	{ ATF_POINTER, 0, 0,
-		.tag = -1 /* Ambiguous tag (CHOICE?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (CHOICE?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_SimpleChoice,
 		.type_selector = 0,
@@ -1454,7 +1454,7 @@ extern asn_TYPE_member_t asn_MBR_NamedSetOfChoice_1[1];
 
 asn_TYPE_member_t asn_MBR_NamedSetOfChoice_1[] = {
 	{ ATF_POINTER, 0, 0,
-		.tag = -1 /* Ambiguous tag (CHOICE?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (CHOICE?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_SimpleChoice,
 		.type_selector = 0,

--- a/tests/tests-asn1c-compiler/72-same-names-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/72-same-names-OK.asn1.-Pfwide-types
@@ -43,7 +43,7 @@ static asn_TYPE_member_t asn_MBR_Member_2[] = {
 		.name = "t1"
 		},
 	{ ATF_NOFLAGS, 0, offsetof(struct Member, t2),
-		.tag = -1 /* Ambiguous tag (CHOICE?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (CHOICE?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_Type2,
 		.type_selector = 0,
@@ -258,7 +258,7 @@ asn_TYPE_descriptor_t asn_DEF_one_name_2 = {
 
 asn_TYPE_member_t asn_MBR_Type1_1[] = {
 	{ ATF_NOFLAGS, 0, offsetof(struct Type1, one_name),
-		.tag = -1 /* Ambiguous tag (CHOICE?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (CHOICE?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_one_name_2,
 		.type_selector = 0,

--- a/tests/tests-asn1c-compiler/92-circular-loops-OK.asn1.-Pfindirect-choice
+++ b/tests/tests-asn1c-compiler/92-circular-loops-OK.asn1.-Pfindirect-choice
@@ -475,7 +475,7 @@ asn_TYPE_descriptor_t asn_DEF_a_2 = {
 
 static asn_TYPE_member_t asn_MBR_c_5[] = {
 	{ ATF_POINTER, 0, 0,
-		.tag = -1 /* Ambiguous tag (CHOICE?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (CHOICE?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_Choice3,
 		.type_selector = 0,

--- a/tests/tests-asn1c-compiler/92-circular-loops-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/92-circular-loops-OK.asn1.-Pfwide-types
@@ -474,7 +474,7 @@ asn_TYPE_descriptor_t asn_DEF_a_2 = {
 
 static asn_TYPE_member_t asn_MBR_c_5[] = {
 	{ ATF_POINTER, 0, 0,
-		.tag = -1 /* Ambiguous tag (CHOICE?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (CHOICE?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_Choice3,
 		.type_selector = 0,

--- a/tests/tests-asn1c-compiler/95-choice-per-order-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/95-choice-per-order-OK.asn1.-Pfwide-types
@@ -127,7 +127,7 @@ static asn_TYPE_member_t asn_MBR_Choice_1[] = {
 		.name = "bitstr"
 		},
 	{ ATF_NOFLAGS, 0, offsetof(struct Choice, choice.ch),
-		.tag = -1 /* Ambiguous tag (CHOICE?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (CHOICE?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_ch_4,
 		.type_selector = 0,

--- a/tests/tests-asn1c-compiler/95-choice-per-order-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/95-choice-per-order-OK.asn1.-Pgen-PER
@@ -143,7 +143,7 @@ static asn_TYPE_member_t asn_MBR_Choice_1[] = {
 		.name = "bitstr"
 		},
 	{ ATF_NOFLAGS, 0, offsetof(struct Choice, choice.ch),
-		.tag = -1 /* Ambiguous tag (CHOICE?) */,
+		.tag = ASN_TAG_AMBIGUOUS /* Ambiguous tag (CHOICE?) */,
 		.tag_mode = 0,
 		.type = &asn_DEF_ch_4,
 		.type_selector = 0,


### PR DESCRIPTION
This gives a symbolic unsigned name for using a ber tag that is ambiguous