### PR TITLE
asn_internal: Call va_end before returning

### DIFF
--- a/skeletons/asn_internal.c
+++ b/skeletons/asn_internal.c
@@ -17,6 +17,7 @@ asn__format_to_callback(int (*cb)(const void *, size_t, void *key), void *key,
         if(wrote < (ssize_t)buf_size) {
             if(wrote < 0) {
                 if(buf != scratch) FREEMEM(buf);
+                va_end(args);
                 return -1;
             }
             break;
@@ -25,11 +26,15 @@ asn__format_to_callback(int (*cb)(const void *, size_t, void *key), void *key,
         buf_size <<= 1;
         if(buf == scratch) {
             buf = MALLOC(buf_size);
-            if(!buf) return -1;
+            if(!buf) {
+              va_end(args);
+              return -1;
+            }
         } else {
             void *p = REALLOC(buf, buf_size);
             if(!p) {
                 FREEMEM(buf);
+                va_end(args);
                 return -1;
             }
             buf = p;
@@ -38,6 +43,7 @@ asn__format_to_callback(int (*cb)(const void *, size_t, void *key), void *key,
 
     cb_ret = cb(buf, wrote, key);
     if(buf != scratch) FREEMEM(buf);
+    va_end(args);  
     if(cb_ret < 0) {
         return -1;
     }


### PR DESCRIPTION
I do not know the project's code-style, in some C projects this kind of error-handling would incorporate a goto.
But because of the general avoidance of goto I added `va_end` before each return.

I suppose has more insight into what this function does, one could "dry" the error handling. 