### PR TITLE
Fix missing nul-termination on XER decode of empty numeric character reference

### DIFF
--- a/skeletons/OCTET_STRING.c
+++ b/skeletons/OCTET_STRING.c
@@ -1028,7 +1028,12 @@ OCTET_STRING__convert_entrefs(void *sptr, const void *chunk_buf,
 				 * Empty character reference ("&#;" or "&#x;"):
 				 * the ';' immediately follows the prefix, with
 				 * no digits in between. This is malformed.
+				 * Restore nul-termination at the last committed
+				 * size before bailing out, so a caller inspecting
+				 * the failed result sees a valid C string rather
+				 * than the partially written, unterminated bytes.
 				 */
+				st->buf[st->size] = 0;
 				return -1;
 			}
 			/*


### PR DESCRIPTION
## Problem

`check-OCTET_STRING` aborts under AddressSanitizer with a `heap-buffer-overflow` (READ). The overflow itself happens in the **test code** — `printf("%s", st->buf)` in `check_impl()` — but it is triggered by a **library** defect: the decoder hands back an `OCTET_STRING_t` whose `st->buf` is not nul-terminated, so the `%s` reads past the heap allocation.

ASan backtrace:

```
READ of size 7 ...
    #2 ... check_impl                       <- the printf("%s") in the test
allocated by:
    #1 ... OCTET_STRING__convert_entrefs    <- buffer the library left unterminated
```

This was introduced by commit `cdebd5d1`, which added both the faulty code path and the test that exercises it.

## Root cause

`OCTET_STRING__convert_entrefs()` builds the decoded output incrementally into `st->buf` and only nul-terminates once, after the conversion loop (the "Courtesy termination"). The empty-reference error path (`<z>a&#;b</z>` / `&#x;`) does `return -1` **after** a stray byte has already been written into the buffer but **before** that termination, leaving `st->buf` unterminated.

Every other converter and the normal exit of this same function uphold the documented courtesy nul-termination; only this error path didn't. Any caller that inspects the buffer of a failed decode (like the test's `%s`) then reads out of bounds.

## Fix

Restore the nul-termination at the last committed size before bailing out:

```c
st->buf[st->size] = 0;
return -1;
```

The buffer is allocated to `st->size + chunk_size + 1` bytes at function entry, and `st->size` is not advanced until after the loop, so index `st->size` is always in bounds — the same index/buffer the normal-exit termination uses (`st->buf[st->size] = 0;`). Writing at the pre-loop `st->size` correctly discards the stray byte while preserving data committed by earlier chunks in the streaming case.

## Verification

Built with AddressSanitizer enabled. Before the fix, `check-OCTET_STRING` aborts with the heap-buffer-overflow at the `<z>a&#;b</z>` case. After the fix, the full `tests-skeletons` suite passes:

```
# PASS:  17
# FAIL:  0
# ERROR: 0
```
