### PR TITLE
Fix of item 2 of issue 254

### DIFF
--- a/libasn1common/asn1_ref.h
+++ b/libasn1common/asn1_ref.h
@@ -5,6 +5,7 @@
 #define	ASN1_REFERENCE_H
 
 struct asn1p_module_s;
+struct asn1p_expr_s;
 
 typedef struct asn1p_ref_s {
 
@@ -39,6 +40,7 @@ typedef struct asn1p_ref_s {
 	size_t comp_count;	/* Number of the components in the reference name. */
 	size_t comp_size;	/* Number of allocated structures */
 
+	struct asn1p_expr_s *ref_expr;  /* De-referenced expression */
 	struct asn1p_module_s *module;	/* Defined in module */
 	int _lineno;	/* Number of line in the file */
 } asn1p_ref_t;

--- a/libasn1compiler/asn1c_ioc.c
+++ b/libasn1compiler/asn1c_ioc.c
@@ -11,7 +11,7 @@
  * Given the table constraint or component relation constraint
  * ({ObjectSetName}{...}) returns "ObjectSetName" as a reference.
  */
-const asn1p_ref_t *
+asn1p_ref_t *
 asn1c_get_information_object_set_reference_from_constraint(arg_t *arg,
     const asn1p_constraint_t *ct) {
 
@@ -68,14 +68,14 @@ asn1c_get_ioc_table(arg_t *arg) {
     asn1p_expr_t *expr = arg->expr;
 	asn1p_expr_t *memb;
     asn1p_expr_t *objset = 0;
-    const asn1p_ref_t *objset_ref = NULL;
+    asn1p_ref_t *objset_ref = NULL;
     asn1c_ioc_table_and_objset_t safe_ioc_tao = {0, 0, 0};
     asn1c_ioc_table_and_objset_t failed_ioc_tao = { 0, 0, 1 };
 
     TQ_FOR(memb, &(expr->members), next) {
         const asn1p_constraint_t *cr_ct =
             asn1p_get_component_relation_constraint(memb->constraints);
-        const asn1p_ref_t *tmpref =
+        asn1p_ref_t *tmpref =
             asn1c_get_information_object_set_reference_from_constraint(arg,
                                                                        cr_ct);
         if(tmpref) {

--- a/libasn1compiler/asn1c_ioc.h
+++ b/libasn1compiler/asn1c_ioc.h
@@ -15,7 +15,7 @@ asn1c_ioc_table_and_objset_t asn1c_get_ioc_table(arg_t *arg);
 int emit_ioc_table(arg_t *arg, asn1p_expr_t *context,
                     asn1c_ioc_table_and_objset_t);
 
-const asn1p_ref_t *asn1c_get_information_object_set_reference_from_constraint(
+asn1p_ref_t *asn1c_get_information_object_set_reference_from_constraint(
     arg_t *arg, const asn1p_constraint_t *ct);
 
 

--- a/libasn1compiler/asn1c_misc.c
+++ b/libasn1compiler/asn1c_misc.c
@@ -69,7 +69,13 @@ asn1c_make_identifier(enum ami_flags_e flags, asn1p_expr_t *expr, ...) {
 		if(expr->_mark & TM_NAMECLASH) {
 			size += strlen(expr->module->ModuleName) + 2;
 			sptr[sptr_cnt++] = expr->module->ModuleName;
+		} else if (expr->reference && expr->reference->ref_expr &&
+			(expr->reference->ref_expr->_mark & TM_NAMECLASH) &&
+			(strcmp(expr->Identifier, expr->reference->ref_expr->Identifier) == 0)) {
+			size += strlen(expr->reference->ref_expr->module->ModuleName) + 2;
+			sptr[sptr_cnt++] = expr->reference->ref_expr->module->ModuleName;
 		}
+
 		sptr[sptr_cnt++] = expr->Identifier;
 
 		size += strlen(expr->Identifier);

--- a/libasn1fix/asn1fix_export.c
+++ b/libasn1fix/asn1fix_export.c
@@ -47,7 +47,7 @@ asn1f_lookup_module_ex(asn1p_t *asn, const char *module_name,
 
 asn1p_expr_t *
 asn1f_lookup_symbol_ex(asn1p_t *asn, asn1_namespace_t *ns, asn1p_expr_t *expr,
-                       const asn1p_ref_t *ref) {
+                       asn1p_ref_t *ref) {
     arg_t arg;
 
     memset(&arg, 0, sizeof(arg));

--- a/libasn1fix/asn1fix_export.h
+++ b/libasn1fix/asn1fix_export.h
@@ -30,7 +30,7 @@ asn1p_expr_t *asn1f_lookup_symbol_ex(
 		asn1p_t *asn,
 		struct asn1_namespace_s *ns,
 		asn1p_expr_t *expr,
-		const asn1p_ref_t *ref);
+		asn1p_ref_t *ref);
 
 /*
  *  Exportable version of an asn1f_class_access().

--- a/libasn1fix/asn1fix_retrieve.c
+++ b/libasn1fix/asn1fix_retrieve.c
@@ -441,8 +441,10 @@ asn1f_lookup_symbol_impl(arg_t *arg, asn1p_expr_t *rhs_pspecs, const asn1p_ref_t
 
 asn1p_expr_t *
 asn1f_lookup_symbol(arg_t *arg, asn1p_expr_t *rhs_pspecs,
-                    const asn1p_ref_t *ref) {
-    return asn1f_lookup_symbol_impl(arg, rhs_pspecs, ref, 0);
+                    asn1p_ref_t *ref) {
+    asn1p_expr_t *expr = asn1f_lookup_symbol_impl(arg, rhs_pspecs, ref, 0);
+    if (ref) ref->ref_expr = expr;
+    return expr;
 }
 
 asn1p_expr_t *

--- a/libasn1fix/asn1fix_retrieve.h
+++ b/libasn1fix/asn1fix_retrieve.h
@@ -38,7 +38,7 @@ asn1p_module_t *asn1f_lookup_module(arg_t *arg,
  * symbol lookup. Not a recursive function.
  */
 asn1p_expr_t *asn1f_lookup_symbol(arg_t *arg, asn1p_expr_t *rhs_pspecs,
-                                  const asn1p_ref_t *ref);
+                                  asn1p_ref_t *ref);
 
 /*
  * Recursively find the original type for the given expression.

--- a/tests/tests-asn1c-compiler/159-add-module-name-to-ios-when-clash-OK.asn1
+++ b/tests/tests-asn1c-compiler/159-add-module-name-to-ios-when-clash-OK.asn1
@@ -1,0 +1,45 @@
+-- OK: Everything is fine
+
+-- iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+-- .spelio.software.asn1c.test (9363.1.5.1)
+-- .159
+
+ModuleA
+	{ iso org(3) dod(6) internet(1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 159 }
+DEFINITIONS IMPLICIT TAGS ::=
+BEGIN
+
+Rate ::= INTEGER(0..65535)
+c-Rate INTEGER ::= 2
+EXT-TYPE ::= CLASS {
+      &extRef RefExt UNIQUE,
+      &ExtValue
+    }
+    WITH SYNTAX {&ExtValue IDENTIFIED BY &extRef}
+RefExt::=INTEGER (0..255)
+
+END
+
+ModuleB
+DEFINITIONS IMPLICIT TAGS ::=
+BEGIN
+
+Rate ::= INTEGER(0..255)
+c-Rate INTEGER ::= 1
+
+END
+
+ModuleC
+DEFINITIONS IMPLICIT TAGS ::=
+BEGIN
+IMPORTS
+	Rate, EXT-TYPE FROM ModuleA
+	c-Repeat FROM ModuleB;
+
+ExtTypes EXT-TYPE ::= {
+	{ Rate IDENTIFIED BY c-Rate },
+	...
+	}
+
+END


### PR DESCRIPTION
**Previous PR #273 can not be reopened, so I re-create a new one here after fix problem when dealing J2735's ASN file.**

If the type of a field of information object set is imported from other module, then modify corresponding parameter to reflect the fact.

For the case stated in item 2 of #254, there are two RepeatRate defined in different modules, i.e.
TCICommonTypes.asn and IEEE-1609-3-WEE. So a suitable prefix using module name should be added to distinguish between them and two files, i.e. TCI-CommonTypes_RepeatRate.c and IEEE-1609-3-WEE_RepeatRate.c, are generated.

For module IEEE-1609-3-WSA, it import RepeatRate from module IEEE-1609-3-WEE. So
```
static const asn_ioc_cell_t asn_IOS_SrvAdvMsgHeaderTCI-CommonTypes_RepeatRate.h` and  `IEEE-1609-3-WEE_RepeatRate.c` are generated.ExtTypes_1_rows[] = {
	{ "&extRef", aioc__value, &asn_DEF_RefExt, &asn_VAL_1_c_RepeatRate },
	{ "&ExtValue", aioc__type, &asn_DEF_RepeatRate },
...
	{ "&ExtValue", aioc__type, &asn_DEF_AdvertiserIdentifier }
};
```
should be :
```
static const asn_ioc_cell_t asn_IOS_SrvAdvMsgHeaderTCI-CommonTypes_RepeatRate.h` and  `IEEE-1609-3-WEE_RepeatRate.c` are generated.ExtTypes_1_rows[] = {
	{ "&extRef", aioc__value, &asn_DEF_RefExt, &asn_VAL_1_c_RepeatRate },
	{ "&ExtValue", aioc__type, &asn_DEF_IEEE_1609_3_WEE_RepeatRate },
...
	{ "&ExtValue", aioc__type, &asn_DEF_AdvertiserIdentifier }
};
```

Starting from 3GPP release 11, there are also duplicate type names MobilityInformation defined in module S1AP-IEs and in module SonTransfer-IEs of 36.413 (S1AP) which suffer from this problem. There is error message when compiling with SonTransfer-IEs module along with other major S1AP modules.
```
ProtocolExtensionField.c:277:31: error: ‘asn_DEF_MobilityInformation’ undeclared here (not in a function); did you mean ‘S1AP_IEs_MobilityInformation_t’?
  { "&Extension", aioc__type, &asn_DEF_MobilityInformation },
```
Applying this pull request, the generated code become :
```
	{ "&Extension", aioc__type, &asn_DEF_S1AP_IEs_MobilityInformation },
```
thus solve S1AP's compilation problem.