### PR TITLE
Fix compiler redefinition warnings for __EXTENSIONS__

### DIFF
--- a/skeletons/asn_internal.h
+++ b/skeletons/asn_internal.h
@@ -7,8 +7,9 @@
  */
 #ifndef	ASN_INTERNAL_H
 #define	ASN_INTERNAL_H
+#ifndef __EXTENSIONS__
 #define __EXTENSIONS__          /* for Sun */
-
+#endif
 #include "asn_application.h"	/* Application-visible API */
 
 #ifndef	__NO_ASSERT_H__		/* Include assert.h only for internal use. */


### PR DESCRIPTION
* check if __EXTENSIONS__ if already
  defined