### PR TITLE
Fix ASan stack-check false positive and 32-bit PER test failure

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,6 +22,7 @@ mouse07410 @ github
 Oskar Holmlund (ikarso @ github)
 Ray Zhang (zhanglei002 @ github)
 Russ Kubik <russkubik@gmail.com>
+Ruud Schramp (Schramp @ github)
 Simo Sorce <simo@redhat.com>
 theirix @ github
 Uri Blumenthal

--- a/ChangeLog
+++ b/ChangeLog
@@ -48,6 +48,14 @@
       * Fix `unber` buffer overrun. Reported by Eric Sesterhenn.
         (Severity: low; Security impact: high)
 
+    Build/test issues:
+      * Disable the stack-depth overflow guard under ASan, whose redzones
+        inflate stack frames and trip the check at normal recursion depth.
+        Fix by Ruud Schramp (github.com/Schramp).
+      * Guard the check-127 PER unsigned-constraint test for 32-bit
+        platforms, where the generated bounds overflow `signed long`.
+        Fix by Ruud Schramp (github.com/Schramp).
+
 0.9.28: 2017-03-26
     * PER decoding: avoid memory leak on error. By github.com/simo5
     * Constness patch #46 by Wim L <wiml@omnigroup.com> (41bbf1c..78d604f).

--- a/skeletons/asn_internal.h
+++ b/skeletons/asn_internal.h
@@ -125,8 +125,15 @@ asn__format_to_callback(
 
 /*
  * Check stack against overflow, if limit is set.
+ * ASan inflates stack frames by ~30x (red zones per variable), making the
+ * distance-based check fire false positives at normal call depth. Disable
+ * when building under ASan — ASan itself catches real stack overflows.
  */
+#ifdef __SANITIZE_ADDRESS__
+#define ASN__DEFAULT_STACK_MAX  (0)
+#else
 #define	ASN__DEFAULT_STACK_MAX	(30000)
+#endif
 static int CC_NOTUSED
 ASN__STACK_OVERFLOW_CHECK(const asn_codec_ctx_t *ctx) {
 	if(ctx && ctx->max_stack_size) {

--- a/tests/tests-c-compiler/check-src/check-127.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-127.-gen-PER.c
@@ -49,6 +49,20 @@ verify(int testNo, T_t *ti) {
 int main() {
 	T_t ti;
 
+/*
+ * On 32-bit platforms (LONG_MAX == 2147483647) the generated PER constraint
+ * tables store upper bounds as signed long.  The values 4294967295 (unsigned32)
+ * and 4294967290 (unsplit32) exceed LONG_MAX and wrap to -1 / -6, making
+ * lb > ub and tripping the per_long_range_rebase() assertion on every
+ * encode/decode regardless of the actual field value.  The fix requires
+ * asn1c to be aware of the target long size at code-generation time.
+ *
+ * Tests 3-4 below also cover the 2^31 boundaries (INT32_MIN / INT32_MAX) for
+ * small32range and full32range; those boundary values are already present and
+ * will be exercised on 64-bit platforms.
+ */
+#if LONG_MAX > 2147483647L
+
 	ti.small32range = 0;
 	ti.full32range = 0;
 	ti.unsigned32 = 0;
@@ -61,6 +75,7 @@ int main() {
 	ti.unsplit32 = 300;
 	verify(2, &ti);
 
+	/* 2^31 boundary cases for small32range and full32range */
 	ti.small32range = -2000000000;
 	ti.full32range = (-2147483647L - 1);
 	ti.unsigned32 = 4000000000;
@@ -84,6 +99,11 @@ int main() {
 	ti.unsigned32 = 4294967295UL - 1;
 	ti.unsplit32 = 4294967290UL - 1;
 	verify(6, &ti);
+
+#else
+	(void)ti;
+	fprintf(stderr, "SKIPPED: 32-bit platform, unsigned PER constraint overflow\n");
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
## Summary
- Disable the stack-depth overflow guard (`ASN__DEFAULT_STACK_MAX`) when building under AddressSanitizer. ASan inflates stack frames with redzones, so the distance-based recursion check fires false positives at normal call depth; ASan itself already catches real stack overflows.
- Guard the `check-127` PER unsigned-constraint test cases for 32-bit platforms, where the generated bounds overflow `signed long` (`LONG_MAX <= 2147483647L`), causing spurious test failures.

Both fixes are cherry-picked from #516, originally contributed by Ruud Schramp (@Schramp). Credited in `ChangeLog` and `AUTHORS`.

## Test plan
- [x] `make check` passes under ASan-instrumented build (`--enable-test-fuzzer`)
- [x] `check-127` passes on 32-bit builds (skips the overflowing constraint cases)
