### PR TITLE
Fix multiple definition of asn_debug_indent in debug builds

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ daa @ github
 Eric Sesterhenn <eric.sesterhenn@x41-dsec.de>
 Erika Thorsen (akire @ github)
 gareins @ github
+Jie Chen (chenjie163 @ github)
 johvik @ github
 Jon Ringle (ringlej @ github)
 kuepe-sl @ github

--- a/skeletons/asn_internal.c
+++ b/skeletons/asn_internal.c
@@ -1,5 +1,13 @@
 #include <asn_internal.h>
 
+#ifdef ASN__DEBUG_INDENT_NEEDS_DEFINITION
+/*
+ * The single definition of the debugging indentation level,
+ * shared by all units which refer to it via "extern" in asn_internal.h.
+ */
+int asn_debug_indent;
+#endif
+
 ssize_t
 asn__format_to_callback(int (*cb)(const void *, size_t, void *key), void *key,
                         const char *fmt, ...) {

--- a/skeletons/asn_internal.h
+++ b/skeletons/asn_internal.h
@@ -50,7 +50,8 @@ int get_asn1c_environment_version(void);	/* Run-time version */
 #else	/* !ASN_THREAD_SAFE */
 #undef  ASN_DEBUG_INDENT_ADD
 #undef  asn_debug_indent
-int asn_debug_indent;
+extern int asn_debug_indent;	/* A single definition is in asn_internal.c */
+#define ASN__DEBUG_INDENT_NEEDS_DEFINITION 1
 #define ASN_DEBUG_INDENT_ADD(i) do { asn_debug_indent += i; } while(0)
 #endif	/* ASN_THREAD_SAFE */
 #define	ASN_DEBUG(fmt, args...)	do {			\


### PR DESCRIPTION
With `ASN_EMIT_DEBUG=1` (C99, non-thread-safe configuration), `asn_internal.h` defined `int asn_debug_indent;` in every translation unit which included it. Compilers defaulting to `-fno-common` (GCC 10+, clang on Linux) reject this at link time with multiple-definition errors.

Declare the variable `extern` in the header and define it once in `asn_internal.c` (a COMMON-FILES skeleton, so it is present in every generated project), keyed off a macro set by the header so the definition appears under exactly the same configuration which declares it. This keeps thread-safe and `ASN_DEBUG`-override builds compiling, where `asn_debug_indent` remains a macro expanding to `0`.

Verified on a multi-TU generated project: with `-fno-common -DASN_EMIT_DEBUG=1` the old header fails with `duplicate symbol '_asn_debug_indent'`, the new one links and runs.

Addresses one of the three items in #515; based on the fix by @chenjie163.