### PR TITLE
Fix UPER forward-compat: skip unrecognized SEQUENCE/CHOICE extensions

### DIFF
--- a/skeletons/constr_CHOICE.c
+++ b/skeletons/constr_CHOICE.c
@@ -890,6 +890,32 @@ CHOICE_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
 			 * CHOICE as an absent selection so that an enclosing type can
 			 * keep decoding its following fields, instead of failing the
 			 * whole message (forward compatibility).
+			 *
+			 * Application-visible contract of this recovery: present==0 is
+			 * overloaded to mean both "no alternative selected" and "an
+			 * unknown extension alternative was received and skipped". The
+			 * forward-compatibility guarantee ends at decoding -- the
+			 * message decodes successfully and every field surrounding this
+			 * CHOICE is recovered, but the unknown alternative's contents
+			 * are discarded. Consequently any whole-message operation that
+			 * must revisit this CHOICE fails cleanly (never crashes) while
+			 * present==0:
+			 *   - asn_check_constraints() reports "no CHOICE element given"
+			 *     (see the else branch of CHOICE_constraint() below);
+			 *   - xer_fprint() / XER encoding of the enclosing value fails;
+			 *   - DER and UPER re-encoding fail (an absent selection is not
+			 *     encodable).
+			 * This is by design and matches the reference toolchain and asn1tools, which
+			 * likewise cannot re-encode an alternative they do not know: a
+			 * relaying application must carry the original octets rather
+			 * than decode-then-re-encode through this type.
+			 *
+			 * The skip's failure is reported conservatively as STARVED
+			 * (RC_WMORE): uper_open_type_skip() collapses every failure to
+			 * -1, and in this path the only non-starvation failure would be
+			 * an out-of-memory REALLOC deep inside uper_open_type_get(),
+			 * where the whole decode is aborting anyway (see the note in
+			 * uper_open_type_skip(), per_opentype.c).
 			 */
 			if(uper_open_type_skip(opt_codec_ctx, pd))
 				ASN__DECODE_STARVED;

--- a/skeletons/constr_CHOICE.c
+++ b/skeletons/constr_CHOICE.c
@@ -882,8 +882,22 @@ CHOICE_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
 		value = uper_get_nsnnwn(pd);
 		if(value < 0) ASN__DECODE_STARVED;
 		value += specs->ext_start;
-		if((unsigned)value >= td->elements_count)
-			ASN__DECODE_FAILED;
+		if((unsigned)value >= td->elements_count) {
+			/*
+			 * Unknown extension alternative: the peer selected a CHOICE
+			 * alternative added in a newer version of the type. X.691
+			 * wraps that value in an open type; skip it and present the
+			 * CHOICE as an absent selection so that an enclosing type can
+			 * keep decoding its following fields, instead of failing the
+			 * whole message (forward compatibility).
+			 */
+			if(uper_open_type_skip(opt_codec_ctx, pd))
+				ASN__DECODE_STARVED;
+			_set_present_idx(st, specs->pres_offset, specs->pres_size, 0);
+			rv.code = RC_OK;
+			rv.consumed = 0;
+			return rv;
+		}
 	}
 
 	/* Adjust if canonical order is different from natural order */

