### PR TITLE
Fix PER constraint inheritance for type aliases

### DIFF
--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -2930,12 +2930,14 @@ emit_member_table(arg_t *arg, asn1p_expr_t *expr, asn1c_ioc_table_and_objset_t *
 static int
 emit_type_DEF(arg_t *arg, asn1p_expr_t *expr, enum tvm_compat tv_mode, int tags_count, int all_tags_count, int elements_count, enum etd_spec spec) {
 	asn1p_expr_t *terminal;
+	asn1p_expr_type_e terminal_etype;
 	int using_type_name = 0;
 	char *expr_id = strdup(MKID(expr));
 	char *p = expr_id;
 	char *p2 = (char *)0;
 
 	terminal = asn1f_find_terminal_type_ex(arg->asn, arg->ns, expr);
+	terminal_etype = expr_get_type(arg, expr);
 
 	if(emit_member_OER_constraints(arg, expr, "type"))
 		return -1;
@@ -3016,8 +3018,8 @@ emit_type_DEF(arg_t *arg, asn1p_expr_t *expr, enum tvm_compat tv_mode, int tags_
 		OUT("{ ");
 		if(arg->flags & A1C_GEN_OER) {
 			if(expr->combined_constraints
-			|| expr->expr_type == ASN_BASIC_ENUMERATED
-			|| expr->expr_type == ASN_CONSTR_CHOICE) {
+			|| terminal_etype == ASN_BASIC_ENUMERATED
+			|| terminal_etype == ASN_CONSTR_CHOICE) {
 				OUT("&asn_OER_type_%s_constr_%d",
 					expr_id, expr->_type_unique_index);
 			} else {
@@ -3030,9 +3032,9 @@ emit_type_DEF(arg_t *arg, asn1p_expr_t *expr, enum tvm_compat tv_mode, int tags_
 
 		if(arg->flags & A1C_GEN_PER) {
             if(expr->combined_constraints
-               || expr->expr_type == ASN_BASIC_ENUMERATED
-               || expr->expr_type == ASN_CONSTR_CHOICE
-               || (expr->expr_type & ASN_STRING_KM_MASK)) {
+               || terminal_etype == ASN_BASIC_ENUMERATED
+               || terminal_etype == ASN_CONSTR_CHOICE
+               || (terminal_etype & ASN_STRING_KM_MASK)) {
                 OUT("&asn_PER_type_%s_constr_%d",
 					expr_id, expr->_type_unique_index);
 			} else {

--- a/tests/tests-asn1c-compiler/160-alias-per-constraints-OK.asn1
+++ b/tests/tests-asn1c-compiler/160-alias-per-constraints-OK.asn1
@@ -1,0 +1,29 @@
+-- OK: Everything is fine
+
+-- iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+-- .spelio.software.asn1c.test (9363.1.5.1)
+-- .160
+
+ModuleAliasPERConstraints
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 160 }
+	DEFINITIONS ::=
+BEGIN
+
+    -- A CHOICE type, and a plain alias to it.  The alias gets its own
+    -- PER/OER constraint table generated (driven by the terminal type),
+    -- but historically that table was not linked into the alias'
+    -- asn_TYPE_descriptor_t, so uPER encode/decode of the alias failed.
+    CombInfo ::= CHOICE {
+        a   INTEGER (0..3),
+        b   BOOLEAN
+    }
+
+    AckCombInfo ::= CombInfo
+
+    T ::= SEQUENCE {
+        direct  CombInfo,
+        alias   AckCombInfo
+    }
+
+END

--- a/tests/tests-c-compiler/Makefile.am
+++ b/tests/tests-c-compiler/Makefile.am
@@ -62,6 +62,7 @@ TESTS += check-src/check-92.-findirect-choice.c
 TESTS += check-src/check-92.c
 TESTS += check-src/check-158.-fcompound-names.c
 TESTS += check-src/check-159.c
+TESTS += check-src/check-160.-gen-PER.c
 
 if TEST_64BIT
 TESTS += check-src/check64-134.-gen-PER.c

--- a/tests/tests-c-compiler/check-src/check-160.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-160.-gen-PER.c
@@ -1,0 +1,78 @@
+#undef	NDEBUG
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <string.h>
+#include <assert.h>
+#include <ctype.h>
+#include <errno.h>
+
+#include <T.h>
+#include <CombInfo.h>
+#include <AckCombInfo.h>
+
+/*
+ * AckCombInfo ::= CombInfo  is a plain alias of a CHOICE type.  asn1c
+ * generates a PER constraint table for the alias (driven by the terminal
+ * type), but historically that table was not linked into the alias'
+ * asn_TYPE_descriptor_t.  As a result the CHOICE index was neither encoded
+ * nor expected on decode, so uPER encode/decode of the alias was broken:
+ * decoding failed outright (no extension marker to fall back on), and the
+ * alias encoding differed from the equivalent non-aliased CHOICE.
+ */
+
+static void
+verify(int testNo, CombInfo_t *ci) {
+	asn_enc_rval_t er_alias;
+	asn_enc_rval_t er_direct;
+	asn_dec_rval_t rv;
+	unsigned char buf_alias[8];
+	unsigned char buf_direct[8];
+	AckCombInfo_t *back = 0;
+
+	/* The alias must encode exactly like the underlying CHOICE. */
+	er_alias = uper_encode_to_buffer(&asn_DEF_AckCombInfo, 0, ci,
+		buf_alias, sizeof buf_alias);
+	er_direct = uper_encode_to_buffer(&asn_DEF_CombInfo, 0, ci,
+		buf_direct, sizeof buf_direct);
+
+	fprintf(stderr, "%d present=%d alias=%zd direct=%zd\n",
+		testNo, ci->present, er_alias.encoded, er_direct.encoded);
+
+	assert(er_alias.encoded > 0);
+	assert(er_direct.encoded > 0);
+	assert(er_alias.encoded == er_direct.encoded);
+	assert(memcmp(buf_alias, buf_direct,
+		(er_alias.encoded + 7) / 8) == 0);
+
+	/* The alias must round-trip through its own descriptor. */
+	rv = uper_decode_complete(0, &asn_DEF_AckCombInfo, (void **)&back,
+		buf_alias, (er_alias.encoded + 7) / 8);
+	assert(rv.code == RC_OK);
+
+	assert(back->present == ci->present);
+	if(ci->present == CombInfo_PR_a) {
+		assert(back->choice.a == ci->choice.a);
+	} else if(ci->present == CombInfo_PR_b) {
+		assert(back->choice.b == ci->choice.b);
+	}
+
+	ASN_STRUCT_FREE(asn_DEF_AckCombInfo, back);
+}
+
+int main() {
+	CombInfo_t ci;
+
+	memset(&ci, 0, sizeof(ci));
+	ci.present = CombInfo_PR_a;
+	ci.choice.a = 2;
+	verify(0, &ci);
+
+	memset(&ci, 0, sizeof(ci));
+	ci.present = CombInfo_PR_b;
+	ci.choice.b = 1;
+	verify(1, &ci);
+
+	printf("OK\n");
+	return 0;
+}


### PR DESCRIPTION
A plain alias of a CHOICE/ENUMERATED/constrained-string (e.g. `AckCombInfo ::= CombInfo`) had its PER/OER constraint table generated but not linked into the alias' `asn_TYPE_descriptor_t`, so uPER encode/decode of the alias failed.

`emit_type_DEF()` now keys the link condition on the *terminal* type, matching how the table itself is generated.

Includes a runtime regression test (check-160) that round-trips a CHOICE alias and asserts it encodes identically to the underlying CHOICE.

Fix by @Ioozzc (supersedes #523).