### PR TITLE
Respect --docdir option to ./configure

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,8 +11,4 @@ SUBDIRS =                       \
     asn1-tools asn1c skeletons  \
     tests examples doc
 
-docsdir = $(datadir)/doc/asn1c
-
-docs_DATA = README.md INSTALL.md REQUIREMENTS.md FAQ ChangeLog BUGS
-
 EXTRA_DIST = README.md INSTALL.md REQUIREMENTS.md FAQ LICENSE BUGS

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,9 +1,5 @@
 
 SUBDIRS = docsrc man
 
-docsdir = $(datadir)/doc/asn1c
-
-docs_DATA = $(srcdir)/asn1c-*.pdf
-
-EXTRA_DIST = $(srcdir)/asn1c-*.pdf
+dist_doc_DATA = $(srcdir)/asn1c-*.pdf
 


### PR DESCRIPTION
Install documentation in the path provided when calling `./configure`. By default this is `$(datarootdir)/doc/asn1c`, which is the same path that was hard-coded in the Makefile, but packages for a distribution might follow a different convention (such as appending the version).

The files in the top-level directory that describe how to build and install the software are not typically included when installing it using `make install`.