### PR TITLE
Fixing syntax error in GeneralisedTime.c

### DIFF
--- a/skeletons/GeneralizedTime.c
+++ b/skeletons/GeneralizedTime.c
@@ -70,7 +70,7 @@ static struct tm *gmtime_r(const time_t *tloc, struct tm *result) {
 #ifdef	HAVE_TM_GMTOFF
 #define	GMTOFF(tm)	((tm).tm_gmtoff)
 #else	/* HAVE_TM_GMTOFF */
-#define	GMTOFF(tm)	(-timezone)
+#define	GMTOFF(tm)	(_timezone)
 #endif	/* HAVE_TM_GMTOFF */
 
 #if	defined(_WIN32)


### PR DESCRIPTION
The description of this issue explains the change: https://github.com/vlm/asn1c/issues/492
