### PR TITLE
Fix warning : function declaration isn’t a prototype

### DIFF
--- a/skeletons/constr_TYPE.h
+++ b/skeletons/constr_TYPE.h
@@ -44,8 +44,8 @@ typedef struct asn_struct_ctx_s {
 #include <asn_random_fill.h>	/* Random structures support */
 
 #ifdef  ASN_DISABLE_OER_SUPPORT
-typedef void (oer_type_decoder_f)();
-typedef void (oer_type_encoder_f)();
+typedef void (oer_type_decoder_f)(void);
+typedef void (oer_type_encoder_f)(void);
 typedef void asn_oer_constraints_t;
 #else
 #include <oer_decoder.h>	/* Octet Encoding Rules encoder */


### PR DESCRIPTION
As title.