### PR TITLE
Fix typos

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -71,7 +71,7 @@
     * Add -fline-refs to avoid being unfriendly to version control systems.
     * Default constraint checking fix.
       Thanks to Bartosz Marcinkiewicz <bma@megawatt.com.pl>
-    * Get rid of non-standard pointer arithmetics on void* pointer.
+    * Get rid of non-standard pointer arithmetic on void* pointer.
     * PER-encoding of integers wider than 32 bits.
 
 0.9.24:    2013-Mar-16
@@ -315,7 +315,7 @@
     * Added ASN1C_ENVIRONMENT_VERSION and get_asn1c_environment_version().
     * Fixed ANY type decoding (Severity: high; Security impact: low).
     * Fixed BER decoder restartability problem with certain primitive
-      types (BOOLEAN, INTEGER, and REAL). The problem occured when the
+      types (BOOLEAN, INTEGER, and REAL). The problem occurred when the
       encoding of such type is split between several bytes.
       (Severity: high; Security impact: low)
     * Support for cross-referencing type definitions (updated ./tests/43-*).
@@ -332,7 +332,7 @@
       the "Spouse" case in A.3.
       (Severity: medium; Security impact: low)
     * Added converters between any generic type and the ANY type.
-    * Parser fixed: Information Object Class fields may be taged.
+    * Parser fixed: Information Object Class fields may be tagged.
     * Parser fixed: tagged types inside SEQUENCE OF/SET OF support.
     * Improved DEFAULT Value parsing and pretty-printing.
     * Condition on distinct tags checker was incorrectly dealing with
@@ -414,7 +414,7 @@
       When encoding data for certain ASN.1 specifications containing
       explicit tags, the tag is always written incorrectly due to
       incorrect memory reference. The encoding will almost always produce
-      unparseable data and might well reference unmapped region so program
+      unparsable data and might well reference unmapped region so program
       would produce segmentation violation. Fortunately, memory is
       read, not written, so remote exploits cannot execute arbitrary
       code and triggering unmapped memory reference is highly unlikely
@@ -503,7 +503,7 @@
 0.8.3:    2004-Mar-14    T-version-0-8-3
 
     * Fixed SET::BER decoder: restart after reaching a buffer boundary
-      weas broken (Severity: high; Security impact: low).
+      was broken (Severity: high; Security impact: low).
     * Fixed OCTET STRING::BER decoder: restart after reaching a buffer
       boundary was broken (Severity: high; Security impact: low).
       Reported by <vss@high.net.ru>

--- a/asn1-tools/unber/libasn1_unber_tool.c
+++ b/asn1-tools/unber/libasn1_unber_tool.c
@@ -369,7 +369,7 @@ print_V(const char *fname, input_stream_t *ibs, output_stream_t *os,
      * Determine how to print the value, either in its native binary form,
      * encoded with &xNN characters, or using pretty-printing.
      * The basic string types (including "useful types", like UTCTime)
-     * are excempt from this determination logic, because their alphabets
+     * are exempt from this determination logic, because their alphabets
      * are subsets of the XML's native UTF-8 encoding.
      */
     switch(etype) {

--- a/doc/docsrc/asn1c-usage.tex
+++ b/doc/docsrc/asn1c-usage.tex
@@ -459,7 +459,7 @@ screen instead of creating a bunch of .c and .h files on disk in the
 current directory. You would probably want to start with \textbf{-P}
 option instead of creating a mess in your current directory. Another
 option, \textbf{-R}, asks compiler to only generate the files which
-need to be generated, and supress linking in the numerous support
+need to be generated, and suppress linking in the numerous support
 files.
 
 Print the compiled output instead of creating multiple source files:
@@ -557,7 +557,7 @@ may produce a shorter executable.}\\
 {\ttfamily -no-gen-PER} & {\small Do not generate the Packed Encoding Rules (PER, X.691) support code.}\\
 {\ttfamily -no-gen-example} & {\small Do not generate the ASN.1 format converter example.}\\
 {\ttfamily -pdu=\{\textbf{all}|\textbf{auto}|\emph{Type}\}} & {\small Create a PDU table for specified types, or discover the Protocol Data Units automatically.
-In case of \texttt{-pdu=\textbf{all}}, all ASN.1 types defined in all modules wil form a PDU table. In case of \texttt{-pdu=\textbf{auto}}, all types not referenced by any other type will form a PDU table. If \texttt{\emph{Type}} is an ASN.1 type identifier, it is added to a PDU table. The last form may be specified multiple times.}\\ \\
+In case of \texttt{-pdu=\textbf{all}}, all ASN.1 types defined in all modules will form a PDU table. In case of \texttt{-pdu=\textbf{auto}}, all types not referenced by any other type will form a PDU table. If \texttt{\emph{Type}} is an ASN.1 type identifier, it is added to a PDU table. The last form may be specified multiple times.}\\ \\
 \textbf{Output Options} & \textbf{Description}\\
 \midrule
 {\ttfamily -print-class-matrix} & {\small When \texttt{-EF} options are given, this option instructs the compiler to print out the collected Information Object Class matrix.}\\
