### PR TITLE
Remove static qualifier from var in SET_OF__encode_sorted

### DIFF
--- a/skeletons/constr_SET_OF.c
+++ b/skeletons/constr_SET_OF.c
@@ -356,7 +356,7 @@ static struct _el_buffer *
 SET_OF__encode_sorted(const asn_TYPE_member_t *elm,
                       const asn_anonymous_set_ *list,
                       enum SET_OF__encode_method method) {
-    static struct _el_buffer *encoded_els;
+    struct _el_buffer *encoded_els;
     int edx;
 
     encoded_els =


### PR DESCRIPTION
The function `SET_OF__encode_sorted` stored the working element buffer
in a static variable. If called recursively (that is, when performing
encoding of a SET containing another SET) the outermost element buffer
is therefore clobbered by the innermost call.

This causes a SEGV on continuation of the outermost call.

Bug found during testing of [Spiffing](https://github.com/surevine/spiffing),
fix verified with the same test suite.