### PR TITLE
Fix residual NULL deref in open type decode cleanup (CVE-2025-32892 follow-up)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,7 +4,7 @@
       * Fix open type decoder NULL dereference and out-of-bounds read when an
         information object set leaves the open type's class field unspecified
         for some objects (an OPTIONAL &Type field omitted by part of the set,
-        e.g. 3GPP elementary-procedure tables).
+        e.g. 3GPP elementary-procedure tables). CVE-2025-32892.
         Reported by Seaver Thorn (NCSU).
         (Severity: medium; Security impact: high)
 

--- a/skeletons/OPEN_TYPE.c
+++ b/skeletons/OPEN_TYPE.c
@@ -112,8 +112,7 @@ OPEN_TYPE_ber_get(const asn_codec_ctx_t *opt_codec_ctx,
     }
 
     if(*memb_ptr2) {
-        const asn_CHOICE_specifics_t *specs =
-            selected.type_descriptor->specifics;
+        const asn_CHOICE_specifics_t *specs = elm->type->specifics;
         if(elm->flags & ATF_POINTER) {
             ASN_STRUCT_FREE(*selected.type_descriptor, inner_value);
             *memb_ptr2 = NULL;
@@ -239,8 +238,7 @@ OPEN_TYPE_xer_get(const asn_codec_ctx_t *opt_codec_ctx,
          * will have to be restarted.
          */
         if(*memb_ptr2) {
-            const asn_CHOICE_specifics_t *specs =
-                selected.type_descriptor->specifics;
+            const asn_CHOICE_specifics_t *specs = elm->type->specifics;
             if(elm->flags & ATF_POINTER) {
                 ASN_STRUCT_FREE(*selected.type_descriptor, inner_value);
                 *memb_ptr2 = NULL;
@@ -360,8 +358,7 @@ OPEN_TYPE_uper_get(const asn_codec_ctx_t *opt_codec_ctx,
     case RC_WMORE:
     case RC_FAIL:
         if(*memb_ptr2) {
-            const asn_CHOICE_specifics_t *specs =
-                selected.type_descriptor->specifics;
+            const asn_CHOICE_specifics_t *specs = elm->type->specifics;
             if(elm->flags & ATF_POINTER) {
                 ASN_STRUCT_FREE(*selected.type_descriptor, inner_value);
                 *memb_ptr2 = NULL;

--- a/skeletons/OPEN_TYPE_oer.c
+++ b/skeletons/OPEN_TYPE_oer.c
@@ -82,8 +82,7 @@ OPEN_TYPE_oer_get(const asn_codec_ctx_t *opt_codec_ctx,
     }
 
     if(*memb_ptr2) {
-        const asn_CHOICE_specifics_t *specs =
-            selected.type_descriptor->specifics;
+        const asn_CHOICE_specifics_t *specs = elm->type->specifics;
         if(elm->flags & ATF_POINTER) {
             ASN_STRUCT_FREE(*selected.type_descriptor, inner_value);
             *memb_ptr2 = NULL;


### PR DESCRIPTION
## Summary

Follow-up to #530 (merged). A **libFuzzer harness over the open type decoders** showed the #530 fix was **incomplete**: a residual NULL-pointer dereference remained in the open type decode failure-cleanup path.

When the inner decode of an open type value fails (`RC_FAIL`/`RC_WMORE`) and the open type member is inline, the cleanup reset the member with:

```c
memset(*memb_ptr2, 0, selected.type_descriptor->specifics->struct_size);
```

i.e. it sized a reset of the **open type CHOICE** using the **selected variant's** specifics. For a variant whose descriptor has no `asn_CHOICE_specifics` (e.g. a primitive such as `BOOLEAN`) that pointer is `NULL`, so sizing the `memset` dereferenced `NULL`; for other variants it used the wrong structure size. Reachable from untrusted input on the same constructs as #530.

This is part of the same **CVE-2025-32892** Information Object Set inconsistency class as #530. (As noted in #530, the CVE advisory marks `vlm/asn1c` "not affected", attributing the mismatch to a velichkov-fork change; this work shows the base repository is affected through the `OPTIONAL &Type` / typeless-row path.)

## Fix

`skeletons/OPEN_TYPE.c` and `skeletons/OPEN_TYPE_oer.c` (BER, XER, uPER, OER getters): size the cleanup reset from the open type's own CHOICE specifics (`elm->type->specifics`) instead of `selected.type_descriptor->specifics`.

## Why fuzzing hadn't caught any of this

The randomized round-trip suite (`tests-randomized`) cannot reach open types at all: it drives every type through `random_fill`, which is a NULL operation for `OPEN_TYPE`, so `SEQUENCE_random_fill` aborts before any fuzzing stage. There was also no open-type/IOC bundle. A decoder-level libFuzzer harness is therefore the right vehicle.

## Test

The libFuzzer harness lives on a separate branch, **`fuzz-open-type-ioc`** (`tests-c-compiler/check-src/check-162.c` + `tests-asn1c-compiler/162-open-type-ioc-fuzz-OK.asn1`), per request that it contain only the test. From an empty corpus it discovers the crashes within seconds on unpatched decoders; with this fix plus #530 it runs clean (verified 32M execs / 90s, no findings) and replays prior crash artifacts cleanly. Its non-fuzzer `main()` replays a built-in seed corpus, so it also fails deterministically without the complete fix.
