### PR TITLE
Add module name as prefix for field of an information object set when required

### DIFF
--- a/libasn1compiler/asn1c_misc.c
+++ b/libasn1compiler/asn1c_misc.c
@@ -217,6 +217,11 @@ asn1c_type_name(arg_t *arg, asn1p_expr_t *expr, enum tnfmt _format) {
 			}
 		}
 
+		if(terminal) {
+			expr->module = terminal->module;
+			expr->_mark = terminal->_mark;
+		}
+
 		if(_format == TNF_CTYPE || _format == TNF_CONSTYPE) {
 			/*
 			 * If the component references the type itself,

--- a/skeletons/OPEN_TYPE.c
+++ b/skeletons/OPEN_TYPE.c
@@ -16,7 +16,12 @@ asn_TYPE_operation_t asn_OP_OPEN_TYPE = {
 	OPEN_TYPE_encode_der,
 	OPEN_TYPE_decode_xer,
 	OPEN_TYPE_encode_xer,
+#ifdef ASN_DISABLE_OER_SUPPORT
 	0, 0,	/* No OER support, use "-gen-OER" to enable */
+#else
+	OPEN_TYPE_decode_oer,
+	OPEN_TYPE_encode_oer,
+#endif
 #ifdef ASN_DISABLE_PER_SUPPORT
 	0, 0,
 #else

--- a/skeletons/OPEN_TYPE.h
+++ b/skeletons/OPEN_TYPE.h
@@ -19,6 +19,8 @@ extern "C" {
 #define OPEN_TYPE_encode_der CHOICE_encode_der
 #define OPEN_TYPE_decode_xer NULL
 #define OPEN_TYPE_encode_xer CHOICE_encode_xer
+#define OPEN_TYPE_decode_oer NULL
+#define OPEN_TYPE_encode_oer CHOICE_encode_oer
 #define OPEN_TYPE_decode_uper NULL
 
 extern asn_TYPE_operation_t asn_OP_OPEN_TYPE;

--- a/tests/tests-asn1c-compiler/159-add-module-name-to-ios-when-clash-OK.asn1
+++ b/tests/tests-asn1c-compiler/159-add-module-name-to-ios-when-clash-OK.asn1
@@ -1,0 +1,47 @@
+
+-- OK: Everything is fine
+
+-- iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+-- .spelio.software.asn1c.test (9363.1.5.1)
+-- .159
+
+ModuleA
+	{ iso org(3) dod(6) internet(1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 159 }
+DEFINITIONS IMPLICIT TAGS ::=
+BEGIN
+
+Rate ::= INTEGER(0..65535)
+c-Rate INTEGER ::= 2
+EXT-TYPE ::= CLASS {
+      &extRef RefExt UNIQUE,
+      &ExtValue
+    }
+    WITH SYNTAX {&ExtValue IDENTIFIED BY &extRef}
+RefExt::=INTEGER (0..255)
+
+END
+
+ModuleB
+DEFINITIONS IMPLICIT TAGS ::=
+BEGIN
+
+Rate ::= INTEGER(0..255)
+c-Rate INTEGER ::= 1
+
+END
+
+ModuleC
+DEFINITIONS IMPLICIT TAGS ::=
+BEGIN
+IMPORTS
+	Rate, EXT-TYPE FROM ModuleA
+	c-Repeat FROM ModuleB;
+
+ExtTypes EXT-TYPE ::= {
+	{ Rate IDENTIFIED BY c-Rate },
+	...
+	}
+
+END
+

--- a/tests/tests-asn1c-compiler/159-add-module-name-to-ios-when-clash-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/159-add-module-name-to-ios-when-clash-OK.asn1.-P
@@ -1,0 +1,216 @@
+
+/*** <<< INCLUDES [Rate] >>> ***/
+
+#include <NativeInteger.h>
+
+/*** <<< TYPE-DECLS [Rate] >>> ***/
+
+typedef long	 ModuleA_Rate_t;
+
+/*** <<< FUNC-DECLS [Rate] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_ModuleA_Rate;
+asn_struct_free_f ModuleA_Rate_free;
+asn_struct_print_f ModuleA_Rate_print;
+asn_constr_check_f ModuleA_Rate_constraint;
+ber_type_decoder_f ModuleA_Rate_decode_ber;
+der_type_encoder_f ModuleA_Rate_encode_der;
+xer_type_decoder_f ModuleA_Rate_decode_xer;
+xer_type_encoder_f ModuleA_Rate_encode_xer;
+
+/*** <<< CODE [Rate] >>> ***/
+
+int
+ModuleA_Rate_constraint(const asn_TYPE_descriptor_t *td, const void *sptr,
+			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
+	long value;
+	
+	if(!sptr) {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: value not given (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+	
+	value = *(const long *)sptr;
+	
+	if((value >= 0 && value <= 65535)) {
+		/* Constraint check succeeded */
+		return 0;
+	} else {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: constraint failed (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+}
+
+/*
+ * This type is implemented using NativeInteger,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< STAT-DEFS [Rate] >>> ***/
+
+static const ber_tlv_tag_t asn_DEF_ModuleA_Rate_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (2 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_ModuleA_Rate = {
+	"Rate",
+	"Rate",
+	&asn_OP_NativeInteger,
+	asn_DEF_ModuleA_Rate_tags_1,
+	sizeof(asn_DEF_ModuleA_Rate_tags_1)
+		/sizeof(asn_DEF_ModuleA_Rate_tags_1[0]), /* 1 */
+	asn_DEF_ModuleA_Rate_tags_1,	/* Same as above */
+	sizeof(asn_DEF_ModuleA_Rate_tags_1)
+		/sizeof(asn_DEF_ModuleA_Rate_tags_1[0]), /* 1 */
+	{ 0, 0, ModuleA_Rate_constraint },
+	0, 0,	/* No members */
+	0	/* No specifics */
+};
+
+
+/*** <<< INCLUDES [RefExt] >>> ***/
+
+#include <NativeInteger.h>
+
+/*** <<< TYPE-DECLS [RefExt] >>> ***/
+
+typedef long	 RefExt_t;
+
+/*** <<< FUNC-DECLS [RefExt] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_RefExt;
+asn_struct_free_f RefExt_free;
+asn_struct_print_f RefExt_print;
+asn_constr_check_f RefExt_constraint;
+ber_type_decoder_f RefExt_decode_ber;
+der_type_encoder_f RefExt_encode_der;
+xer_type_decoder_f RefExt_decode_xer;
+xer_type_encoder_f RefExt_encode_xer;
+
+/*** <<< CODE [RefExt] >>> ***/
+
+int
+RefExt_constraint(const asn_TYPE_descriptor_t *td, const void *sptr,
+			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
+	long value;
+	
+	if(!sptr) {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: value not given (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+	
+	value = *(const long *)sptr;
+	
+	if((value >= 0 && value <= 255)) {
+		/* Constraint check succeeded */
+		return 0;
+	} else {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: constraint failed (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+}
+
+/*
+ * This type is implemented using NativeInteger,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< STAT-DEFS [RefExt] >>> ***/
+
+static const ber_tlv_tag_t asn_DEF_RefExt_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (2 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_RefExt = {
+	"RefExt",
+	"RefExt",
+	&asn_OP_NativeInteger,
+	asn_DEF_RefExt_tags_1,
+	sizeof(asn_DEF_RefExt_tags_1)
+		/sizeof(asn_DEF_RefExt_tags_1[0]), /* 1 */
+	asn_DEF_RefExt_tags_1,	/* Same as above */
+	sizeof(asn_DEF_RefExt_tags_1)
+		/sizeof(asn_DEF_RefExt_tags_1[0]), /* 1 */
+	{ 0, 0, RefExt_constraint },
+	0, 0,	/* No members */
+	0	/* No specifics */
+};
+
+
+/*** <<< INCLUDES [Rate] >>> ***/
+
+#include <NativeInteger.h>
+
+/*** <<< TYPE-DECLS [Rate] >>> ***/
+
+typedef long	 ModuleB_Rate_t;
+
+/*** <<< FUNC-DECLS [Rate] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_ModuleB_Rate;
+asn_struct_free_f ModuleB_Rate_free;
+asn_struct_print_f ModuleB_Rate_print;
+asn_constr_check_f ModuleB_Rate_constraint;
+ber_type_decoder_f ModuleB_Rate_decode_ber;
+der_type_encoder_f ModuleB_Rate_encode_der;
+xer_type_decoder_f ModuleB_Rate_decode_xer;
+xer_type_encoder_f ModuleB_Rate_encode_xer;
+
+/*** <<< CODE [Rate] >>> ***/
+
+int
+ModuleB_Rate_constraint(const asn_TYPE_descriptor_t *td, const void *sptr,
+			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
+	long value;
+	
+	if(!sptr) {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: value not given (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+	
+	value = *(const long *)sptr;
+	
+	if((value >= 0 && value <= 255)) {
+		/* Constraint check succeeded */
+		return 0;
+	} else {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: constraint failed (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+}
+
+/*
+ * This type is implemented using NativeInteger,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< STAT-DEFS [Rate] >>> ***/
+
+static const ber_tlv_tag_t asn_DEF_ModuleB_Rate_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (2 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_ModuleB_Rate = {
+	"Rate",
+	"Rate",
+	&asn_OP_NativeInteger,
+	asn_DEF_ModuleB_Rate_tags_1,
+	sizeof(asn_DEF_ModuleB_Rate_tags_1)
+		/sizeof(asn_DEF_ModuleB_Rate_tags_1[0]), /* 1 */
+	asn_DEF_ModuleB_Rate_tags_1,	/* Same as above */
+	sizeof(asn_DEF_ModuleB_Rate_tags_1)
+		/sizeof(asn_DEF_ModuleB_Rate_tags_1[0]), /* 1 */
+	{ 0, 0, ModuleB_Rate_constraint },
+	0, 0,	/* No members */
+	0	/* No specifics */
+};
+


### PR DESCRIPTION
If the type of a field of information object set is imported from other module, then modify corresponding parameter to reflect the fact.

For the case stated in item 2 of #254, there are two `RepeatRate` defined in different modules, i.e. 
`TCICommonTypes.asn` and `IEEE-1609-3-WEE`. So a suitable prefix using module name should be added to distinguish between them and two files, i.e. `TCI-CommonTypes_RepeatRate.c` and  `IEEE-1609-3-WEE_RepeatRate.c`, are generated.

For module `IEEE-1609-3-WSA`, it import `RepeatRate` from module `IEEE-1609-3-WEE`. So 

```
static const asn_ioc_cell_t asn_IOS_SrvAdvMsgHeaderTCI-CommonTypes_RepeatRate.h` and  `IEEE-1609-3-WEE_RepeatRate.c` are generated.ExtTypes_1_rows[] = {
	{ "&extRef", aioc__value, &asn_DEF_RefExt, &asn_VAL_1_c_RepeatRate },
	{ "&ExtValue", aioc__type, &asn_DEF_RepeatRate },
...
	{ "&ExtValue", aioc__type, &asn_DEF_AdvertiserIdentifier }
};
```
should be : 
```
static const asn_ioc_cell_t asn_IOS_SrvAdvMsgHeaderTCI-CommonTypes_RepeatRate.h` and  `IEEE-1609-3-WEE_RepeatRate.c` are generated.ExtTypes_1_rows[] = {
	{ "&extRef", aioc__value, &asn_DEF_RefExt, &asn_VAL_1_c_RepeatRate },
	{ "&ExtValue", aioc__type, &asn_DEF_IEEE_1609_3_WEE_RepeatRate },
...
	{ "&ExtValue", aioc__type, &asn_DEF_AdvertiserIdentifier }
};
```