@@ -571,7 +571,7 @@ in \texttt{-E} output.}\\
 
 \chapter{API reference}
 
-The functions desribed in this chapter are to be used by the application
+The functions described in this chapter are to be used by the application
 programmer. These functions won't likely change change or get removed until
 the next major release.
 

--- a/libasn1common/genhash.c
+++ b/libasn1common/genhash.c
@@ -50,7 +50,7 @@
  * 
  * In the NORMAL mode we use the lower part of the genhash_t structure
  * to hold a set of pointers, including a pointer to the hash buckets.
- * We agressively expand hash buckets size when adding new elements
+ * We aggressively expand hash buckets size when adding new elements
  * to lower the number of key comparisons.
  */
 

--- a/libasn1common/genhash.h
+++ b/libasn1common/genhash.h
@@ -190,7 +190,7 @@ int genhash_iter_init(genhash_iter_t *iter,
  * Returns the key and value of each element in optional (key) and (value),
  * which must be passed as the pointers to pointers (hence these ***'s).
  * OWNERSHIP:
- * 	The key and value are pointers to the internally manageed locations.
+ * 	The key and value are pointers to the internally managed locations.
  * RETURN VALUES:
  * 	0 if no more elements will be returned, otherwise 1.
  * EXAMPLE:
@@ -207,7 +207,7 @@ int genhash_iter(genhash_iter_t *iter, void */***/key, void */***/val);
 /*
  * Dispose of the iterator.
  * After this operations, the iterator contents unusable
- * and shall not be accesed. (genhash_iter_init() is OK).
+ * and shall not be accessed. (genhash_iter_init() is OK).
  */
 void genhash_iter_done(genhash_iter_t *iter);
 

--- a/libasn1compiler/asn1c_compat.c
+++ b/libasn1compiler/asn1c_compat.c
@@ -121,7 +121,7 @@ asn1c_open_file(const char *destdir, const char *name, const char *ext,
 	if(opt_tmpname) {
 		*opt_tmpname = strdup(fname);
 		if(*opt_tmpname) {
-			/* Successfull */
+			/* Successful */
 		} else {
 			if(created) unlink(fname);
 			fclose(fp);

--- a/libasn1fix/asn1fix_crange.c
+++ b/libasn1fix/asn1fix_crange.c
@@ -824,7 +824,7 @@ asn1constraint_compute_OER_range(const char *dbg_name, asn1p_expr_type_e expr_ty
 asn1cnst_range_t *
 asn1constraint_compute_PER_range(const char *dbg_name, asn1p_expr_type_e expr_type, const asn1p_constraint_t *ct, enum asn1p_constraint_type_e requested_ct_type, const asn1cnst_range_t *minmax, int *exmet, enum cpr_flags cpr_flags) {
     if(0) return asn1constraint_compute_constraint_range(dbg_name, expr_type, ct, requested_ct_type, minmax, exmet, cpr_flags | CPR_strict_PER_visibility);
-    /* Due to pecularities of PER constraint handling, we don't enable strict PER visibility upfront here. */
+    /* Due to peculiarities of PER constraint handling, we don't enable strict PER visibility upfront here. */
     return asn1constraint_compute_constraint_range(dbg_name, expr_type, ct, requested_ct_type, minmax, exmet, cpr_flags);
 }
 

--- a/libasn1fix/asn1fix_cws.c
+++ b/libasn1fix/asn1fix_cws.c
@@ -349,7 +349,7 @@ _asn1f_parse_class_object_data(arg_t *arg, asn1p_expr_t *eclass,
 			cell = asn1p_ioc_row_cell_fetch(row,
 					chunk->content.token);
 			if(cell == NULL) {
-				FATAL("Field reference %s found in WITH SYNAX {} clause does not match actual field in Object Class %s",
+				FATAL("Field reference %s found in WITH SYNTAX {} clause does not match actual field in Object Class %s",
 					chunk->content.token,
 					eclass->Identifier, eclass->_lineno);
 				if(newpos) *newpos = buf;

--- a/libasn1fix/asn1fix_misc.c
+++ b/libasn1fix/asn1fix_misc.c
@@ -84,7 +84,7 @@ asn1f_printable_value(asn1p_value_t *v) {
 			int i;
 			/*
 			 * Compute number of bytes necessary
-			 * to represend the binary value.
+			 * to represent the binary value.
 			 */
 			int bits = v->value.binary_vector.size_in_bits;
 			len = ((bits%8)?bits:(bits >> 2)) + sizeof("''H");
@@ -251,7 +251,7 @@ asn1f_check_unique_expr(arg_t *arg) {
 }
 
 /*
- * Check that every preceeding child of the given expr is not
+ * Check that every preceding child of the given expr is not
  * having the name of the given one.
  */
 int

--- a/libasn1fix/asn1fix_misc.h
+++ b/libasn1fix/asn1fix_misc.h
@@ -16,7 +16,7 @@ int asn1f_recurse_expr(arg_t *arg, int (*f)(arg_t *arg));
 int asn1f_check_unique_expr(arg_t *arg);
 
 /*
- * Check that every preceeding child of the given expr is not
+ * Check that every preceding child of the given expr is not
  * having the name of the given one.
  * If opt_compare == NULL, the default comparison of the argument's
  * names (identifiers) will be performed.

--- a/libasn1fix/asn1fix_retrieve.h
+++ b/libasn1fix/asn1fix_retrieve.h
@@ -62,7 +62,7 @@ asn1p_expr_t *asn1f_find_terminal_type(arg_t *arg, asn1p_expr_t *tc);
  * 	value Type2 ::= value2
  * 	value2 Type3 ::= 3
  * Then this function will return the expression for value2 if given
- * the v as an argment.
+ * the v as an argument.
  */
 asn1p_expr_t *asn1f_find_terminal_value(arg_t *arg, asn1p_expr_t *tc);
 

--- a/libasn1fix/check_fixer.c
+++ b/libasn1fix/check_fixer.c
@@ -195,7 +195,7 @@ check(const char *fname,
 	} else if(!expected_parseable) {
 		fprintf(stderr,
 			"The file \"%s\" is not expected to be parseable, "
-			"yet parsing was successfull!\n", fname);
+			"yet parsing was successful!\n", fname);
 		r_value = -1;
 	}
 	if(!asn) return r_value;

--- a/libasn1parser/asn1p_integer.c
+++ b/libasn1parser/asn1p_integer.c
@@ -24,9 +24,9 @@ enum strtox_result_e {
     STRTOX_ERROR_RANGE = -3, /* Input outside of supported numeric range */
     STRTOX_ERROR_INVAL = -2, /* Invalid data encountered (e.g., "+-") */
     STRTOX_EXPECT_MORE = -1, /* More data expected (e.g. "+") */
-    STRTOX_OK = 0,           /* Conversion succeded, number ends at (*end) */
+    STRTOX_OK = 0,           /* Conversion succeeded, number ends at (*end) */
     STRTOX_EXTRA_DATA =
-        1 /* Conversion succeded, but the string has extra stuff */
+        1 /* Conversion succeeded, but the string has extra stuff */
 };
 
 static enum strtox_result_e

--- a/libasn1parser/asn1p_integer.h
+++ b/libasn1parser/asn1p_integer.h
@@ -21,7 +21,7 @@
 /*
  * Basic integer type used in numerous places.
  * ASN.1 does not define any limits on this number, so it must be sufficiently
- * large to accomodate typical inputs. It does not have to be a dynamically
+ * large to accommodate typical inputs. It does not have to be a dynamically
  * allocated type with potentially unlimited width: consider the width of
  * an integer defined here as one of the "compiler limitations".
  * NOTE: this is NOT a type for ASN.1 "INTEGER" type representation, this

--- a/libasn1parser/asn1p_l.c
+++ b/libasn1parser/asn1p_l.c
@@ -2081,7 +2081,7 @@ static asn1c_integer_t _lex_atoi(const char *ptr);
 static double          _lex_atod(const char *ptr);
 
 /*
- * Check that the type is defined in the year of the standard choosen.
+ * Check that the type is defined in the year of the standard chosen.
  */
 #define	TYPE_LIFETIME(fyr, lyr)				\
 	(!asn1p_lexer_types_year			\

--- a/libasn1parser/asn1p_l.l
+++ b/libasn1parser/asn1p_l.l
@@ -31,7 +31,7 @@ static asn1c_integer_t _lex_atoi(const char *ptr);
 static double          _lex_atod(const char *ptr);
 
 /*
- * Check that the type is defined in the year of the standard choosen.
+ * Check that the type is defined in the year of the standard chosen.
  */
 #define	TYPE_LIFETIME(fyr, lyr)				\
 	(!asn1p_lexer_types_year			\

--- a/libasn1parser/asn1p_y.y
+++ b/libasn1parser/asn1p_y.y
@@ -657,7 +657,7 @@ Assignment:
 	}
 
 	/*
-	 * Erroneous attemps
+	 * Erroneous attempts
 	 */
 	| BasicString {
 		return yyerror(

--- a/skeletons/INTEGER.c
+++ b/skeletons/INTEGER.c
@@ -684,7 +684,7 @@ INTEGER_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
 	/* #12.2.3 */
 	if(ct && ct->lower_bound) {
 		/*
-		 * TODO: replace by in-place arithmetics.
+		 * TODO: replace by in-place arithmetic.
 		 */
 		long value = 0;
 		if(asn_INTEGER2long(st, &value))

--- a/skeletons/INTEGER.h
+++ b/skeletons/INTEGER.h
@@ -79,8 +79,8 @@ enum asn_strtox_result_e {
     ASN_STRTOX_ERROR_RANGE = -3,  /* Input outside of supported numeric range */
     ASN_STRTOX_ERROR_INVAL = -2,  /* Invalid data encountered (e.g., "+-") */
     ASN_STRTOX_EXPECT_MORE = -1,  /* More data expected (e.g. "+") */
-    ASN_STRTOX_OK          =  0,  /* Conversion succeded, number ends at (*end) */
-    ASN_STRTOX_EXTRA_DATA  =  1   /* Conversion succeded, but the string has extra stuff */
+    ASN_STRTOX_OK          =  0,  /* Conversion succeeded, number ends at (*end) */
+    ASN_STRTOX_EXTRA_DATA  =  1   /* Conversion succeeded, but the string has extra stuff */
 };
 enum asn_strtox_result_e asn_strtol_lim(const char *str, const char **end,
                                         long *l);

--- a/skeletons/NativeInteger.c
+++ b/skeletons/NativeInteger.c
@@ -109,7 +109,7 @@ NativeInteger_decode_ber(const asn_codec_ctx_t *opt_codec_ctx,
 	/*
 	 * ASN.1 encoded INTEGER: buf_ptr, length
 	 * Fill the native, at the same time checking for overflow.
-	 * If overflow occured, return with RC_FAIL.
+	 * If overflow occurred, return with RC_FAIL.
 	 */
 	{
 		INTEGER_t tmp;

--- a/skeletons/NativeReal.c
+++ b/skeletons/NativeReal.c
@@ -120,7 +120,7 @@ NativeReal_decode_ber(const asn_codec_ctx_t *opt_codec_ctx,
     /*
      * ASN.1 encoded REAL: buf_ptr, length
      * Fill the Dbl, at the same time checking for overflow.
-     * If overflow occured, return with RC_FAIL.
+     * If overflow occurred, return with RC_FAIL.
      */
     {
         uint8_t scratch[24]; /* Longer than %.16f in decimal */

--- a/skeletons/OCTET_STRING.c
+++ b/skeletons/OCTET_STRING.c
@@ -119,7 +119,7 @@ asn_TYPE_descriptor_t asn_DEF_OCTET_STRING = {
 /*
  * The main reason why ASN.1 is still alive is that too much time and effort
  * is necessary for learning it more or less adequately, thus creating a gut
- * necessity to demonstrate that aquired skill everywhere afterwards.
+ * necessity to demonstrate that acquired skill everywhere afterwards.
  * No, I am not going to explain what the following stuff is.
  */
 struct _stack_el {

--- a/skeletons/REAL.h
+++ b/skeletons/REAL.h
@@ -42,7 +42,7 @@ ssize_t REAL__dump(double d, int canonical, asn_app_consume_bytes_f *cb, void *a
  * Convert between native double type and REAL representation (DER).
  * RETURN VALUES:
  *  0: Value converted successfully
- * -1: An error occured while converting the value: invalid format.
+ * -1: An error occurred while converting the value: invalid format.
  */
 int asn_REAL2double(const REAL_t *real_ptr, double *d);
 int asn_double2REAL(REAL_t *real_ptr, double d);

--- a/skeletons/asn_bit_data.h
+++ b/skeletons/asn_bit_data.h
@@ -36,7 +36,7 @@ asn_bit_data_t *asn_bit_data_new_contiguous(const void *data, size_t size_bits);
  */
 int32_t asn_get_few_bits(asn_bit_data_t *, int get_nbits);
 
-/* Undo the immediately preceeding "get_few_bits" operation */
+/* Undo the immediately preceding "get_few_bits" operation */
 void asn_get_undo(asn_bit_data_t *, int get_nbits);
 
 /*

--- a/skeletons/ber_tlv_tag.c
+++ b/skeletons/ber_tlv_tag.c
@@ -42,7 +42,7 @@ ber_fetch_tag(const void *ptr, size_t size, ber_tlv_tag_t *tag_r) {
 			 */
 			if(val >> ((8 * sizeof(val)) - 9)) {
 				/*
-				 * We would not be able to accomodate
+				 * We would not be able to accommodate
 				 * any more tag bits.
 				 */
 				return -1;

--- a/skeletons/constr_CHOICE.c
+++ b/skeletons/constr_CHOICE.c
@@ -65,7 +65,7 @@
 static unsigned _fetch_present_idx(const void *struct_ptr, unsigned off,
                                    unsigned size);
 static void _set_present_idx(void *sptr, unsigned offset, unsigned size,
-                             unsigned pres);
+                             unsigned present);
 static const void *_get_member_ptr(const asn_TYPE_descriptor_t *,
                                    const void *sptr, asn_TYPE_member_t **elm,
                                    unsigned *present);
@@ -162,7 +162,7 @@ CHOICE_decode_ber(const asn_codec_ctx_t *opt_codec_ctx,
 			}
 
 			if(ctx->left >= 0) {
-				/* ?Substracted below! */
+				/* ?Subtracted below! */
 				ctx->left += rval.consumed;
 			}
 			ADVANCE(rval.consumed);

--- a/skeletons/constr_CHOICE_oer.c
+++ b/skeletons/constr_CHOICE_oer.c
@@ -109,7 +109,7 @@ oer_fetch_tag(const void *ptr, size_t size, ber_tlv_tag_t *tag_r) {
              */
             if(val >> ((8 * sizeof(val)) - 9)) {
                 /*
-                 * We would not be able to accomodate
+                 * We would not be able to accommodate
                  * any more tag bits.
                  */
                 return -1;

--- a/skeletons/constr_SEQUENCE.c
+++ b/skeletons/constr_SEQUENCE.c
@@ -167,7 +167,7 @@ SEQUENCE_decode_ber(const asn_codec_ctx_t *opt_codec_ctx,
 		}
 
 		if(ctx->left >= 0)
-			ctx->left += rval.consumed; /* ?Substracted below! */
+			ctx->left += rval.consumed; /* ?Subtracted below! */
 		ADVANCE(rval.consumed);
 
 		NEXT_PHASE(ctx);

--- a/skeletons/constr_SEQUENCE_oer.c
+++ b/skeletons/constr_SEQUENCE_oer.c
@@ -486,7 +486,7 @@ SEQUENCE_encode_oer(const asn_TYPE_descriptor_t *td,
     }
 
     /*
-     * Before encode extensions, encode extensions additions presense bitmap
+     * Before encode extensions, encode extensions additions presence bitmap
      # X.696 (08/2015) #16.4.
      */
     if(has_extensions) {

--- a/skeletons/constr_SET.c
+++ b/skeletons/constr_SET.c
@@ -155,7 +155,7 @@ SET_decode_ber(const asn_codec_ctx_t *opt_codec_ctx,
 		}
 
 		if(ctx->left >= 0)
-			ctx->left += rval.consumed; /* ?Substracted below! */
+			ctx->left += rval.consumed; /* ?Subtracted below! */
 		ADVANCE(rval.consumed);
 
 		NEXT_PHASE(ctx);
@@ -171,7 +171,7 @@ SET_decode_ber(const asn_codec_ctx_t *opt_codec_ctx,
 		 * try to decode the next member from the list of
 		 * this structure's elements.
 		 * Note that elements in BER may arrive out of
-		 * order, yet DER mandates that they shall arive in the
+		 * order, yet DER mandates that they shall arrive in the
 		 * canonical order of their tags. So, there is a room
 		 * for optimization.
 		 */

--- a/skeletons/constr_SET_OF.c
+++ b/skeletons/constr_SET_OF.c
@@ -123,7 +123,7 @@ SET_OF_decode_ber(const asn_codec_ctx_t *opt_codec_ctx,
 		}
 
 		if(ctx->left >= 0)
-			ctx->left += rval.consumed; /* ?Substracted below! */
+			ctx->left += rval.consumed; /* ?Subtracted below! */
 		ADVANCE(rval.consumed);
 
 		ASN_DEBUG("Structure consumes %ld bytes, "

--- a/skeletons/constr_TYPE.h
+++ b/skeletons/constr_TYPE.h
@@ -237,8 +237,8 @@ typedef struct asn_TYPE_member_s {
 typedef struct asn_TYPE_tag2member_s {
     ber_tlv_tag_t el_tag;   /* Outmost tag of the member */
     unsigned el_no;         /* Index of the associated member, base 0 */
-    int toff_first;         /* First occurence of the el_tag, relative */
-    int toff_last;          /* Last occurence of the el_tag, relative */
+    int toff_first;         /* First occurrence of the el_tag, relative */
+    int toff_last;          /* Last occurrence of the el_tag, relative */
 } asn_TYPE_tag2member_t;
 
 /*

--- a/skeletons/converter-example.c
+++ b/skeletons/converter-example.c
@@ -45,7 +45,7 @@ extern asn_TYPE_descriptor_t *asn_pdu_collection[];
 #endif
 
 /*
- * Open file and parse its contens.
+ * Open file and parse its contents.
  */
 static void *data_decode_from_file(enum asn_transfer_syntax,
                                    asn_TYPE_descriptor_t *asnTypeOfPDU,
@@ -225,7 +225,7 @@ main(int ac, char *av[]) {
 #endif
 
     /*
-     * Pocess the command-line argments.
+     * Process the command-line arguments.
      */
     while((ch = getopt(ac, av, "i:o:1b:cdn:p:hs:" JUNKOPT RANDOPT)) != -1)
     switch(ch) {
@@ -586,7 +586,7 @@ buffer_dump() {
 
 /*
  * Move the buffer content left N bits, possibly joining it with
- * preceeding content.
+ * preceding content.
  */
 static void
 buffer_shift_left(size_t offset, int bits) {

--- a/skeletons/per_opentype.c
+++ b/skeletons/per_opentype.c
@@ -138,7 +138,7 @@ uper_open_type_get_simple(const asn_codec_ctx_t *ctx,
 	} else {
 		FREEMEM(buf);
 		/* rv.code could be RC_WMORE, nonsense in this context */
-		rv.code = RC_FAIL; /* Noone would give us more */
+		rv.code = RC_FAIL; /* No one would give us more */
 	}
 
 	return rv;

--- a/skeletons/xer_encoder.h
+++ b/skeletons/xer_encoder.h
@@ -54,7 +54,7 @@ int xer_fprint(FILE *stream, const struct asn_TYPE_descriptor_s *td,
 enum xer_equivalence_e {
     XEQ_SUCCESS,          /* The only completely positive return value */
     XEQ_FAILURE,          /* General failure */
-    XEQ_ENCODE1_FAILED,   /* First sructure XER encoding failed */
+    XEQ_ENCODE1_FAILED,   /* First structure XER encoding failed */
     XEQ_ENCODE2_FAILED,   /* Second structure XER encoding failed */
     XEQ_DIFFERENT,        /* Structures encoded into different XER */
     XEQ_DECODE_FAILED,    /* Decode of the XER data failed */

--- a/skeletons/xer_support.h
+++ b/skeletons/xer_support.h
@@ -40,8 +40,8 @@ typedef int (pxml_callback_f)(pxml_chunk_type_e _type,
 
 /*
  * Parse the given buffer as it were a chunk of XML data.
- * Invoke the specified callback each time the meaninful data is found.
- * This function returns number of bytes consumed from the bufer.
+ * Invoke the specified callback each time the meaningful data is found.
+ * This function returns number of bytes consumed from the buffer.
  * It will always be lesser than or equal to the specified _size.
  * The next invocation of this function must account the difference.
  */

--- a/tests/tests-asn1c-compiler/138-oer-constraints-OK.asn1
+++ b/tests/tests-asn1c-compiler/138-oer-constraints-OK.asn1
@@ -23,7 +23,7 @@ BEGIN
     I-1-5 ::= INTEGER ((0..5) ^ (EConstr))      -- OER-visible constraint 1..5
     J-4-5 ::= INTEGER ((EConstr) ^ (4..9))      -- OER-visible constraint 4..5
     K-1-4 ::= INTEGER ((FConstr) ^ (EConstr))   -- OER-visible constraint 1..4
-    -- X.696 #8.2.5 UNION with exeptions are ignored
+    -- X.696 #8.2.5 UNION with exceptions are ignored
     L-0-5 ::= INTEGER ((0) | (5))               -- OER-visible constraint 0..5
     M-inv ::= INTEGER ((0) | (EConstr),...)     -- Not OER-visible
     N-0-5 ::= INTEGER ((FConstr) | (5))         -- OER-visible constraint 0..5

--- a/tests/tests-asn1c-compiler/38-comments-OK.asn1
+++ b/tests/tests-asn1c-compiler/38-comments-OK.asn1
@@ -25,7 +25,7 @@ BEGIN
 
 	blah blah blah
 	/* nested comment */
-	-- this is an insignificant coment
+	-- this is an insignificant comment
 	-- this is a comment too -- and this is a comment
 
  */

--- a/tests/tests-c-compiler/check-src/check-30.-fwide-types.c
+++ b/tests/tests-c-compiler/check-src/check-30.-fwide-types.c
@@ -146,7 +146,7 @@ check(int is_ok, uint8_t *buf, size_t size, size_t consumed) {
 	T_t t, *tp;
 	asn_dec_rval_t rval;
 
-	fprintf(stderr, "\nMust %s:\n", is_ok?"suceed":"fail");
+	fprintf(stderr, "\nMust %s:\n", is_ok?"succeed":"fail");
 
 	tp = memset(&t, 0, sizeof(t));
 


### PR DESCRIPTION
This fixes lots of typos that end up in the generated output, possibly
in other projects, which would then be unable to fix these typos as they
will reappear when running asn1c again.

Warned-by: codespell