### PR TITLE
tests: runtime behavioral test for CVE-2025-32893 (check-164)

### DIFF
--- a/tests/tests-asn1c-compiler/164-ios-valueset-behavior-OK.asn1
+++ b/tests/tests-asn1c-compiler/164-ios-valueset-behavior-OK.asn1
@@ -1,0 +1,60 @@
+
+-- OK: Everything is fine
+
+-- Behavioral regression test for CVE-2025-32893. Companion to the
+-- compilation/golden test 163: where 163 checks that the *generated code*
+-- forks into two distinct information object tables, this spec is compiled
+-- and the generated decoder is actually *run* (see
+-- tests-c-compiler/check-src/check-164.-fcompound-names.c).
+--
+-- SetA and SetB intentionally reuse the SAME &id (1) but bind it to
+-- DIFFERENT types (IntPayload vs StrPayload). `Message.second' is
+-- parameterized by SetB, so its open type at id 1 must decode as an
+-- IA5String. Without the fix, asn1f_parameterization_fork() fails to fork the
+-- two parameterizations and `second' silently reuses SetA's table (id 1 maps
+-- to an INTEGER), so the very same encoding decodes differently. The runtime
+-- test detects that: a value valid under SetB is rejected, and vice versa.
+
+-- iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+-- .spelio.software.asn1c.test (9363.1.5.1)
+-- .164
+
+ModuleIosValuesetBehavior
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 164 }
+	DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+    Id ::= INTEGER
+
+    P ::= CLASS {
+        &id     Id UNIQUE,
+        &Type
+    } WITH SYNTAX { TYPE &Type IDENTIFIED BY &id }
+
+    IntPayload  ::= INTEGER
+    BoolPayload ::= BOOLEAN
+    StrPayload  ::= IA5String
+    OctPayload  ::= OCTET STRING
+
+    SetA P ::= {
+        {TYPE IntPayload  IDENTIFIED BY 1} |
+        {TYPE BoolPayload IDENTIFIED BY 2}
+    }
+
+    SetB P ::= {
+        {TYPE OctPayload  IDENTIFIED BY 2} |
+        {TYPE StrPayload  IDENTIFIED BY 1}
+    }
+
+    Message ::= SEQUENCE {
+        first   SpecializedContent {{SetA}},
+        second  SpecializedContent {{SetB}}
+    }
+
+    SpecializedContent {P : Set} ::= SEQUENCE {
+        id      P.&id({Set}),
+        value   P.&Type({Set}{@id})
+    }
+
+END

--- a/tests/tests-c-compiler/Makefile.am
+++ b/tests/tests-c-compiler/Makefile.am
@@ -66,6 +66,7 @@ TESTS += check-src/check-160.-gen-PER.c
 TESTS += check-src/check-161.-fcompound-names.c
 TESTS += check-src/check-161.-fcompound-names.-gen-PER.c
 TESTS += check-src/check-162.c
+TESTS += check-src/check-164.-fcompound-names.c
 
 if TEST_64BIT
 TESTS += check-src/check64-134.-gen-PER.c