--- a/skeletons/per_opentype.c
+++ b/skeletons/per_opentype.c
@@ -274,6 +274,20 @@ uper_open_type_skip(const asn_codec_ctx_t *ctx, asn_per_data_t *pd) {
     s_op.uper_decoder = uper_sot_suck;
 
 	rv = uper_open_type_get(ctx, &s_td, 0, 0, pd);
+	/*
+	 * The rich rval code is collapsed to a boolean here, so callers
+	 * (constr_SEQUENCE.c, constr_CHOICE.c) uniformly map any failure to
+	 * ASN__DECODE_STARVED (RC_WMORE). uper_open_type_get() can in principle
+	 * report RC_FAIL as well -- for the skip use case only via an
+	 * out-of-memory REALLOC in uper_open_type_get_simple(), since the
+	 * uper_sot_suck() decoder itself never fails and an integral-octet open
+	 * type leaves no non-zero padding. Distinguishing that one case would
+	 * require widening this public API's return contract and updating both
+	 * callers, for a state (OOM mid-decode) where the whole decode is
+	 * already aborting and reporting "want more data" is imprecise but
+	 * harmless: the buffer is not advanced and no caller recovers by
+	 * retrying. The conservative STARVED mapping is therefore retained.
+	 */
 	if(rv.code != RC_OK)
 		return -1;
 	else

--- a/skeletons/per_opentype.c
+++ b/skeletons/per_opentype.c
@@ -295,7 +295,17 @@ uper_sot_suck(const asn_codec_ctx_t *ctx, const asn_TYPE_descriptor_t *td,
 	(void)constraints;
 	(void)sptr;
 
-	while(per_get_few_bits(pd, 24) >= 0);
+	/*
+	 * Consume (skip) the open type content of an unrecognized extension.
+	 * The content is always an integral number of octets (X.691), so step
+	 * 8 bits at a time. per_get_few_bits() has all-or-nothing semantics:
+	 * a 24-bit step reads nothing once fewer than 24 bits remain, so any
+	 * open type whose length is not a multiple of 3 octets is under-read,
+	 * leaving residual bits that derail decoding of the following fields
+	 * (e.g. a 1-octet extension fails with "Too large padding").
+	 * The step MUST stay a divisor of 8.
+	 */
+	while(per_get_few_bits(pd, 8) >= 0);
 
 	rv.code = RC_OK;
 	rv.consumed = pd->moved;

--- a/tests/tests-asn1c-compiler/165-uper-extension-skip-OK.asn1
+++ b/tests/tests-asn1c-compiler/165-uper-extension-skip-OK.asn1
@@ -1,0 +1,38 @@
+-- OK: Everything is fine
+
+-- iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+-- .spelio.software.asn1c.test (9363.1.5.1)
+-- .165
+
+-- Forward compatibility of UPER decoding: this module is the OLD
+-- version of the protocol.  The test decodes byte streams produced
+-- by a NEWER version (with extension additions after "...") and
+-- expects the unknown extensions to be skipped, with all root fields
+-- recovered.
+
+ModuleUPERExtensionSkip
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 165 }
+	DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+	T ::= SEQUENCE {
+		seq1 MsgCount,
+		...
+	}
+
+	C ::= CHOICE {
+		c1 MsgCount,
+		c2 MsgCount,
+		...
+	}
+
+	N ::= SEQUENCE {
+		a MsgCount,
+		ch C,
+		b MsgCount
+	}
+
+	MsgCount ::= INTEGER (0..127)
+
+END

--- a/tests/tests-asn1c-compiler/165-uper-extension-skip-OK.asn1
+++ b/tests/tests-asn1c-compiler/165-uper-extension-skip-OK.asn1
@@ -33,6 +33,12 @@ BEGIN
 		b MsgCount
 	}
 
+	M ::= SEQUENCE {
+		a MsgCount,
+		t T,
+		b MsgCount
+	}
+
 	MsgCount ::= INTEGER (0..127)
 
 END

--- a/tests/tests-c-compiler/Makefile.am
+++ b/tests/tests-c-compiler/Makefile.am
@@ -67,6 +67,7 @@ TESTS += check-src/check-161.-fcompound-names.c
 TESTS += check-src/check-161.-fcompound-names.-gen-PER.c
 TESTS += check-src/check-162.c
 TESTS += check-src/check-164.-fcompound-names.c
+TESTS += check-src/check-165.-gen-PER.c
 
 if TEST_64BIT
 TESTS += check-src/check64-134.-gen-PER.c

--- a/tests/tests-c-compiler/check-src/check-165.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-165.-gen-PER.c
@@ -2,11 +2,19 @@
  * UPER forward compatibility: an old decoder must skip the unknown
  * extension additions produced by a newer version of the protocol and
  * keep decoding the remaining fields (X.691).
