### PR TITLE
Fix OCTET_STRING/BIT_STRING skeleton dependency

### DIFF
--- a/skeletons/file-dependencies
+++ b/skeletons/file-dependencies
@@ -79,7 +79,7 @@ oer_support.h oer_support.c
 OPEN_TYPE.h OPEN_TYPE_oer.c constr_CHOICE.h
 INTEGER.h INTEGER_oer.c
 BIT_STRING.h BIT_STRING_oer.c OCTET_STRING.h
-OCTET_STRING.h OCTET_STRING_oer.c
+OCTET_STRING.h OCTET_STRING_oer.c BIT_STRING.h
 NativeInteger.h NativeInteger_oer.c
 NativeEnumerated.h NativeEnumerated_oer.c
 constr_CHOICE.h constr_CHOICE_oer.c


### PR DESCRIPTION
Missing BIT_STRING dependency in `skeletons/file-dependencies` results in uncopied Makefile dependency when OER is enabled:

```
$ cc -I. -DPDU=PDU *.c
/usr/bin/ld: /tmp/ccopqGWu.o:(.data.rel+0x38): undefined reference to `BIT_STRING_decode_oer'
/usr/bin/ld: /tmp/ccopqGWu.o:(.data.rel+0x40): undefined reference to `BIT_STRING_encode_oer'
collect2: error: ld returned 1 exit status
```

Correcting this dependency causes `BIT_STRING_oer.c` to be copied and added to `Makefile.am.libasncodec`, eliminating the above errors.