### PR TITLE
Detect AddressSanitizer under Clang via __has_feature

### DIFF
--- a/skeletons/asn_internal.h
+++ b/skeletons/asn_internal.h
@@ -128,8 +128,18 @@ asn__format_to_callback(
  * ASan inflates stack frames by ~30x (red zones per variable), making the
  * distance-based check fire false positives at normal call depth. Disable
  * when building under ASan — ASan itself catches real stack overflows.
+ * GCC and MSVC define __SANITIZE_ADDRESS__; Clang only exposes
+ * __has_feature(address_sanitizer).
  */
-#ifdef __SANITIZE_ADDRESS__
+#if defined(__SANITIZE_ADDRESS__)
+#define ASN__ASAN_ENABLED 1
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define ASN__ASAN_ENABLED 1
+#endif
+#endif
+
+#ifdef ASN__ASAN_ENABLED
 #define ASN__DEFAULT_STACK_MAX  (0)
 #else
 #define	ASN__DEFAULT_STACK_MAX	(30000)


### PR DESCRIPTION
e579f5a2 disabled the distance-based stack overflow check under ASan, but the guard only tests `__SANITIZE_ADDRESS__`, which GCC and MSVC define and Clang does not. Clang only exposes `__has_feature(address_sanitizer)`, so Clang ASan builds still hit the false positives.

This adds the standard two-pronged detection (factored out of #476 by @pespin — the rest of that PR is superseded by e579f5a2).

Verified with `clang -E`: `ASN__DEFAULT_STACK_MAX` is 30000 in a plain build and 0 with `-fsanitize=address`.