- * The golden byte streams below were produced by a commercial ASN.1
- * toolchain (the project's interoperability reference) from a newer
- * version of this module:
- *   T': SEQUENCE { seq1 MsgCount, ..., [[seq8 seq9]], seq10 } (all present)
+ * The golden byte streams below were produced from abstract values by
+ * a commercial ASN.1 toolchain (the project's interoperability
+ * reference), cross-checked with the independent asn1tools codec, from
+ * a newer version of this module:
+ *   T': SEQUENCE { seq1 MsgCount, ..., seq10 MsgCount OPTIONAL }
+ *       (a single flat, ungrouped extension addition -- value
+ *       { seq1 1, seq10 9 })
  *   C': CHOICE { c1, c2, ..., c3 MsgCount }                   (c3 chosen)
+ *   M': SEQUENCE { a MsgCount, t T', b MsgCount }
+ *       (value { a 5, t { seq1 1, seq10 9 }, b 7 }, to check that a
+ *       SEQUENCE field *following* another SEQUENCE with a skipped
+ *       extension is also recovered correctly, mirroring the N test
+ *       below for CHOICE)
  */
 #undef	NDEBUG
 #include <stdio.h>
@@ -17,18 +25,18 @@
 #include <T.h>
 #include <C.h>
 #include <N.h>
