### PR TITLE
Fix XER decode crash in debug builds

### DIFF
--- a/skeletons/OCTET_STRING.c
+++ b/skeletons/OCTET_STRING.c
@@ -1023,7 +1023,18 @@ OCTET_STRING__convert_entrefs(void *sptr, const void *chunk_buf,
 				continue;
 			}
 			if(!len || pval[len-1] != 0x3b) goto want_more;
-			assert(val > 0);
+			if(len == 1) {
+				/*
+				 * Empty character reference ("&#;" or "&#x;"):
+				 * the ';' immediately follows the prefix, with
+				 * no digits in between. This is malformed.
+				 */
+				return -1;
+			}
+			/*
+			 * A zero-valued reference ("&#0;", "&#x0;") is valid
+			 * and yields a NUL octet, emitted by the code below.
+			 */
 			p += (pval - p) + len - 1; /* Advance past entref */
 
 			if(val < 0x80) {

--- a/tests/tests-skeletons/check-OCTET_STRING.c
+++ b/tests/tests-skeletons/check-OCTET_STRING.c
@@ -8,12 +8,15 @@
 
 enum encoding_type { HEX, BINARY, UTF8 };
 
-#define check(t, tag, buf, verify)  check_impl(__LINE__, t, tag, buf, verify)
+#define check(t, tag, buf, verify) \
+	check_impl(__LINE__, t, tag, buf, verify, (verify) ? strlen(verify) : 0)
+/* Variant with an explicit verify length, for values with embedded NULs. */
+#define check_n(t, tag, buf, verify, vlen) \
+	check_impl(__LINE__, t, tag, buf, verify, vlen)
 
 static void
-check_impl(int lineno, enum encoding_type type, char *tagname, char *xmlbuf, char *verify) {
+check_impl(int lineno, enum encoding_type type, char *tagname, char *xmlbuf, char *verify, size_t verlen) {
 	size_t xmllen = strlen(xmlbuf);
-	size_t verlen = verify ? strlen(verify) : 0;
 	asn_TYPE_descriptor_t *td = &asn_DEF_OCTET_STRING;
 	OCTET_STRING_t *st = 0;
 	OCTET_STRING_t **stp = &st;
@@ -139,6 +142,12 @@ main() {
 	check(UTF8, "z", "<z>a&#5000000000;b</z>", "a&#5000000000;b");
 	check(UTF8, "z", "<z>a&#300</z>", "a&#300");
 	check(UTF8, "z", "<z>a&#-300;</z>", "a&#-300;");
+	/* Zero-valued reference is valid and carries a NUL octet. */
+	check_n(UTF8, "z", "<z>a&#0;b</z>", "a\0b", 3);
+	check_n(UTF8, "z", "<z>a&#x0;b</z>", "a\0b", 3);
+	/* Empty reference (no digits) is malformed and must fail. */
+	check(UTF8, "z", "<z>a&#;b</z>", 0);
+	check(UTF8, "z", "<z>a&#x;b</z>", 0);
 	check(UTF8, "z", "<z>a<ff/>b</z>", "a\014b");
 	check(UTF8, "z", "<z>a<soh/>b</z>", "a\001b");
 	check(UTF8, "z", "<z>a<bel/></z>", "a\007");


### PR DESCRIPTION
## Problem in debug builds

`OCTET_STRING__convert_entrefs()` (the UTF-8 XER body converter shared by all restricted character string types) aborted via `assert(val > 0)` when a value contained a numeric character reference that either evaluated to zero (`&#0;`, `&#x0;`) or contained no digits at all (`&#;`, `&#x;`). Malformed XER input could therefore crash the decoder for any of UTF8String, IA5String, VisibleString, NumericString, PrintableString, BMPString, UniversalString, ObjectDescriptor, UTCTime, GeneralizedTime. Originally surfaced by the `check-70` libFuzzer harness.

## Fix

Replace the assertion with explicit handling, distinguishing the two cases by how much `OS__strtoent()` consumed:

- **Empty reference** (no digits — only the `;` consumed, `len == 1`): malformed → `return -1`, which `xer_decode_general` maps to `RC_FAIL`.
- **Zero-valued reference** (`&#0;`, `&#x0;`): a valid reference to U+0000 → falls through to the existing UTF-8 emitter, which writes a single `0x00` octet.

This brings the degenerate case in line with the hex/binary XER paths, which already reject out-of-alphabet input, while preserving a genuine zero code point as a real value. Per-type alphabet/format enforcement (e.g. VisibleString or the time types rejecting `\0`) remains the responsibility of `asn_check_constraints()`, unchanged by this patch.

## Tests

`tests/tests-skeletons/check-OCTET_STRING.c` gains cases for `&#0;`, `&#x0;` (expect a carried NUL octet) and `&#;`, `&#x;` (expect `RC_FAIL`), plus a `check_n` helper variant that takes an explicit verify length so the embedded-NUL value can be asserted.

Verified: `check-OCTET_STRING` passes; both `check-70` and `check-70.-fwide-types` pass with their full 60s fuzz runs.