### PR TITLE
Improve test coverage for parser and AST testing.

### DIFF
--- a/libasn1compiler/asn1c_save.c
+++ b/libasn1compiler/asn1c_save.c
@@ -234,7 +234,7 @@ asn1c__save_example_mk_makefile(arg_t *arg, const asn1c_dep_chainset *deps,
 
     for(int i = 0; i < argc; i++)
         safe_fprintf(mkf, "%s%s", i ? " " : "", argv[i]);
-	safe_fprintf(mkf, "\n\n");
+    safe_fprintf(mkf, "\n\n");
 
     fclose(mkf);
     safe_fprintf(stderr, "Generated %s%s\n", destdir, makefile_name);

--- a/tests/tests-asn1c-compiler/check-parsing.sh
+++ b/tests/tests-asn1c-compiler/check-parsing.sh
@@ -33,7 +33,7 @@ for ref in ${top_srcdir}/tests/tests-asn1c-compiler/*.asn1.-*; do
 	newversion=${template}.new
 	LANG=C sed -e 's/^found in .*/found in .../' < "$ref" > "$oldversion"
 	ec=0
-	(${top_builddir}/asn1c/asn1c -S ${top_srcdir}/skeletons -no-gen-OER -no-gen-PER "-$flags" "$src" | LANG=C sed -e 's/^found in .*/found in .../' > "$newversion") || ec=$?
+	(${top_builddir}/asn1c/asn1c -S ${top_srcdir}/skeletons -no-gen-OER -no-gen-PER "-$flags" "$src" 2>&1 | LANG=C sed -e 's/^found in .*/found in .../' > "$newversion") || ec=$?
 	if [ $? = 0 ]; then
 		diff $diffArgs "$oldversion" "$newversion" || ec=$?
 	fi
@@ -43,7 +43,7 @@ for ref in ${top_srcdir}/tests/tests-asn1c-compiler/*.asn1.-*; do
 	fi
 	rm -f $oldversion $newversion
 	if [ "$1" = "regenerate" ]; then
-		${top_builddir}/asn1c/asn1c -S ${top_srcdir}/skeletons -no-gen-OER -no-gen-PER "-$flags" "$src" > "$ref"
+		${top_builddir}/asn1c/asn1c -S ${top_srcdir}/skeletons -no-gen-OER -no-gen-PER "-$flags" "$src" > "$ref" 2>&1
 	fi
 done
 


### PR DESCRIPTION
I suggest to improve test coverage by including the stderr output of asn1c in the test evaluation of the test group tests-asn1c-compiler. 

After some testing and playing with the compiler itself and going through the tests, I got the impression, that this would help to improve the test quality. 

Please, take regeneration of the the reference files not too easy and do more cross checking, as I'm not sure of the current completeness of the given tests.