+#include <M.h>
 
 int main() {
 	asn_dec_rval_t rv;
 
 	/*
-	 * A SEQUENCE with two unknown extension additions present.
-	 * ext-present=1, seq1=1, 2-bit ext bitmap 11, and two open types
-	 * (1 and 2 bytes of content: not a multiple of 3, which used to
-	 * derail the 24-bit skipping step in uper_sot_suck()).
+	 * A SEQUENCE with one unknown extension addition present:
+	 * ext-present=1, seq1=1, 1-bit ext bitmap 1, one open type
+	 * (1 byte of content, holding seq10=9 padded to an octet).
 	 */
 	static const unsigned char seq_ext[] =
-		"\x81\x03\x80\x88\x00\x89\x00";
+		"\x81\x01\x01\x12";
 	T_t *t = 0;
 	rv = uper_decode(0, &asn_DEF_T, (void *)&t, seq_ext,
 			sizeof(seq_ext) - 1, 0, 0);
@@ -63,6 +71,22 @@ int main() {
 	assert(n->ch.present == C_PR_NOTHING);
 	assert(n->b == 7);
 	ASN_STRUCT_FREE(asn_DEF_N, n);
+
+	/*
+	 * A SEQUENCE-with-skipped-extension nested in another SEQUENCE:
+	 * the field after it must still be recovered (the SEQUENCE
+	 * analogue of the CHOICE case above).
+	 * { a 5, t { seq1 1 (seq10 unknown, skipped) }, b 7 }
+	 */
+	static const unsigned char nest_seq[] = "\x0b\x02\x02\x02\x24\x1c";
+	M_t *m = 0;
+	rv = uper_decode(0, &asn_DEF_M, (void *)&m, nest_seq,
+			sizeof(nest_seq) - 1, 0, 0);
+	assert(rv.code == RC_OK);
+	assert(m->a == 5);
+	assert(m->t.seq1 == 1);
+	assert(m->b == 7);
+	ASN_STRUCT_FREE(asn_DEF_M, m);
 
 	/* Sanity: same-version encodings still round-trip. */
 	unsigned char buf[8];

--- a/tests/tests-c-compiler/check-src/check-165.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-165.-gen-PER.c
@@ -1,0 +1,87 @@
+/*
+ * UPER forward compatibility: an old decoder must skip the unknown
+ * extension additions produced by a newer version of the protocol and
+ * keep decoding the remaining fields (X.691).
+ * The golden byte streams below were produced by a commercial ASN.1
+ * toolchain (the project's interoperability reference) from a newer
+ * version of this module:
+ *   T': SEQUENCE { seq1 MsgCount, ..., [[seq8 seq9]], seq10 } (all present)
+ *   C': CHOICE { c1, c2, ..., c3 MsgCount }                   (c3 chosen)
+ */
+#undef	NDEBUG
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include <T.h>
+#include <C.h>
+#include <N.h>
+
+int main() {
+	asn_dec_rval_t rv;
+
+	/*
+	 * A SEQUENCE with two unknown extension additions present.
+	 * ext-present=1, seq1=1, 2-bit ext bitmap 11, and two open types
+	 * (1 and 2 bytes of content: not a multiple of 3, which used to
+	 * derail the 24-bit skipping step in uper_sot_suck()).
+	 */
+	static const unsigned char seq_ext[] =
+		"\x81\x03\x80\x88\x00\x89\x00";
+	T_t *t = 0;
+	rv = uper_decode(0, &asn_DEF_T, (void *)&t, seq_ext,
+			sizeof(seq_ext) - 1, 0, 0);
+	assert(rv.code == RC_OK);
+	assert(t->seq1 == 1);
+	ASN_STRUCT_FREE(asn_DEF_T, t);
+
+	/*
+	 * A CHOICE selecting an alternative unknown to this version:
+	 * ext=1, extension index 0 (c3), open type of 1 byte (value 9).
+	 * Must decode as "no alternative selected" instead of failing.
+	 */
+	static const unsigned char cho_ext[] = "\x80\x01\x12";
+	C_t *c = 0;
+	rv = uper_decode(0, &asn_DEF_C, (void *)&c, cho_ext,
+			sizeof(cho_ext) - 1, 0, 0);
+	assert(rv.code == RC_OK);
+	assert(c->present == C_PR_NOTHING);
+	ASN_STRUCT_FREE(asn_DEF_C, c);
+
+	/*
+	 * The same unknown CHOICE alternative nested in a SEQUENCE:
+	 * the fields after the CHOICE must still be recovered.
+	 * { a 5, ch c3:9, b 7 }
+	 */
+	static const unsigned char nest_ext[] = "\x0b\x00\x02\x24\x1c";
+	N_t *n = 0;
+	rv = uper_decode(0, &asn_DEF_N, (void *)&n, nest_ext,
+			sizeof(nest_ext) - 1, 0, 0);
+	assert(rv.code == RC_OK);
+	assert(n->a == 5);
+	assert(n->ch.present == C_PR_NOTHING);
+	assert(n->b == 7);
+	ASN_STRUCT_FREE(asn_DEF_N, n);
+
+	/* Sanity: same-version encodings still round-trip. */
+	unsigned char buf[8];
+	T_t t0;
+	memset(&t0, 0, sizeof(t0));
+	t0.seq1 = 5;
+	asn_enc_rval_t er = uper_encode_to_buffer(&asn_DEF_T, 0, &t0,
+			buf, sizeof(buf));
+	assert(er.encoded == 8);
+	assert(buf[0] == 0x05);
+
+	C_t c0;
+	memset(&c0, 0, sizeof(c0));
+	c0.present = C_PR_c1;
+	c0.choice.c1 = 9;
+	er = uper_encode_to_buffer(&asn_DEF_C, 0, &c0, buf, sizeof(buf));
+	assert(er.encoded == 9);
+	assert(buf[0] == 0x04 && buf[1] == 0x80);
+
+	printf("Finished OK\n");
+	return 0;
+}

--- a/tests/tests-skeletons/Makefile.am
+++ b/tests/tests-skeletons/Makefile.am
@@ -17,7 +17,8 @@ check_PROGRAMS =            \
     check-OER-NativeEnumerated \
     check-PER-support       \
     check-PER-UniversalString  \
-    check-PER-INTEGER
+    check-PER-INTEGER       \
+    check-PER-opentype
 
 if EXPLICIT_M32
 check_PROGRAMS +=                   \
@@ -37,7 +38,8 @@ check_PROGRAMS +=                   \
     check-32-OER-NativeEnumerated   \
     check-32-PER-support            \
     check-32-PER-UniversalString    \
-    check-32-PER-INTEGER
+    check-32-PER-INTEGER            \
+    check-32-PER-opentype
 
 check_32_ber_tlv_tag_CFLAGS=$(CFLAGS_M32)
 check_32_ber_tlv_tag_LDADD=$(LDADD_32)
@@ -90,6 +92,9 @@ check_32_PER_UniversalString_SOURCES=check-PER-UniversalString.c
 check_32_PER_INTEGER_CFLAGS=$(CFLAGS_M32)
 check_32_PER_INTEGER_LDADD=$(LDADD_32)
 check_32_PER_INTEGER_SOURCES=check-PER-INTEGER.c
+check_32_PER_opentype_CFLAGS=$(CFLAGS_M32)
+check_32_PER_opentype_LDADD=$(LDADD_32)
+check_32_PER_opentype_SOURCES=check-PER-opentype.c
 
 LDADD_32 = -lm $(top_builddir)/skeletons/libasn1cskeletons_c89_32.la
 endif

--- a/tests/tests-skeletons/check-PER-opentype.c
+++ b/tests/tests-skeletons/check-PER-opentype.c
@@ -1,0 +1,58 @@
+/*
+ * Regression test for uper_open_type_skip() (per_opentype.c).
+ * An unrecognized extension's open type content is an integral number
+ * of octets; skipping it must consume exactly the length determinant
+ * plus the content, for every content length, leaving subsequent
+ * fields decodable.
+ */
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <asn_application.h>
+#include <per_support.h>
+#include <per_opentype.h>
+
+static void
+check_skip(size_t content_bytes, int fill) {
+    uint8_t buf[16];
+    asn_per_data_t pd;
+    int ret;
+    int32_t next;
+
+    assert(content_bytes + 2 <= sizeof(buf));
+
+    /* [length determinant][content x N][next field sentinel] */
+    buf[0] = (uint8_t)content_bytes; /* X.691 #11.9 short form */
+    memset(&buf[1], fill, content_bytes);
+    buf[1 + content_bytes] = 0x5A;
+
+    memset(&pd, 0, sizeof(pd));
+    pd.buffer = buf;
+    pd.nboff = 0;
+    pd.nbits = 8 * (2 + content_bytes);
+
+    ret = uper_open_type_skip(NULL, &pd);
+    fprintf(stderr, "Skip open type of %zu bytes of 0x%02x => %d, moved %zu\n",
+            content_bytes, fill, ret, pd.moved);
+    assert(ret == 0);
+
+    /* Exactly the open type was consumed... */
+    assert(pd.moved == 8 * (1 + content_bytes));
+
+    /* ...so the next field is still decodable. */
+    next = per_get_few_bits(&pd, 8);
+    assert(next == 0x5A);
+}
+
+int
+main(void) {
+    size_t n;
+
+    for(n = 0; n <= 10; n++) {
+        check_skip(n, 0xAA); /* Non-zero contents */
+        check_skip(n, 0x00); /* All-zeros contents */
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Background

Addresses the long-standing open-type skip report in issue #40. An older decoder built against a v1 schema must be able to skip an unknown SEQUENCE extension addition or CHOICE extension alternative added by a v2 peer and keep decoding the remaining root fields — this is the entire point of extensibility markers (`...`) in X.680. Before this fix, asn1c instead corrupted or aborted decoding of everything after the unknown extension.

## What

Two fixes for UPER forward compatibility with extensible types, so a decoder built from an **older** schema version can skip unknown extensions and keep decoding (interoperating byte-for-byte with a major commercial ASN.1 toolchain and the independent open-source `asn1tools` reference — `pip install asn1tools` to reproduce).

- `per_opentype.c` — skip an unrecognized extension's open type in **8-bit** steps instead of 24. `per_get_few_bits()` is all-or-nothing, so a 24-bit step under-reads any open type whose length is not a multiple of 3 octets, derailing the following fields.
- `constr_CHOICE.c` — on an **unknown extension alternative**, skip the open type and present the CHOICE as an absent selection instead of `ASN__DECODE_FAILED`. This failure happens before the open-type skip path, so the `per_opentype.c` fix alone does not fix CHOICE.

## Root cause

- `skeletons/per_opentype.c`: the unrecognized-extension skip loop advanced the bit cursor 24 bits at a time. `per_get_few_bits()` has all-or-nothing semantics, so any open type whose byte length isn't a multiple of 3 leaves the cursor misaligned for everything that follows in the PDU.
- `skeletons/constr_CHOICE.c`: an unknown extension alternative tag hit `ASN__DECODE_FAILED` before ever reaching the open-type skip path, so the fix above could not help CHOICE on its own.

## Fix

Both sites now walk the open type in 8-bit steps (the smallest common denominator of any content length), and CHOICE treats an unrecognized extension alternative as "skip the open type, report absent" rather than failing the whole message.


## Validation

Differential testing against a major commercial ASN.1 toolchain (gold reference) and asn1tools (independent open-source reference):

- **SEQUENCE**: gold extension bytes decode correctly after the fix; a 0..10-byte extension boundary sweep goes from 7 failures to 11/11 pass, matching asn1tools; plain-extension encode is byte-identical to the reference toolchain.
- **CHOICE**: nested `SEQUENCE{a, ch, b}` with `ch` = an unknown extension alternative recovers `a` and `b` (`ch` absent), matching asn1tools `{a, (None,None), b}`; encode of all alternatives is byte-identical to the reference toolchain.

Note: re-encoding an *unknown* extension is intentionally unsupported — the commercial toolchain and asn1tools behave the same way (the original contents are not retained).

## Tests

- `tests/tests-skeletons/check-PER-opentype.c` — unit test of `uper_open_type_skip()` over content lengths 0..10 bytes x {0x00, 0xAA}: the length determinant plus content are consumed exactly and the following field stays decodable. Fails against the old 24-bit stepping (a 1-octet open type is under-read).
- `tests/tests-asn1c-compiler/165-uper-extension-skip-OK.asn1` + `tests/tests-c-compiler/check-src/check-165.-gen-PER.c` — end-to-end decode of reference byte streams from a newer protocol version: an old decoder skips an unknown SEQUENCE extension addition and an unknown CHOICE alternative and still recovers the surrounding root fields, including both a CHOICE nested in a SEQUENCE and a SEQUENCE-with-skipped-extension nested in a SEQUENCE, plus a same-version encode sanity check.

Combined-integration verification (all three UPER extension fixes in this series merged on one ref): full `make check` shows zero new failures vs pristine master, and an end-to-end replay of the original reporter's corpus (every golden `.uper` vector x every older-version decoder, per type) has **zero true failures** (the `[[...]]` extension-group cells are out of scope for this series, tracked separately).

### Evidence correction (2026-07-15)

An independent review found that check-165's original SEQUENCE golden vector (`81 03 80 88 00 89 00`) was mis-described: under the grouped-extension (`[[seq8, seq9]]`) reading the comment implied, that byte string has the extension-addition-group present bit set but both group members absent and non-zero padding bits — not a valid encoding under X.691 §19.9/§11.1.3.1, and not something a spec-conforming peer would ever emit in strict mode. It only happens to be a legal encoding under a different (flat, ungrouped) reading of the extension.

The vector has been replaced with `81 01 01 12`, independently re-derived from the abstract value `{ seq1 1, seq10 9 }` and cross-checked byte-for-byte by both a commercial ASN.1 toolchain and `asn1tools` against a newer module with a single flat extension addition (`T' ::= SEQUENCE { seq1 MsgCount, ..., seq10 MsgCount OPTIONAL }`). The in-code comment and the surrounding prose have been corrected to match (no more "grouped", no more "all extensions present"). A new `M` type/assertion (`SEQUENCE { a, t T, b }`) was also added to check-165 to cover a SEQUENCE field following another SEQUENCE with a skipped extension — the SEQUENCE analogue of the existing CHOICE-nested-in-SEQUENCE (`N`) case. The fix's code and its other conclusions are unaffected; only this one golden vector and its description were wrong.

## Behavior change & migration

- **New observable state**: a CHOICE that decodes an unknown extension alternative now reports `present == 0` (the same value used for "no alternative selected") instead of failing the whole decode. This is overloaded by design: it lets an enclosing type keep decoding its remaining fields.
- **Migration safety net**: any whole-message operation that must revisit that CHOICE fails cleanly (never crashes) while `present == 0` — `asn_check_constraints()` reports "no CHOICE element given", and XER/DER/UPER re-encoding fail (an absent selection is not encodable). Calling `asn_check_constraints()` after decode is therefore an equivalent way to recover the old "reject" semantics for callers that need it. This matches the reference toolchain and asn1tools, which likewise cannot re-encode an alternative they do not know — a relaying application must carry the original octets rather than decode-then-re-encode through this type.
- A companion PR in this series adds a compile-time escape hatch (`ASN_REJECT_UNKNOWN_EXTENSIONS`) restoring clean `RC_FAIL` at exactly this site.

The skip's failure is reported conservatively as STARVED (`RC_WMORE`); the only non-starvation failure in this path is an out-of-memory `REALLOC`, where the decode is aborting regardless, so the boolean return of `uper_open_type_skip()` is left unchanged and the limitation is documented in-code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

