### PR TITLE
tests: libFuzzer harness for open type / IOC decoders (CVE-2025-32892 coverage)

### DIFF
--- a/tests/tests-asn1c-compiler/162-open-type-ioc-fuzz-OK.asn1
+++ b/tests/tests-asn1c-compiler/162-open-type-ioc-fuzz-OK.asn1
@@ -1,0 +1,40 @@
+-- OK: Everything is fine
+
+-- Fuzz target: open type (Information Object Class / component relation)
+-- whose information object set has a row that does NOT define a type for the
+-- open type column (an OPTIONAL &Type field omitted by some objects).
+--
+-- Decoding bytes whose discriminant selects the typeless row used to
+-- dereference a NULL type descriptor, and decoding bytes selecting a later,
+-- defined row used to index past the open type CHOICE. A libFuzzer harness
+-- over the decoders (see tests-c-compiler/check-src/check-162.c) reaches both
+-- without any prior knowledge of the triggering input.
+
+-- iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+-- .spelio.software.asn1c.test (9363.1.5.1)
+-- .162
+
+ModuleOpenTypeIOCFuzz
+	{ iso org(3) dod(6) internet(1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 162 }
+	DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+	Id ::= INTEGER
+
+	T ::= SEQUENCE {
+		id     P.&id({Objs}),
+		value  P.&Type({Objs}{@id})
+	}
+
+	P ::= CLASS {
+		&id    Id UNIQUE,
+		&Type  OPTIONAL
+	} WITH SYNTAX { ID &id [TYPE &Type] }
+
+	-- The object for id 0 defines no &Type; id 1 selects Payload.
+	Objs P ::= { {ID 0} | {ID 1 TYPE Payload} }
+
+	Payload ::= BOOLEAN
+
+END

--- a/tests/tests-c-compiler/Makefile.am
+++ b/tests/tests-c-compiler/Makefile.am
@@ -65,6 +65,7 @@ TESTS += check-src/check-159.c
 TESTS += check-src/check-160.-gen-PER.c
 TESTS += check-src/check-161.-fcompound-names.c
 TESTS += check-src/check-161.-fcompound-names.-gen-PER.c
+TESTS += check-src/check-162.c
 
 if TEST_64BIT
 TESTS += check-src/check64-134.-gen-PER.c

--- a/tests/tests-c-compiler/check-src/check-162.c
+++ b/tests/tests-c-compiler/check-src/check-162.c
@@ -1,0 +1,79 @@
+#undef NDEBUG
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include <T.h>
+
+/*
+ * libFuzzer harness for the open type / Information Object Class decoder
+ * defects (NULL type descriptor dereference on a typeless discriminant, and
+ * out-of-bounds indexing of the open type CHOICE for a later defined row).
+ *
+ * Unlike the deterministic regression test (check-161), this harness has no
+ * knowledge of the triggering input: it simply hands arbitrary bytes to the
+ * decoder.  Fuzzing it discovers both defects within seconds on unpatched
+ * code, and stays clean once the open type selector / decoders are fixed.
+ *
+ * It is also why these defects escaped the existing fuzz suite: the randomized
+ * round-trip harness (tests-randomized) drives types through random_fill,
+ * which is a NULL operation for open types, so an open type can never reach
+ * the fuzzing stage there.
+ */
+
+static void
+decode_once(const uint8_t *Data, size_t Size) {
+    T_t *t = NULL;
+    (void)ber_decode(0, &asn_DEF_T, (void **)&t, Data, Size);
+    ASN_STRUCT_FREE(asn_DEF_T, t);
+}
+
+#ifdef ENABLE_LIBFUZZER
+
+int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+    decode_once(Data, Size);
+    return 0;
+}
+
+#else /* !ENABLE_LIBFUZZER */
+
+/*
+ * Without libFuzzer, replay a tiny built-in corpus through the same entry
+ * point.  It includes a value whose discriminant (id 0) selects the typeless
+ * row and a value whose discriminant (id 1) selects the later, defined row;
+ * both crash unpatched code and decode cleanly once fixed.  No assertion on
+ * the decode result is needed: the bug manifests as a crash / sanitizer abort.
+ *
+ *   30 LL  80 01 ID  a1 LL <inner>      -- SEQUENCE { [0] id, [1] value }
+ */
+int main(void) {
+    /* id 0 -> typeless row: NULL type descriptor dereference. */
+    static const uint8_t typeless[] = {
+        0x30, 0x07, 0x80, 0x01, 0x00, 0xa1, 0x02, 0x30, 0x00
+    };
+    /* id 1 -> defined row Payload (BOOLEAN), valid encoding. */
+    static const uint8_t defined[] = {
+        0x30, 0x08, 0x80, 0x01, 0x01, 0xa1, 0x03, 0x01, 0x01, 0xff
+    };
+    /*
+     * id 1 -> defined row, but the inner value is truncated so its decode
+     * fails: the failure-cleanup path used the *variant* type descriptor's
+     * (NULL) specifics to size the reset of the open type CHOICE.
+     */
+    static const uint8_t truncated[] = {
+        0x30, 0x80, 0x80, 0x01, 0x01, 0x81
+    };
+
+    decode_once(typeless, sizeof(typeless));
+    decode_once(defined, sizeof(defined));
+    decode_once(truncated, sizeof(truncated));
+
+    printf("OK: open type IOC fuzz seeds decoded without crashing.\n");
+    return 0;
+}
+
+#endif /* ENABLE_LIBFUZZER */


### PR DESCRIPTION
## Summary

Adds the fuzz coverage that the open type / Information Object Class decoders were missing (the gap behind #530 / #531 / **CVE-2025-32892**). Test only — no production code changes — per request that this branch contain just the test.

## Why this was needed

The randomized round-trip suite (`tests-randomized`) cannot reach open types at all: it drives every type through `random_fill`, which is a NULL operation for `asn_OP_OPEN_TYPE`, so `SEQUENCE_random_fill` calls a NULL op and aborts before any fuzzing happens. There was also no open-type/IOC bundle. So the IOS type-selector / open type decode paths were never fuzzed, and the CVE-2025-32892-class crashes went unnoticed.

## What this adds

- `tests/tests-asn1c-compiler/162-open-type-ioc-fuzz-OK.asn1` — an open type whose information object set has a typeless row (an `OPTIONAL &Type` omitted by one object).
- `tests/tests-c-compiler/check-src/check-162.c` — a libFuzzer harness over the decoders (`#ifdef ENABLE_LIBFUZZER`). Unlike the deterministic regression (check-161), it has no knowledge of the triggering input: from an empty corpus it discovers the crashes within seconds on unpatched decoders. Its non-fuzzer `main()` replays a small built-in seed corpus, so it also fails deterministically (no libFuzzer required).

## Behaviour

- Crashes on unpatched decoders (NULL type-descriptor deref; out-of-bounds CHOICE indexing; and the failure-cleanup NULL deref).
- Runs clean once both #530 and #531 are applied (verified: 32M execs / 90 s from an empty corpus, no findings; prior crash artifacts replay clean).

Depends on **#531** (and the already-merged #530) to pass; on plain `master` it still fails, by design, because the cleanup-path defect (#531) is not yet merged.
