### PR TITLE
push NULL on stack instead of 0; sizeof(NULL) > sizeof(0) in MinGW64,…

### DIFF
--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -84,8 +84,8 @@ static int emit_type_DEF(arg_t *arg, asn1p_expr_t *expr, enum tvm_compat tv_mode
 } while(0)
 
 /* MKID_safe() without checking for reserved keywords */
-#define	MKID(expr)	(asn1c_make_identifier(0, expr, 0))
-#define	MKID_safe(expr)	(asn1c_make_identifier(AMI_CHECK_RESERVED, expr, 0))
+#define	MKID(expr)	(asn1c_make_identifier(0, expr, NULL))
+#define	MKID_safe(expr)	(asn1c_make_identifier(AMI_CHECK_RESERVED, expr, NULL))
 
 int
 asn1c_lang_C_type_REAL(arg_t *arg) {
@@ -741,7 +741,7 @@ asn1c_lang_C_type_SEx_OF(arg_t *arg) {
 				if(0)
 				tmp_memb.Identifier = strdup(
 					asn1c_make_identifier(0,
-						expr, "Member", 0));
+						expr, "Member", NULL));
 				assert(tmp_memb.Identifier);
 			}
 			tmp.default_cb(&tmp);
@@ -2426,7 +2426,7 @@ emit_type_DEF(arg_t *arg, asn1p_expr_t *expr, enum tvm_compat tv_mode, int tags_
 			OUT("\"%s\",\n", p?p:"");
 			OUT("\"%s\",\n",
 				p ? asn1c_make_identifier(AMI_CHECK_RESERVED,
-					0, p, 0) : "");
+					0, p, NULL) : "");
 		} else {
 			OUT("\"%s\",\n", expr->Identifier);
 			OUT("\"%s\",\n", expr->Identifier);

--- a/libasn1compiler/asn1c_misc.c
+++ b/libasn1compiler/asn1c_misc.c
@@ -263,7 +263,7 @@ asn1c_type_name(arg_t *arg, asn1p_expr_t *expr, enum tnfmt _format) {
 	switch(_format) {
 	case TNF_UNMODIFIED:
 		return asn1c_make_identifier(AMI_MASK_ONLY_SPACES,
-			0, exprid ? exprid->Identifier : typename, 0);
+			0, exprid ? exprid->Identifier : typename, NULL);
 	case TNF_INCLUDE:
 		return asn1c_make_identifier(
 			AMI_MASK_ONLY_SPACES | AMI_NODELIMITER,
@@ -271,15 +271,15 @@ asn1c_type_name(arg_t *arg, asn1p_expr_t *expr, enum tnfmt _format) {
 				? "\"" : "<"),
 			exprid ? exprid->Identifier : typename,
 			((!stdname || (arg->flags & A1C_INCLUDES_QUOTED))
-				? ".h\"" : ".h>"), 0);
+				? ".h\"" : ".h>"), NULL);
 	case TNF_SAFE:
-		return asn1c_make_identifier(0, exprid, typename, 0);
+		return asn1c_make_identifier(0, exprid, typename, NULL);
 	case TNF_CTYPE:	/* C type */
 		return asn1c_make_identifier(0, exprid,
-				exprid?"t":typename, exprid?0:"t", 0);
+				exprid?"t":typename, exprid?0:"t", NULL);
 	case TNF_RSAFE:	/* Recursion-safe type */
 		return asn1c_make_identifier(AMI_CHECK_RESERVED, 0,
-			"struct", " ", typename, 0);
+			"struct", " ", typename, NULL);
 	}
 
 	assert(!"unreachable");


### PR DESCRIPTION
… which results in an access violation when pulling.

When compiling asn1c with MinGW64 out of MSys64 the resulting asn1c.exe crashes with an access violation while parsing. The reason is the usage of va_arg  libasn1compiler/asn1c_misc.c line 72. This pulls until a null value is read.

On different occations (int) 0 is being pushed on the stack instead of (intptr_t) NULL. Because sizeof(int) < sizeof(intptr_t) with this compiler too less data is pushed onto the stack, because what is being pushed is a char *, and sizeof(char *) == sizeof(intptr_t). Hence the access violation.

This patch fixes a possible problem on all platforms, and at least on MinGW64 a real problem.

The patch is relative to v0.9.28. It would be good to see a v0.9.29 coming with this, being compatible to v0.9.28 otherwise.