### PR TITLE
Fix open type decoder NULL deref and OOB write on typeless IOS rows

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,13 @@
 
+0.9.??:
+    FIXES IN COMPILER-GENERATED OUTPUT:
+      * Fix open type decoder NULL dereference and out-of-bounds read when an
+        information object set leaves the open type's class field unspecified
+        for some objects (an OPTIONAL &Type field omitted by part of the set,
+        e.g. 3GPP elementary-procedure tables).
+        Reported by Seaver Thorn (NCSU).
+        (Severity: medium; Security impact: high)
+
 0.9.29:
     FEATURES:
     * Added support for basic Information Object Sets driven code generation.

--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -2668,6 +2668,7 @@ emit_member_type_selector(arg_t *arg, asn1p_expr_t *expr, asn1c_ioc_table_and_ob
     OUT("size_t constraining_column = %zu; /* %s */\n", constraining_column, cfield);
     OUT("size_t for_column = %zu; /* %s */\n", for_column, for_field);
     OUT("size_t row;\n");
+    OUT("size_t presence_index = 0;\n");
 
     const char *tname = asn1c_type_name(arg, constraining_memb, TNF_SAFE);
     if(constraining_memb->marker.flags & EM_INDIRECT) {
@@ -2702,9 +2703,19 @@ emit_member_type_selector(arg_t *arg, asn1p_expr_t *expr, asn1c_ioc_table_and_ob
     OUT("    const asn_ioc_cell_t *constraining_cell = &itable->rows[row * itable->columns_count + constraining_column];\n");
     OUT("    const asn_ioc_cell_t *type_cell = &itable->rows[row * itable->columns_count + for_column];\n");
     OUT("\n");
+    OUT("    /*\n");
+    OUT("     * The CHOICE which carries the open type value only contains the\n");
+    OUT("     * rows which actually define a type for this column, so count those\n");
+    OUT("     * rows to derive the CHOICE presence index. A row which selects no\n");
+    OUT("     * type leaves both result fields cleared, which the decoders treat\n");
+    OUT("     * as a decode failure.\n");
+    OUT("     */\n");
+    OUT("    if(type_cell->type_descriptor) presence_index++;\n");
     OUT("    if(constraining_cell->type_descriptor->op->compare_struct(constraining_cell->type_descriptor, constraining_value, constraining_cell->value_sptr) == 0) {\n");
-    OUT("        result.type_descriptor = type_cell->type_descriptor;\n");
-    OUT("        result.presence_index = row + 1;\n");
+    OUT("        if(type_cell->type_descriptor) {\n");
+    OUT("            result.type_descriptor = type_cell->type_descriptor;\n");
+    OUT("            result.presence_index = presence_index;\n");
+    OUT("        }\n");
     OUT("        break;\n");
     OUT("    }\n");
     OUT("}\n");

--- a/skeletons/OPEN_TYPE.c
+++ b/skeletons/OPEN_TYPE.c
@@ -58,7 +58,12 @@ OPEN_TYPE_ber_get(const asn_codec_ctx_t *opt_codec_ctx,
     }
 
     selected = elm->type_selector(td, sptr);
-    if(!selected.presence_index) {
+    if(!selected.presence_index || !selected.type_descriptor) {
+        /*
+         * The constraining value does not select any type, or selects a
+         * row of the information object set which does not define a type
+         * for this open type field. Either way, there's nothing to decode.
+         */
         ASN__DECODE_FAILED;
     }
 
@@ -147,7 +152,12 @@ OPEN_TYPE_xer_get(const asn_codec_ctx_t *opt_codec_ctx,
     }
 
     selected = elm->type_selector(td, sptr);
-    if(!selected.presence_index) {
+    if(!selected.presence_index || !selected.type_descriptor) {
+        /*
+         * The constraining value does not select any type, or selects a
+         * row of the information object set which does not define a type
+         * for this open type field. Either way, there's nothing to decode.
+         */
         ASN__DECODE_FAILED;
     }
 
@@ -306,7 +316,12 @@ OPEN_TYPE_uper_get(const asn_codec_ctx_t *opt_codec_ctx,
     }
 
     selected = elm->type_selector(td, sptr);
-    if(!selected.presence_index) {
+    if(!selected.presence_index || !selected.type_descriptor) {
+        /*
+         * The constraining value does not select any type, or selects a
+         * row of the information object set which does not define a type
+         * for this open type field. Either way, there's nothing to decode.
+         */
         ASN__DECODE_FAILED;
     }
 

--- a/skeletons/OPEN_TYPE_oer.c
+++ b/skeletons/OPEN_TYPE_oer.c
@@ -30,7 +30,12 @@ OPEN_TYPE_oer_get(const asn_codec_ctx_t *opt_codec_ctx,
     }
 
     selected = elm->type_selector(td, sptr);
-    if(!selected.presence_index) {
+    if(!selected.presence_index || !selected.type_descriptor) {
+        /*
+         * The constraining value does not select any type, or selects a
+         * row of the information object set which does not define a type
+         * for this open type field. Either way, there's nothing to decode.
+         */
         ASN__DECODE_FAILED;
     }
 

--- a/tests/tests-asn1c-compiler/139-component-relation-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/139-component-relation-OK.asn1.-P
@@ -87,15 +87,26 @@ select_Frame_value_type(const asn_TYPE_descriptor_t *parent_type, const void *pa
 	size_t constraining_column = 0; /* &id */
 	size_t for_column = 1; /* &Type */
 	size_t row;
+	size_t presence_index = 0;
 	const long *constraining_value = (const long *)((const char *)parent_sptr + offsetof(struct Frame, ident));
 	
 	for(row=0; row < itable->rows_count; row++) {
 	    const asn_ioc_cell_t *constraining_cell = &itable->rows[row * itable->columns_count + constraining_column];
 	    const asn_ioc_cell_t *type_cell = &itable->rows[row * itable->columns_count + for_column];
 	
+	    /*
+	     * The CHOICE which carries the open type value only contains the
+	     * rows which actually define a type for this column, so count those
+	     * rows to derive the CHOICE presence index. A row which selects no
+	     * type leaves both result fields cleared, which the decoders treat
+	     * as a decode failure.
+	     */
+	    if(type_cell->type_descriptor) presence_index++;
 	    if(constraining_cell->type_descriptor->op->compare_struct(constraining_cell->type_descriptor, constraining_value, constraining_cell->value_sptr) == 0) {
-	        result.type_descriptor = type_cell->type_descriptor;
-	        result.presence_index = row + 1;
+	        if(type_cell->type_descriptor) {
+	            result.type_descriptor = type_cell->type_descriptor;
+	            result.presence_index = presence_index;
+	        }
 	        break;
 	    }
 	}

--- a/tests/tests-asn1c-compiler/140-component-relation-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/140-component-relation-OK.asn1.-P
@@ -87,15 +87,26 @@ select_Frame_value_type(const asn_TYPE_descriptor_t *parent_type, const void *pa
 	size_t constraining_column = 0; /* &id */
 	size_t for_column = 1; /* &Type */
 	size_t row;
+	size_t presence_index = 0;
 	const long *constraining_value = (const long *)((const char *)parent_sptr + offsetof(struct Frame, ident));
 	
 	for(row=0; row < itable->rows_count; row++) {
 	    const asn_ioc_cell_t *constraining_cell = &itable->rows[row * itable->columns_count + constraining_column];
 	    const asn_ioc_cell_t *type_cell = &itable->rows[row * itable->columns_count + for_column];
 	
+	    /*
+	     * The CHOICE which carries the open type value only contains the
+	     * rows which actually define a type for this column, so count those
+	     * rows to derive the CHOICE presence index. A row which selects no
+	     * type leaves both result fields cleared, which the decoders treat
+	     * as a decode failure.
+	     */
+	    if(type_cell->type_descriptor) presence_index++;
 	    if(constraining_cell->type_descriptor->op->compare_struct(constraining_cell->type_descriptor, constraining_value, constraining_cell->value_sptr) == 0) {
-	        result.type_descriptor = type_cell->type_descriptor;
-	        result.presence_index = row + 1;
+	        if(type_cell->type_descriptor) {
+	            result.type_descriptor = type_cell->type_descriptor;
+	            result.presence_index = presence_index;
+	        }
 	        break;
 	    }
 	}

--- a/tests/tests-asn1c-compiler/141-component-relation-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/141-component-relation-OK.asn1.-P
@@ -93,15 +93,26 @@ select_Frame_value_type(const asn_TYPE_descriptor_t *parent_type, const void *pa
 	size_t constraining_column = 0; /* &id */
 	size_t for_column = 1; /* &Type */
 	size_t row;
+	size_t presence_index = 0;
 	const long *constraining_value = (const long *)((const char *)parent_sptr + offsetof(struct Frame, ident));
 	
 	for(row=0; row < itable->rows_count; row++) {
 	    const asn_ioc_cell_t *constraining_cell = &itable->rows[row * itable->columns_count + constraining_column];
 	    const asn_ioc_cell_t *type_cell = &itable->rows[row * itable->columns_count + for_column];
 	
+	    /*
+	     * The CHOICE which carries the open type value only contains the
+	     * rows which actually define a type for this column, so count those
+	     * rows to derive the CHOICE presence index. A row which selects no
+	     * type leaves both result fields cleared, which the decoders treat
+	     * as a decode failure.
+	     */
+	    if(type_cell->type_descriptor) presence_index++;
 	    if(constraining_cell->type_descriptor->op->compare_struct(constraining_cell->type_descriptor, constraining_value, constraining_cell->value_sptr) == 0) {
-	        result.type_descriptor = type_cell->type_descriptor;
-	        result.presence_index = row + 1;
+	        if(type_cell->type_descriptor) {
+	            result.type_descriptor = type_cell->type_descriptor;
+	            result.presence_index = presence_index;
+	        }
 	        break;
 	    }
 	}

--- a/tests/tests-asn1c-compiler/144-ios-parameterization-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/144-ios-parameterization-OK.asn1.-P
@@ -158,15 +158,26 @@ select_SpecializedContent_30P0_value_type(const asn_TYPE_descriptor_t *parent_ty
 	size_t constraining_column = 0; /* &id */
 	size_t for_column = 1; /* &Type */
 	size_t row;
+	size_t presence_index = 0;
 	const long *constraining_value = (const long *)((const char *)parent_sptr + offsetof(struct SpecializedContent_30P0, id));
 	
 	for(row=0; row < itable->rows_count; row++) {
 	    const asn_ioc_cell_t *constraining_cell = &itable->rows[row * itable->columns_count + constraining_column];
 	    const asn_ioc_cell_t *type_cell = &itable->rows[row * itable->columns_count + for_column];
 	
+	    /*
+	     * The CHOICE which carries the open type value only contains the
+	     * rows which actually define a type for this column, so count those
+	     * rows to derive the CHOICE presence index. A row which selects no
+	     * type leaves both result fields cleared, which the decoders treat
+	     * as a decode failure.
+	     */
+	    if(type_cell->type_descriptor) presence_index++;
 	    if(constraining_cell->type_descriptor->op->compare_struct(constraining_cell->type_descriptor, constraining_value, constraining_cell->value_sptr) == 0) {
-	        result.type_descriptor = type_cell->type_descriptor;
-	        result.presence_index = row + 1;
+	        if(type_cell->type_descriptor) {
+	            result.type_descriptor = type_cell->type_descriptor;
+	            result.presence_index = presence_index;
+	        }
 	        break;
 	    }
 	}

--- a/tests/tests-asn1c-compiler/146-ios-parameterization-per-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/146-ios-parameterization-per-OK.asn1.-Pgen-PER
@@ -158,15 +158,26 @@ select_SpecializedContent_30P0_value_type(const asn_TYPE_descriptor_t *parent_ty
 	size_t constraining_column = 0; /* &id */
 	size_t for_column = 1; /* &Type */
 	size_t row;
+	size_t presence_index = 0;
 	const long *constraining_value = (const long *)((const char *)parent_sptr + offsetof(struct SpecializedContent_30P0, id));
 	
 	for(row=0; row < itable->rows_count; row++) {
 	    const asn_ioc_cell_t *constraining_cell = &itable->rows[row * itable->columns_count + constraining_column];
 	    const asn_ioc_cell_t *type_cell = &itable->rows[row * itable->columns_count + for_column];
 	
+	    /*
+	     * The CHOICE which carries the open type value only contains the
+	     * rows which actually define a type for this column, so count those
+	     * rows to derive the CHOICE presence index. A row which selects no
+	     * type leaves both result fields cleared, which the decoders treat
+	     * as a decode failure.
+	     */
+	    if(type_cell->type_descriptor) presence_index++;
 	    if(constraining_cell->type_descriptor->op->compare_struct(constraining_cell->type_descriptor, constraining_value, constraining_cell->value_sptr) == 0) {
-	        result.type_descriptor = type_cell->type_descriptor;
-	        result.presence_index = row + 1;
+	        if(type_cell->type_descriptor) {
+	            result.type_descriptor = type_cell->type_descriptor;
+	            result.presence_index = presence_index;
+	        }
 	        break;
 	    }
 	}

--- a/tests/tests-asn1c-compiler/156-union-ios-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/156-union-ios-OK.asn1.-Pgen-PER
@@ -169,15 +169,26 @@ select_SpecializedContent_42P0_value_type(const asn_TYPE_descriptor_t *parent_ty
 	size_t constraining_column = 0; /* &id */
 	size_t for_column = 1; /* &Type */
 	size_t row;
+	size_t presence_index = 0;
 	const long *constraining_value = (const long *)((const char *)parent_sptr + offsetof(struct SpecializedContent_42P0, id));
 	
 	for(row=0; row < itable->rows_count; row++) {
 	    const asn_ioc_cell_t *constraining_cell = &itable->rows[row * itable->columns_count + constraining_column];
 	    const asn_ioc_cell_t *type_cell = &itable->rows[row * itable->columns_count + for_column];
 	
+	    /*
+	     * The CHOICE which carries the open type value only contains the
+	     * rows which actually define a type for this column, so count those
+	     * rows to derive the CHOICE presence index. A row which selects no
+	     * type leaves both result fields cleared, which the decoders treat
+	     * as a decode failure.
+	     */
+	    if(type_cell->type_descriptor) presence_index++;
 	    if(constraining_cell->type_descriptor->op->compare_struct(constraining_cell->type_descriptor, constraining_value, constraining_cell->value_sptr) == 0) {
-	        result.type_descriptor = type_cell->type_descriptor;
-	        result.presence_index = row + 1;
+	        if(type_cell->type_descriptor) {
+	            result.type_descriptor = type_cell->type_descriptor;
+	            result.presence_index = presence_index;
+	        }
 	        break;
 	    }
 	}

--- a/tests/tests-asn1c-compiler/161-open-type-no-type-OK.asn1
+++ b/tests/tests-asn1c-compiler/161-open-type-no-type-OK.asn1
@@ -1,0 +1,44 @@
+-- OK: Everything is fine
+
+-- Regression test: open type whose information object set contains a row
+-- that does not define a type for the open type column.
+--
+-- Decoding a value whose discriminant selects such a typeless row used to
+-- dereference a NULL type descriptor (reported crash), while decoding a value
+-- which selects a *later*, typed row used to index past the open type CHOICE
+-- (the CHOICE only holds the rows that define a type), reading out of bounds.
+
+-- iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+-- .spelio.software.asn1c.test (9363.1.5.1)
+-- .161
+
+ModuleOpenTypeNoType
+	{ iso org(3) dod(6) internet(1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 161 }
+	DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+	ProcedureCode ::= INTEGER
+
+	UnsuccessfulOutcome ::= SEQUENCE {
+		procedureCode  PROCEDURE.&procedureCode({Procedures}),
+		value          PROCEDURE.&UnsuccessfulOutcome({Procedures}{@procedureCode})
+	}
+
+	PROCEDURE ::= CLASS {
+		&procedureCode       ProcedureCode UNIQUE,
+		&UnsuccessfulOutcome OPTIONAL
+	} WITH SYNTAX {
+		PROCEDURE CODE        &procedureCode
+		[UNSUCCESSFUL OUTCOME &UnsuccessfulOutcome]
+	}
+
+	-- The object for code 0 has no &UnsuccessfulOutcome type; code 1 does.
+	Procedures PROCEDURE ::= {
+		{ PROCEDURE CODE 0 } |
+		{ PROCEDURE CODE 1 UNSUCCESSFUL OUTCOME FailureB }
+	}
+
+	FailureB ::= SEQUENCE {}
+
+END

--- a/tests/tests-c-compiler/Makefile.am
+++ b/tests/tests-c-compiler/Makefile.am
@@ -63,6 +63,8 @@ TESTS += check-src/check-92.c
 TESTS += check-src/check-158.-fcompound-names.c
 TESTS += check-src/check-159.c
 TESTS += check-src/check-160.-gen-PER.c
+TESTS += check-src/check-161.-fcompound-names.c
+TESTS += check-src/check-161.-fcompound-names.-gen-PER.c
 
 if TEST_64BIT
 TESTS += check-src/check64-134.-gen-PER.c

--- a/tests/tests-c-compiler/check-src/check-161.-fcompound-names.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-161.-fcompound-names.-gen-PER.c
@@ -1,0 +1,67 @@
+#undef NDEBUG
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include <UnsuccessfulOutcome.h>
+
+/*
+ * uPER counterpart of check-161: the same open type typeless-row defects are
+ * reachable through OPEN_TYPE_uper_get / uper_open_type_get.
+ *
+ *   1. A discriminant selecting the typeless row (procedureCode 0) used to
+ *      reach uper_open_type_get() with a NULL type descriptor and dereference
+ *      it (td->op->uper_decoder).
+ *   2. A discriminant selecting the later, typed row (procedureCode 1) used to
+ *      index past the open type CHOICE elements array.
+ *
+ * Rather than hardcode a bitstream, encode a valid value and decode it back
+ * (covering defect 2), then flip the procedureCode octet to 0 and decode that
+ * (covering defect 1).
+ */
+
+int main(void) {
+    UnsuccessfulOutcome_t u;
+    UnsuccessfulOutcome_t *d = NULL;
+    uint8_t buf[32];
+    asn_enc_rval_t er;
+    asn_dec_rval_t rv;
+    size_t nbytes;
+
+    memset(&u, 0, sizeof(u));
+    u.procedureCode = 1;
+    u.value.present = UnsuccessfulOutcome__value_PR_FailureB;
+
+    er = uper_encode_to_buffer(&asn_DEF_UnsuccessfulOutcome, 0, &u, buf, sizeof(buf));
+    assert(er.encoded > 0);
+    nbytes = (er.encoded + 7) / 8;
+    fprintf(stderr, "uPER encoded %zd bits (%zu bytes)\n", er.encoded, nbytes);
+
+    /* Defect 2: valid value selecting the typed row must round-trip. */
+    rv = uper_decode_complete(0, &asn_DEF_UnsuccessfulOutcome, (void **)&d,
+                              buf, nbytes);
+    fprintf(stderr, "valid procedureCode=1: code=%d\n", (int)rv.code);
+    assert(rv.code == RC_OK);
+    assert(d->procedureCode == 1);
+    assert(d->value.present == UnsuccessfulOutcome__value_PR_FailureB);
+    ASN_STRUCT_FREE(asn_DEF_UnsuccessfulOutcome, d);
+    d = NULL;
+
+    /*
+     * Defect 1: the procedureCode is an unconstrained INTEGER encoded as
+     * length octet (0x01) followed by the value octet; flipping that value
+     * octet to 0 selects the typeless row. It must fail, not crash.
+     */
+    assert(nbytes >= 2);
+    assert(buf[0] == 0x01 && buf[1] == 0x01);
+    buf[1] = 0x00;
+    rv = uper_decode_complete(0, &asn_DEF_UnsuccessfulOutcome, (void **)&d,
+                              buf, nbytes);
+    fprintf(stderr, "typeless procedureCode=0: code=%d\n", (int)rv.code);
+    assert(rv.code == RC_FAIL);
+    ASN_STRUCT_FREE(asn_DEF_UnsuccessfulOutcome, d);
+
+    printf("OK: uPER open type typeless-row regression test passed.\n");
+    return 0;
+}

--- a/tests/tests-c-compiler/check-src/check-161.-fcompound-names.c
+++ b/tests/tests-c-compiler/check-src/check-161.-fcompound-names.c
@@ -1,0 +1,88 @@
+#undef NDEBUG
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include <UnsuccessfulOutcome.h>
+
+/*
+ * Regression test for the open type decoder crashes reported by
+ * Seaver Thorn (NCSU).
+ *
+ * The information object set behind the "value" open type has a row for
+ * procedureCode 0 which does NOT define a type, and a row for procedureCode 1
+ * which selects FailureB.  Two distinct defects were triggered:
+ *
+ *   1. Decoding a message whose procedureCode selects the typeless row made
+ *      the generated type selector hand back a NULL type descriptor with a
+ *      non-zero presence index; the decoder then dereferenced the NULL
+ *      descriptor (reported NULL pointer crash).
+ *
+ *   2. The open type value is carried by a CHOICE that only contains the rows
+ *      which define a type.  The selector returned the raw information object
+ *      set row number as the presence index, so selecting the typed row
+ *      (procedureCode 1, row index 1) indexed element [1] of a one-element
+ *      CHOICE -- an out-of-bounds read on a perfectly valid message.
+ *
+ * After the fix the selector counts only the typed rows, and the decoders
+ * reject a discriminant that resolves to no type.
+ *
+ * Message layout (AUTOMATIC TAGS):
+ *   30 07        -- SEQUENCE, length 7
+ *   80 01 NN     -- [0] procedureCode = NN
+ *   a1 02        -- [1] value (EXPLICIT), length 2
+ *   30 00        --   FailureB ::= SEQUENCE {}
+ */
+
+/* procedureCode 1 -> selects FailureB: must decode cleanly. */
+static const uint8_t valid_code1[] = {
+    0x30, 0x07, 0x80, 0x01, 0x01, 0xa1, 0x02, 0x30, 0x00
+};
+
+/* procedureCode 0 -> selects a row that defines no type: must fail, not crash. */
+static const uint8_t typeless_code0[] = {
+    0x30, 0x07, 0x80, 0x01, 0x00, 0xa1, 0x02, 0x30, 0x00
+};
+
+#ifdef ENABLE_LIBFUZZER
+
+int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+    UnsuccessfulOutcome_t *u = NULL;
+    ber_decode(0, &asn_DEF_UnsuccessfulOutcome, (void **)&u, Data, Size);
+    ASN_STRUCT_FREE(asn_DEF_UnsuccessfulOutcome, u);
+    return 0;
+}
+
+#else /* !ENABLE_LIBFUZZER */
+
+int main(void) {
+    UnsuccessfulOutcome_t *u = NULL;
+    asn_dec_rval_t rv;
+
+    /* A valid message which selects the typed row must round-trip. */
+    rv = ber_decode(0, &asn_DEF_UnsuccessfulOutcome, (void **)&u,
+                    valid_code1, sizeof(valid_code1));
+    fprintf(stderr, "valid procedureCode=1: code=%d consumed=%zu\n",
+            (int)rv.code, rv.consumed);
+    assert(rv.code == RC_OK);
+    assert(rv.consumed == sizeof(valid_code1));
+    assert(u != NULL);
+    assert(u->procedureCode == 1);
+    assert(u->value.present == UnsuccessfulOutcome__value_PR_FailureB);
+    ASN_STRUCT_FREE(asn_DEF_UnsuccessfulOutcome, u);
+    u = NULL;
+
+    /* A discriminant that resolves to no type must fail without crashing. */
+    rv = ber_decode(0, &asn_DEF_UnsuccessfulOutcome, (void **)&u,
+                    typeless_code0, sizeof(typeless_code0));
+    fprintf(stderr, "typeless procedureCode=0: code=%d consumed=%zu\n",
+            (int)rv.code, rv.consumed);
+    assert(rv.code == RC_FAIL);
+    ASN_STRUCT_FREE(asn_DEF_UnsuccessfulOutcome, u);
+
+    printf("OK: open type typeless-row regression test passed.\n");
+    return 0;
+}
+
+#endif /* ENABLE_LIBFUZZER */


### PR DESCRIPTION
## Summary

Fixes a security-relevant crash / memory-corruption in the open type decoders, reported by **Seaver Thorn (NCSU)**.

This is an instance of **CVE-2025-32892** (Information Object Set data-structure inconsistency: the type descriptor's element count disagrees with the IOS row count, so the type selector indexes a missing element → NULL deref / out-of-bounds; the ASN1spect `FindIOSMismatch` class). Note: the CVE advisory marks `vlm/asn1c` as *"not affected"* — attributing the mismatch to a velichkov-fork change — but this PR demonstrates the base repository **is** affected through a different root cause: an `OPTIONAL &Type` field that some objects omit (the typeless-row path), which makes the generated selector's `row+1` presence index overrun the open type CHOICE.

When an information object set leaves the open type's class field unspecified for some objects (an `OPTIONAL &Type` field omitted by part of the set — the pattern used throughout 3GPP elementary-procedure tables, e.g. `&UnsuccessfulOutcome OPTIONAL`), the open type CHOICE only contains the rows that actually define a type, but the generated type selector returned the **raw IOS row number** as the presence index.

Two defects followed, both reachable from untrusted decoder input (BER/OER/PER/XER):

1. **NULL dereference (DoS).** A value whose discriminant selects a *typeless* row makes the selector return a `NULL` type descriptor with a non-zero presence index. The decoders only checked the presence index, then dereferenced `selected.type_descriptor->op` → crash. This is the originally reported crash (`OPEN_TYPE.c:85`).

2. **Out-of-bounds access escalating to a write.** A value selecting a *later, defined* row (preceded by a typeless one) indexes past the CHOICE `elements[]` array. The out-of-bounds `.memb_offset` is then used as the address the inner value is decoded into, turning the read into an **out-of-bounds write of attacker-influenced data** (`inner_value = CHOICE_base + garbage_offset`, decoded into directly). This triggers even on otherwise well-formed input.

Severity: medium (the construct is uncommon in general ASN.1 but widespread in deployed 3GPP signaling). Security impact: high (remotely reachable OOB write of controlled data; not merely a hard failure).

## Fix

- **`libasn1compiler/asn1c_C.c`** (`emit_member_type_selector`): the generated selector now counts only rows that define a type to derive the presence index, and leaves the result cleared for a typeless row. For gap-free object sets this is identical to the previous `row+1`, so existing generated output is unchanged in behaviour.
- **`skeletons/OPEN_TYPE.c` / `OPEN_TYPE_oer.c`** (ber/xer/uper/oer getters): also reject a selection with a `NULL` type descriptor — defense in depth that also protects code generated by older compilers when linked against the updated skeletons.

The two fixes are complementary: the compiler change corrects both bugs for regenerated code; the skeleton guard independently stops the NULL-deref crash even with previously generated selectors.

## Tests

- New regression test **161** (`tests/tests-asn1c-compiler/161-open-type-no-type-OK.asn1` + `tests/tests-c-compiler/check-src/check-161.-fcompound-names.c`): a valid `procedureCode=1` message round-trips (`RC_OK`); a typeless `procedureCode=0` message fails cleanly (`RC_FAIL`, no crash). Verified to **fail before** the fix and **pass after**.
- Regenerated the affected IOS reference outputs (139/140/141/144/146/156) — diff is purely the new selector shape.
- Full `tests-c-compiler` suite green (43 PASS / 1 pre-existing XFAIL / 0 FAIL); `check-parsing.sh` green.

