### PR TITLE
Update ASN1C_ENVIRONMENT_VERSION to v0.9.29

### DIFF
--- a/skeletons/asn_internal.h
+++ b/skeletons/asn_internal.h
@@ -21,7 +21,7 @@ extern "C" {
 #endif
 
 /* Environment version might be used to avoid running with the old library */
-#define	ASN1C_ENVIRONMENT_VERSION	923	/* Compile-time version */
+#define	ASN1C_ENVIRONMENT_VERSION	929	/* Compile-time version */
 int get_asn1c_environment_version(void);	/* Run-time version */
 
 #define	CALLOC(nmemb, size)	calloc(nmemb, size)


### PR DESCRIPTION
The current master version - [with the breaking API](https://github.com/vlm/asn1c/commit/5615304c9abc3c70d35a2aceafc45bfc94255b56#diff-91c5b46dc84a94604a4e4d0caed9bf85590a2eddbb12d2e8dc80badf324a9dfb) - is not recognizable, therefore one cannot support both versions via `#ifdef` or similar constructs(?)