### PR TITLE
docs: fix simple typo, occured -> occurred

### DIFF
--- a/skeletons/NativeInteger.c
+++ b/skeletons/NativeInteger.c
@@ -109,7 +109,7 @@ NativeInteger_decode_ber(const asn_codec_ctx_t *opt_codec_ctx,
 	/*
 	 * ASN.1 encoded INTEGER: buf_ptr, length
 	 * Fill the native, at the same time checking for overflow.
-	 * If overflow occured, return with RC_FAIL.
+	 * If overflow occurred, return with RC_FAIL.
 	 */
 	{
 		INTEGER_t tmp;

--- a/skeletons/NativeReal.c
+++ b/skeletons/NativeReal.c
@@ -120,7 +120,7 @@ NativeReal_decode_ber(const asn_codec_ctx_t *opt_codec_ctx,
     /*
      * ASN.1 encoded REAL: buf_ptr, length
      * Fill the Dbl, at the same time checking for overflow.
-     * If overflow occured, return with RC_FAIL.
+     * If overflow occurred, return with RC_FAIL.
      */
     {
         uint8_t scratch[24]; /* Longer than %.16f in decimal */

--- a/skeletons/REAL.h
+++ b/skeletons/REAL.h
@@ -42,7 +42,7 @@ ssize_t REAL__dump(double d, int canonical, asn_app_consume_bytes_f *cb, void *a
  * Convert between native double type and REAL representation (DER).
  * RETURN VALUES:
  *  0: Value converted successfully
- * -1: An error occured while converting the value: invalid format.
+ * -1: An error occurred while converting the value: invalid format.
  */
 int asn_REAL2double(const REAL_t *real_ptr, double *d);
 int asn_double2REAL(REAL_t *real_ptr, double d);


### PR DESCRIPTION
There is a small typo in skeletons/NativeInteger.c, skeletons/NativeReal.c, skeletons/REAL.h.

Should read `occurred` rather than `occured`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md