### PR TITLE
Reject -fno-constraints together with constraint-driven encodings (PER/OER)

### DIFF
--- a/asn1c/asn1c.c
+++ b/asn1c/asn1c.c
@@ -271,6 +271,21 @@ main(int ac, char **av) {
     }
 
     /*
+     * PER and OER encodings rely on the type constraints to determine the
+     * wire representation (e.g. SIZE and value ranges drive the encoding).
+     * Disabling constraints would silently produce non-conformant output,
+     * so refuse the combination outright.
+     */
+    if((asn1_compiler_flags & A1C_NO_CONSTRAINTS)
+       && (asn1_compiler_flags & (A1C_GEN_PER | A1C_GEN_OER))) {
+        fprintf(stderr,
+                "Error: -fno-constraints is incompatible with %s"
+                " (these encodings rely on constraints)\n",
+                (asn1_compiler_flags & A1C_GEN_PER) ? "-gen-PER" : "-gen-OER");
+        exit(EX_USAGE);
+    }
+
+    /*
      * Ensure that there are some input files present.
      */
     if(ac > optind) {


### PR DESCRIPTION
## Problem

`-fno-constraints` and the **PER**/**OER** codecs do not mix. Those two
encodings derive the *wire representation* from the type's constraints —
`SIZE(...)` and value ranges select the packed/octet layout — so generating
them with constraint information stripped out would silently produce
**non-conformant output** that no constraint-aware peer can decode.

## Fix

Refuse the combination at option-validation time with a clear diagnostic:

```
$ asn1c -gen-PER -fno-constraints module.asn1
Error: -fno-constraints is incompatible with -gen-PER (these encodings rely on constraints)
```

PER and OER are enabled **by default**, so `-fno-constraints` on its own is
rejected too; to use it (for BER/DER/XER, where constraints are validation
only) pair it with `-no-gen-PER -no-gen-OER`.

## Compatibility of `-fno-constraints` with each encoding

| Encoding        | Enabled by              | Constraints affect the wire format? | Compatible with `-fno-constraints`? |
| --------------- | ----------------------- | ----------------------------------- | ----------------------------------- |
| BER             | always                  | No — validation only                | ✅ Yes |
| DER             | always                  | No — validation only                | ✅ Yes |
| CER (decode)    | always                  | No — validation only                | ✅ Yes |
| XER (XML)       | always                  | No — validation only                | ✅ Yes |
| OER  (`-gen-OER`) | default (on)          | **Yes** — `SIZE`/value ranges drive the encoding | ❌ No |
| PER / UPER (`-gen-PER`) | default (on)    | **Yes** — `SIZE`/value ranges drive the encoding | ❌ No |

To keep `-fno-constraints`, disable the constraint-driven codecs:

```
asn1c -fno-constraints -no-gen-PER -no-gen-OER module.asn1
```

Supersedes #522.