### PR TITLE
configure.ac: don't fail when cross-compiling ASan leak probe

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -208,6 +208,8 @@ Check out https://clang.llvm.org/docs/AddressSanitizer.html#how-to-build])])
     CFLAGS="${CFLAGS} ${SANITIZER_CFLAGS}"
     AC_RUN_IFELSE([AC_LANG_PROGRAM()], [
         ASAN_ENV_FLAGS="${ASAN_ENV_FLAGS} ASAN_OPTIONS=detect_leaks=1"
+    ], [], [
+        AC_MSG_WARN([cannot determine ASan leak-detection support while cross-compiling; assuming detect_leaks=1 is unsupported])
     ])
     CFLAGS="${save_cflags}"
     unset ASAN_OPTIONS


### PR DESCRIPTION
AC_RUN_IFELSE executes a test binary to check whether the AddressSanitizer runtime supports leak detection. Without an action-if-cross-compiling branch, this aborts configure entirely under cross-compilation instead of degrading gracefully, since the resulting binary cannot run on the build host.

Add a cross-compiling fallback that warns and leaves ASAN_ENV_FLAGS unset, matching the pessimistic-default approach autoconf recommends for runtime checks and the soft-fail pattern already used elsewhere in this file for unsupported sanitizer features.