--- a/tests/tests-c-compiler/check-src/check-164.-fcompound-names.c
+++ b/tests/tests-c-compiler/check-src/check-164.-fcompound-names.c
@@ -1,0 +1,65 @@
+#undef NDEBUG
+#include <stdio.h>
+#include <assert.h>
+
+#include <Message.h>
+
+/*
+ * Behavioral regression test for CVE-2025-32893.
+ *
+ * The companion compilation test (163) checks that the *generated code* forks
+ * into two distinct information object tables.  This test compiles spec 164
+ * and actually *runs* the generated decoder to prove the forked tables are
+ * enforced at decode time.
+ *
+ * Spec 164 defines two information object sets that bind the SAME &id (1) to
+ * DIFFERENT types:
+ *
+ *     SetA: id 1 -> IntPayload (INTEGER)
+ *     SetB: id 1 -> StrPayload (IA5String)
+ *
+ * Message.second is parameterized by SetB, so its open type at id 1 must
+ * decode as an IA5String and reject an INTEGER.  Without the fix,
+ * asn1f_parameterization_fork() treats the two parameterizations as identical
+ * (asn1p_expr_compare() ignored the VALUESET constraint), `second' silently
+ * reuses SetA's table, and the acceptance flips: an INTEGER is accepted at
+ * id 1 and the IA5String is rejected.  Either assertion below then fires.
+ */
+
+/* Message { first {id 1, INTEGER 42}, second {id 1, IA5String "hi"} } */
+static const uint8_t msg_setB_ia5[] = {
+    0x30, 0x15, 0xa0, 0x08, 0x80, 0x01, 0x01, 0xa1, 0x03, 0x02, 0x01, 0x2a,
+    0xa1, 0x09, 0x80, 0x01, 0x01, 0xa1, 0x04, 0x16, 0x02, 0x68, 0x69
+};
+
+/* Same, but second's open type carries INTEGER 42 (valid only under SetA). */
+static const uint8_t msg_setB_int[] = {
+    0x30, 0x14, 0xa0, 0x08, 0x80, 0x01, 0x01, 0xa1, 0x03, 0x02, 0x01, 0x2a,
+    0xa1, 0x08, 0x80, 0x01, 0x01, 0xa1, 0x03, 0x02, 0x01, 0x2a
+};
+
+static int
+decode_code(const uint8_t *buf, size_t size) {
+    Message_t *m = NULL;
+    asn_dec_rval_t rv = ber_decode(0, &asn_DEF_Message, (void **)&m, buf, size);
+    ASN_STRUCT_FREE(asn_DEF_Message, m);
+    return rv.code;
+}
+
+int main(void) {
+    int code;
+
+    /* SetB binds id 1 to IA5String: the IA5String payload must be accepted. */
+    code = decode_code(msg_setB_ia5, sizeof(msg_setB_ia5));
+    printf("second = IA5String at id 1: ber_decode -> %d\n", code);
+    assert(code == RC_OK);
+
+    /* SetB does NOT bind id 1 to INTEGER: the INTEGER payload must be rejected. */
+    code = decode_code(msg_setB_int, sizeof(msg_setB_int));
+    printf("second = INTEGER  at id 1: ber_decode -> %d\n", code);
+    assert(code != RC_OK);
+
+    printf("OK: open type at id 1 is constrained by SetB (IA5String),"
+           " not SetA (INTEGER).\n");
+    return 0;
+}


### PR DESCRIPTION
## What

Follow-up to #535 (CVE-2025-32893, already merged). That fix shipped with a
compilation test (163) that only **diffs generated source** — it can't be run,
because asn1c emits non-compilable C for value sets that bind an *inline*
built-in type to `&Type` (the cells come out as `{ "&Type", , ...`).

This adds a **runtime** behavioral test that compiles a spec and actually runs
the generated decoder, proving the forked information object tables are
enforced at decode time.

## How it discriminates

New spec `164-ios-valueset-behavior-OK.asn1` has two object sets binding the
**same `&id` (1)** to **different named types**:

- `SetA`: id 1 → `IntPayload` (INTEGER)
- `SetB`: id 1 → `StrPayload` (IA5String)

`Message.second` is parameterized by `SetB`. `check-164.-fcompound-names.c`
decodes two crafted messages and asserts:

- an IA5String payload at id 1 (valid under SetB) is **accepted** (`RC_OK`);
- an INTEGER payload at id 1 (valid only under SetA) is **rejected**.

Without the fix, `asn1f_parameterization_fork()` doesn't fork the two
parameterizations, `second` reuses SetA's table, and both assertions flip
(INTEGER accepted, IA5String rejected) — the program aborts.

## Verification

Built an unpatched compiler at `007e3b6b` (parent of the fix):

- unpatched: `second` collapses onto SetA's type; check-164 aborts with the
  IA5String value rejected (`ber_decode -> 2`).
- patched: check-164 passes.

Full `make check` is green under a default `./configure` (the c-compiler suite
goes 46 → 47 tests). The test references only `asn_DEF_Message` / `Message_t`,
so it compiles against both the patched and unpatched output and fails at
runtime rather than at compile time.
