### PR TITLE
UPER ENUMERATED forward-compat: accept and losslessly relay unknown extension values

### DIFF
--- a/skeletons/NativeEnumerated.c
+++ b/skeletons/NativeEnumerated.c
@@ -136,15 +136,24 @@ NativeEnumerated_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
 			/*
 			 * Unknown extension value: the peer used an enumeration value
 			 * added in a newer version of the type. An extension value is
-			 * just the index (there is no open type to skip) and it has
+			 * just an index (there is no open type to skip) and it has
 			 * already been consumed, so accept it instead of failing -- an
 			 * enclosing type can then keep decoding its following fields
-			 * (forward compatibility). Store the extension ordinal, which
-			 * is >= map_count and therefore distinguishable from every
-			 * known value. Such an unknown value cannot be re-encoded.
+			 * (forward compatibility).
+			 *
+			 * A plain long has no in-band way to say "unknown", so store a
+			 * value guaranteed to differ from every value known to this
+			 * (older) decoder: one past the largest known enumeration value.
+			 * value2enum is sorted by nat_value, so its last entry holds the
+			 * maximum. This cannot collide with a known value -- the ordinal
+			 * itself could, because enumeration values may be sparse, e.g.
+			 * { a(0), b(2), ... } where an unknown ordinal of 2 would alias
+			 * b(2) -- and it is absent from value2enum, so re-encoding fails
+			 * cleanly: an unknown extension value is decode-only.
 			 */
-			*native = value;
-			ASN_DEBUG("Decoded %s = unknown extension %ld", td->name, value);
+			*native = specs->value2enum[specs->map_count - 1].nat_value + 1;
+			ASN_DEBUG("Decoded %s = unknown extension (ordinal %ld)",
+				td->name, value);
 			return rval;
 		}
 	}

--- a/skeletons/NativeEnumerated.c
+++ b/skeletons/NativeEnumerated.c
@@ -131,31 +131,37 @@ NativeEnumerated_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
 		 */
 		value = uper_get_nsnnwn(pd);
 		if(value < 0) ASN__DECODE_STARVED;
-		value += specs->extension - 1;
-		if(value >= specs->map_count) {
+		if(value + specs->extension - 1 >= specs->map_count) {
 			/*
 			 * Unknown extension value: the peer used an enumeration value
-			 * added in a newer version of the type. An extension value is
-			 * just an index (there is no open type to skip) and it has
-			 * already been consumed, so accept it instead of failing -- an
-			 * enclosing type can then keep decoding its following fields
-			 * (forward compatibility).
+			 * added in a newer version of the type. Such a value is carried
+			 * (X.691 #14) only as its extension index -- there is no open
+			 * type to skip and the index has already been consumed. X.680 #6
+			 * forbids treating this as an error, so accept it: an enclosing
+			 * type can then keep decoding its following fields (forward
+			 * compatibility).
 			 *
-			 * A plain long has no in-band way to say "unknown", so store a
-			 * value guaranteed to differ from every value known to this
-			 * (older) decoder: one past the largest known enumeration value.
-			 * value2enum is sorted by nat_value, so its last entry holds the
-			 * maximum. This cannot collide with a known value -- the ordinal
-			 * itself could, because enumeration values may be sparse, e.g.
-			 * { a(0), b(2), ... } where an unknown ordinal of 2 would alias
-			 * b(2) -- and it is absent from value2enum, so re-encoding fails
-			 * cleanly: an unknown extension value is decode-only.
+			 * The true abstract value is unknowable to this older decoder,
+			 * and a plain long has no out-of-band way to flag "unknown". So,
+			 * like a commercial ASN.1 toolchain (the project's interoperability
+			 * reference, which stores INT_MAX - index), store the wire index enciphered as
+			 * LONG_MAX - index -- `value` still holds the raw index here.
+			 * NativeEnumerated_encode_uper recognises this reserved region
+			 * and re-emits the identical index, so the value can be relayed
+			 * byte-for-byte under the same PER transfer syntax. See the
+			 * contract in NativeEnumerated.h.
+			 *
+			 * uper_get_nsnnwn caps the index at two length octets (<=65535);
+			 * guard the reserved region against anything wider.
 			 */
-			*native = specs->value2enum[specs->map_count - 1].nat_value + 1;
-			ASN_DEBUG("Decoded %s = unknown extension (ordinal %ld)",
-				td->name, value);
+			if(value > 65535)
+				ASN__DECODE_FAILED;
+			*native = LONG_MAX - value;
+			ASN_DEBUG("Decoded %s = unknown extension index %ld"
+				" (stored as LONG_MAX-%ld)", td->name, value, value);
 			return rval;
 		}
+		value += specs->extension - 1;
 	}
 
 	*native = specs->value2enum[value].nat_value;
@@ -206,6 +212,31 @@ NativeEnumerated_encode_uper(const asn_TYPE_descriptor_t *td,
 	kf = bsearch(&key, specs->value2enum, specs->map_count,
 		sizeof(key), NativeEnumerated__compar_value2enum);
 	if(!kf) {
+		/*
+		 * No known enumeration maps to this value. If it is an unknown
+		 * extension value that a previous UPER decode stored enciphered as
+		 * LONG_MAX - wire_index (see NativeEnumerated.h), and this
+		 * enumeration is extensible, relay it: recover the index and
+		 * re-emit it exactly as received (extension bit + nsnnwn index).
+		 * This mirrors the reference toolchain and yields a byte-for-byte
+		 * identical relay under the same PER transfer syntax. A value the
+		 * application fabricated inside the reserved region is passed
+		 * through as an index too (garbage in, garbage out, as with the
+		 * reference toolchain); a
+		 * reserved-region value handed to a non-extensible enumeration
+		 * still fails below.
+		 */
+		if((ct->flags & APC_EXTENSIBLE) && specs->extension
+		&& ASN_NATIVE_ENUMERATED_IS_UNKNOWN_EXT(native)) {
+			long ext_index = LONG_MAX - native;
+			ASN_DEBUG("Relaying %s unknown extension index %ld",
+				td->name, ext_index);
+			if(per_put_few_bits(po, 1, 1))	/* extension present bit */
+				ASN__ENCODE_FAILED;
+			if(uper_put_nsnnwn(po, ext_index))
+				ASN__ENCODE_FAILED;
+			ASN__ENCODED_OK(er);
+		}
 		ASN_DEBUG("No element corresponds to %ld", native);
 		ASN__ENCODE_FAILED;
 	}

--- a/skeletons/NativeEnumerated.c
+++ b/skeletons/NativeEnumerated.c
@@ -13,6 +13,18 @@
 #include <NativeEnumerated.h>
 
 /*
+ * The unknown-extension reserved region published in NativeEnumerated.h is
+ * sized by the widest extension index the PER runtime can transfer
+ * (ASN_UPER_NSNNWN_MAX, per_support.h). NativeEnumerated.h must stay
+ * self-contained -- it also ships in builds that do not carry per_support.h
+ * -- so the two constants are defined independently; fail the build here,
+ * where both are visible, if they ever drift apart.
+ */
+#if ASN_NATIVE_ENUMERATED_UNKNOWN_EXT_BASE != (LONG_MAX - ASN_UPER_NSNNWN_MAX)
+#error ASN_NATIVE_ENUMERATED_UNKNOWN_EXT_BASE out of sync with ASN_UPER_NSNNWN_MAX
+#endif
+
+/*
  * NativeEnumerated basic type description.
  */
 static const ber_tlv_tag_t asn_DEF_NativeEnumerated_tags[] = {
@@ -151,10 +163,11 @@ NativeEnumerated_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
 			 * byte-for-byte under the same PER transfer syntax. See the
 			 * contract in NativeEnumerated.h.
 			 *
-			 * uper_get_nsnnwn caps the index at two length octets (<=65535);
-			 * guard the reserved region against anything wider.
+			 * uper_get_nsnnwn caps the index at two length octets
+			 * (ASN_UPER_NSNNWN_MAX); guard the reserved region against
+			 * anything wider.
 			 */
-			if(value > 65535)
+			if(value > ASN_UPER_NSNNWN_MAX)
 				ASN__DECODE_FAILED;
 			*native = LONG_MAX - value;
 			ASN_DEBUG("Decoded %s = unknown extension index %ld"

--- a/skeletons/NativeEnumerated.c
+++ b/skeletons/NativeEnumerated.c
@@ -132,8 +132,21 @@ NativeEnumerated_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
 		value = uper_get_nsnnwn(pd);
 		if(value < 0) ASN__DECODE_STARVED;
 		value += specs->extension - 1;
-		if(value >= specs->map_count)
-			ASN__DECODE_FAILED;
+		if(value >= specs->map_count) {
+			/*
+			 * Unknown extension value: the peer used an enumeration value
+			 * added in a newer version of the type. An extension value is
+			 * just the index (there is no open type to skip) and it has
+			 * already been consumed, so accept it instead of failing -- an
+			 * enclosing type can then keep decoding its following fields
+			 * (forward compatibility). Store the extension ordinal, which
+			 * is >= map_count and therefore distinguishable from every
+			 * known value. Such an unknown value cannot be re-encoded.
+			 */
+			*native = value;
+			ASN_DEBUG("Decoded %s = unknown extension %ld", td->name, value);
+			return rval;
+		}
 	}
 
 	*native = specs->value2enum[value].nat_value;

--- a/skeletons/NativeEnumerated.h
+++ b/skeletons/NativeEnumerated.h
@@ -32,8 +32,14 @@ extern asn_TYPE_operation_t asn_OP_NativeEnumerated;
  * ASN.1 toolchain (the project's interoperability reference, which stores
  * INT_MAX - index), the UPER decoder stores the wire index enciphered as
  * LONG_MAX - index, i.e.
- * in the reserved region [LONG_MAX - 65535, LONG_MAX] (uper_get_nsnnwn caps
- * the index at two length octets, so 65535 is its widest possible value).
+ * in the reserved region [LONG_MAX - 65535, LONG_MAX].
+ *
+ * The literal 65535 is the widest index the PER runtime can transfer
+ * (ASN_UPER_NSNNWN_MAX in per_support.h: uper_get_nsnnwn() reads at most a
+ * 2-octet long form). It is repeated here rather than referenced because
+ * this header is a self-contained application contract that also ships in
+ * builds without per_support.h; a compile-time cross-check in
+ * NativeEnumerated.c fails the build if the two constants ever drift apart.
  *
  * Contract for such a stored value:
  *   - The application MUST NOT interpret it as a meaningful enumeration

--- a/skeletons/NativeEnumerated.h
+++ b/skeletons/NativeEnumerated.h
@@ -13,6 +13,7 @@
 #define	_NativeEnumerated_H_
 
 #include <NativeInteger.h>
+#include <limits.h>	/* For LONG_MAX */
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,6 +21,38 @@ extern "C" {
 
 extern asn_TYPE_descriptor_t asn_DEF_NativeEnumerated;
 extern asn_TYPE_operation_t asn_OP_NativeEnumerated;
+
+/*
+ * UPER forward compatibility: an extensible ENUMERATED value added by a
+ * newer version of the type is carried on the wire (X.691 #14) only as its
+ * extension index -- the true abstract value is unknowable to an older
+ * decoder (X.680 #20.1 NOTE: enumeration values are ordered but not
+ * necessarily contiguous). X.680 #6 forbids failing on such a value, yet a
+ * plain long has no out-of-band way to flag "unknown". Following a commercial
+ * ASN.1 toolchain (the project's interoperability reference, which stores
+ * INT_MAX - index), the UPER decoder stores the wire index enciphered as
+ * LONG_MAX - index, i.e.
+ * in the reserved region [LONG_MAX - 65535, LONG_MAX] (uper_get_nsnnwn caps
+ * the index at two length octets, so 65535 is its widest possible value).
+ *
+ * Contract for such a stored value:
+ *   - The application MUST NOT interpret it as a meaningful enumeration
+ *     value; it is only a placeholder for "unknown extension index N".
+ *   - It may be relayed as-is: NativeEnumerated_encode_uper recognises the
+ *     region and re-emits the identical index, so an unknown value received
+ *     from one peer can be forwarded byte-for-byte to another, provided the
+ *     SAME PER transfer syntax is used (X.680 #6/#7.1). The extension index
+ *     is version-stable (X.680 #20.4 forces additions to ascend), so relay
+ *     stays correct across schema versions.
+ *   - Transcoding it to a different transfer syntax (DER/OER/XER) is
+ *     meaningless -- those codecs carry the abstract value, not the index --
+ *     and rightly fails (map miss) or, for codecs without a map check
+ *     (DER/OER integer), emits this conspicuous near-LONG_MAX garbage rather
+ *     than a plausible-looking enumeration value.
+ */
+#define ASN_NATIVE_ENUMERATED_UNKNOWN_EXT_BASE  (LONG_MAX - 65535)
+#define ASN_NATIVE_ENUMERATED_IS_UNKNOWN_EXT(v) \
+	((v) >= ASN_NATIVE_ENUMERATED_UNKNOWN_EXT_BASE)
 
 xer_type_encoder_f NativeEnumerated_encode_xer;
 oer_type_decoder_f NativeEnumerated_decode_oer;

--- a/skeletons/per_support.h
+++ b/skeletons/per_support.h
@@ -54,6 +54,16 @@ ssize_t uper_get_length(asn_per_data_t *pd, int effective_bound_bits,
 ssize_t uper_get_nslength(asn_per_data_t *pd);
 
 /*
+ * The widest normally small non-negative whole number (X.691 #11.6) this
+ * implementation can transfer: uper_get_nsnnwn() reads at most a 2-octet
+ * long form (X.691 itself sets no bound). Contracts derived from this
+ * capability (e.g. the NativeEnumerated.h unknown-extension reserved
+ * region) are cross-checked against it at compile time; see
+ * NativeEnumerated.c.
+ */
+#define ASN_UPER_NSNNWN_MAX 65535
+
+/*
  * Get the normally small non-negative whole number.
  */
 ssize_t uper_get_nsnnwn(asn_per_data_t *pd);

--- a/tests/tests-asn1c-compiler/166-uper-enum-extension-OK.asn1
+++ b/tests/tests-asn1c-compiler/166-uper-enum-extension-OK.asn1
@@ -1,0 +1,46 @@
+-- OK: Everything is fine
+
+-- iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+-- .spelio.software.asn1c.test (9363.1.5.1)
+-- .166
+
+-- Forward compatibility of UPER coding of an extensible ENUMERATED
+-- (Solution C, reference-isomorphic lossless relay).
+--
+-- This module is the OLD (base) version. The test decodes enumeration
+-- values added by a NEWER version (after the ellipsis) and expects them
+-- to be accepted (RC_OK) without aliasing any known value, so fields
+-- following the enum keep decoding, and to re-encode byte-for-byte
+-- identically, so an unknown value received from one peer can be relayed
+-- to another under the same PER transfer syntax, as the reference toolchain does.
+
+ModuleUPEREnumExtension
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 166 }
+	DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+	E ::= ENUMERATED {
+		ee1 (0),
+		ee2 (1),
+		...
+	}
+
+	-- Sparse values: the placeholder for an unknown extension must not
+	-- alias sp2(2). Storing LONG_MAX-index (not the extension ordinal)
+	-- guarantees this.
+	S ::= ENUMERATED {
+		sp1 (0),
+		sp2 (2),
+		...
+	}
+
+	N ::= SEQUENCE {
+		a MsgCount,
+		en E,
+		b MsgCount
+	}
+
+	MsgCount ::= INTEGER (0..127)
+
+END

--- a/tests/tests-c-compiler/Makefile.am
+++ b/tests/tests-c-compiler/Makefile.am
@@ -67,6 +67,7 @@ TESTS += check-src/check-161.-fcompound-names.c
 TESTS += check-src/check-161.-fcompound-names.-gen-PER.c
 TESTS += check-src/check-162.c
 TESTS += check-src/check-164.-fcompound-names.c
+TESTS += check-src/check-166.-gen-PER.c
 
 if TEST_64BIT
 TESTS += check-src/check64-134.-gen-PER.c

--- a/tests/tests-c-compiler/check-src/check-166.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-166.-gen-PER.c
@@ -1,0 +1,108 @@
+/*
+ * UPER forward compatibility for an extensible ENUMERATED (Solution C,
+ * reference-isomorphic lossless relay), exercised end to end through
+ * generated code. A value added by a newer version (an unknown extension)
+ * must:
+ *   - decode successfully (X.680 #6) without derailing subsequent fields;
+ *   - be stored as LONG_MAX - extension_index, distinct per index and never
+ *     aliasing a known value (even in a sparse enumeration);
+ *   - re-encode byte-for-byte identically, so it can be relayed under the
+ *     same PER transfer syntax, exactly as the reference toolchain does.
+ * Golden bytes cross-checked against the reference toolchain and asn1tools.
+ */
+#undef	NDEBUG
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <limits.h>
+
+#include <E.h>
+#include <S.h>
+#include <N.h>
+
+int main() {
+	asn_dec_rval_t rv;
+	asn_enc_rval_t er;
+	unsigned char buf[8];
+
+	/* Known root value decodes as usual. */
+	static const unsigned char enc_ee2[] = { 0x40 };
+	long *e = 0;
+	rv = uper_decode(0, &asn_DEF_E, (void *)&e, enc_ee2, 1, 0, 0);
+	assert(rv.code == RC_OK);
+	assert(*e == E_ee2);
+	ASN_STRUCT_FREE(asn_DEF_E, e);
+
+	/*
+	 * ee4 from a newer version { ee1, ee2, ..., ee3(3), ee4(4) }:
+	 * extension bit 1, extension index 1 => 0x81. Must decode (RC_OK)
+	 * into LONG_MAX-1 and re-encode byte-identically (relay).
+	 */
+	static const unsigned char enc_ee4[] = { 0x81 };
+	e = 0;
+	rv = uper_decode(0, &asn_DEF_E, (void *)&e, enc_ee4, 1, 0, 0);
+	assert(rv.code == RC_OK);
+	assert(*e == LONG_MAX - 1);
+	er = uper_encode_to_buffer(&asn_DEF_E, 0, e, buf, sizeof buf);
+	assert(er.encoded == 8);		/* 1 ext bit + 7 nsnnwn bits */
+	assert(buf[0] == 0x81);			/* lossless relay */
+	ASN_STRUCT_FREE(asn_DEF_E, e);
+
+	/*
+	 * ee6 (extension index 3) => 0x83 => LONG_MAX-3 => relay 0x83.
+	 * This is the reference toolchain's golden byte (base decodes it to INT_MAX-3 and
+	 * re-encodes 0x83); asn1c stores LONG_MAX-3 and does the same.
+	 */
+	static const unsigned char enc_ee6[] = { 0x83 };
+	e = 0;
+	rv = uper_decode(0, &asn_DEF_E, (void *)&e, enc_ee6, 1, 0, 0);
+	assert(rv.code == RC_OK);
+	assert(*e == LONG_MAX - 3);
+	er = uper_encode_to_buffer(&asn_DEF_E, 0, e, buf, sizeof buf);
+	assert(er.encoded == 8);
+	assert(buf[0] == 0x83);
+	ASN_STRUCT_FREE(asn_DEF_E, e);
+
+	/*
+	 * Sparse enumeration { sp1(0), sp2(2), ... }: an unknown extension
+	 * (index 0 => 0x80) must not alias the known sp2(2). Storing
+	 * LONG_MAX (not the ordinal 2) keeps it distinct; relay to 0x80.
+	 */
+	static const unsigned char enc_sp_ext[] = { 0x80 };
+	long *s = 0;
+	rv = uper_decode(0, &asn_DEF_S, (void *)&s, enc_sp_ext, 1, 0, 0);
+	assert(rv.code == RC_OK);
+	assert(*s != S_sp2);
+	assert(*s == LONG_MAX);
+	er = uper_encode_to_buffer(&asn_DEF_S, 0, s, buf, sizeof buf);
+	assert(er.encoded == 8);
+	assert(buf[0] == 0x80);
+	ASN_STRUCT_FREE(asn_DEF_S, s);
+
+	/*
+	 * Unknown enum extension nested in SEQUENCE { a 5, en ee4, b 7 } => the
+	 * fields around it must be recovered, en stored as LONG_MAX-1, and the
+	 * whole PDU must relay byte-for-byte.
+	 */
+	static const unsigned char nest_ee4[] = { 0x0b, 0x02, 0x1c };
+	N_t *n = 0;
+	rv = uper_decode(0, &asn_DEF_N, (void *)&n, nest_ee4, 3, 0, 0);
+	assert(rv.code == RC_OK);
+	assert(n->a == 5);
+	assert(n->en == LONG_MAX - 1);
+	assert(n->b == 7);
+	er = uper_encode_to_buffer(&asn_DEF_N, 0, n, buf, sizeof buf);
+	assert(er.encoded == 22);		/* 7 + (1+7) + 7 bits */
+	assert(buf[0] == 0x0b && buf[1] == 0x02 && buf[2] == 0x1c);
+	ASN_STRUCT_FREE(asn_DEF_N, n);
+
+	/* Sanity: same-version round-trip of a known value. */
+	long e0 = E_ee2;
+	er = uper_encode_to_buffer(&asn_DEF_E, 0, &e0, buf, sizeof buf);
+	assert(er.encoded == 2);
+	assert(buf[0] == 0x40);
+
+	printf("Finished OK\n");
+	return 0;
+}

--- a/tests/tests-skeletons/Makefile.am
+++ b/tests/tests-skeletons/Makefile.am
@@ -17,7 +17,8 @@ check_PROGRAMS =            \
     check-OER-NativeEnumerated \
     check-PER-support       \
     check-PER-UniversalString  \
-    check-PER-INTEGER
+    check-PER-INTEGER       \
+    check-PER-NativeEnumerated
 
 if EXPLICIT_M32
 check_PROGRAMS +=                   \
@@ -37,7 +38,8 @@ check_PROGRAMS +=                   \
     check-32-OER-NativeEnumerated   \
     check-32-PER-support            \
     check-32-PER-UniversalString    \
-    check-32-PER-INTEGER
+    check-32-PER-INTEGER            \
+    check-32-PER-NativeEnumerated
 
 check_32_ber_tlv_tag_CFLAGS=$(CFLAGS_M32)
 check_32_ber_tlv_tag_LDADD=$(LDADD_32)
@@ -90,6 +92,9 @@ check_32_PER_UniversalString_SOURCES=check-PER-UniversalString.c
 check_32_PER_INTEGER_CFLAGS=$(CFLAGS_M32)
 check_32_PER_INTEGER_LDADD=$(LDADD_32)
 check_32_PER_INTEGER_SOURCES=check-PER-INTEGER.c
+check_32_PER_NativeEnumerated_CFLAGS=$(CFLAGS_M32)
+check_32_PER_NativeEnumerated_LDADD=$(LDADD_32)
+check_32_PER_NativeEnumerated_SOURCES=check-PER-NativeEnumerated.c
 
 LDADD_32 = -lm $(top_builddir)/skeletons/libasn1cskeletons_c89_32.la
 endif

--- a/tests/tests-skeletons/check-PER-NativeEnumerated.c
+++ b/tests/tests-skeletons/check-PER-NativeEnumerated.c
@@ -1,0 +1,249 @@
+/*
+ * Regression test for UPER coding of an extensible NativeEnumerated
+ * (skeletons/NativeEnumerated.c), Solution C -- reference-isomorphic lossless
+ * relay of unknown extension values.
+ *
+ * A value added by a newer version of the type (an "unknown extension")
+ * must:
+ *   - decode successfully (X.680 #6 forbids failing) so an enclosing type
+ *     keeps parsing its subsequent fields (forward compatibility);
+ *   - be stored as LONG_MAX - wire_index, distinct per index and never
+ *     aliasing any value known to this older decoder (even sparse maps);
+ *   - re-encode byte-for-byte identically (relay), like the reference toolchain.
+ * Known root/extension values must be completely unaffected, and a value
+ * outside the reserved region (or handed to a non-extensible enumeration)
+ * must still fail to encode.
+ *
+ * Golden bytes cross-checked against the reference toolchain and asn1tools (base decodes
+ * 0x83 to INT_MAX-3 and relays it back to 0x83; full encodes ee1..ee6 to
+ * 00/40/80/81/82/83).
+ */
+#undef NDEBUG
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+#include <limits.h>
+
+#include <asn_application.h>
+#include <NativeEnumerated.h>
+#include <per_support.h>
+
+/*
+ * base:   E ::= ENUMERATED { ee1(0), ee2(1), ... }
+ * (root count 2, so specs->extension = 3, map_count = 2)
+ */
+static const asn_INTEGER_enum_map_t base_value2enum[] = {
+    { 0, 3, "ee1" },
+    { 1, 3, "ee2" }
+};
+static const unsigned int base_enum2value[] = { 0, 1 };
+static const asn_INTEGER_specifics_t base_specs = {
+    base_value2enum, base_enum2value, 2, 3, 1, 0, 0
+};
+
+/*
+ * full:   E ::= ENUMERATED { ee1(0), ee2(1), ..., ee3(3), ee4(4), ee5(5), ee6(6) }
+ * A newer version that knows the extension additions the base version does not.
+ */
+static const asn_INTEGER_enum_map_t full_value2enum[] = {
+    { 0, 3, "ee1" }, { 1, 3, "ee2" }, { 3, 3, "ee3" },
+    { 4, 3, "ee4" }, { 5, 3, "ee5" }, { 6, 3, "ee6" }
+};
+static const unsigned int full_enum2value[] = { 0, 1, 2, 3, 4, 5 };
+static const asn_INTEGER_specifics_t full_specs = {
+    full_value2enum, full_enum2value, 6, 3, 1, 0, 0
+};
+
+/*
+ * sparse: S ::= ENUMERATED { a(0), b(2), ... }
+ * The unknown-extension placeholder must not alias the known b(2): storing
+ * the extension ordinal instead of LONG_MAX-index would, since ordinal 2
+ * equals b's value.
+ */
+static const asn_INTEGER_enum_map_t sparse_value2enum[] = {
+    { 0, 1, "a" },
+    { 2, 1, "b" }
+};
+static const unsigned int sparse_enum2value[] = { 0, 1 };
+static const asn_INTEGER_specifics_t sparse_specs = {
+    sparse_value2enum, sparse_enum2value, 2, 3, 1, 0, 0
+};
+
+/*
+ * noext:  N ::= ENUMERATED { x(0), y(1) }  -- NOT extensible.
+ */
+static const asn_INTEGER_enum_map_t noext_value2enum[] = {
+    { 0, 1, "x" },
+    { 1, 1, "y" }
+};
+static const unsigned int noext_enum2value[] = { 0, 1 };
+static const asn_INTEGER_specifics_t noext_specs = {
+    noext_value2enum, noext_enum2value, 2, 0, 1, 0, 0
+};
+
+static const asn_per_constraints_t ext_constraints = {
+    { APC_CONSTRAINED | APC_EXTENSIBLE, 1, 1, 0, 1 }, /* value (root index) */
+    { APC_UNCONSTRAINED, -1, -1, 0, 0 },
+    0, 0
+};
+static const asn_per_constraints_t noext_constraints = {
+    { APC_CONSTRAINED, 1, 1, 0, 1 },
+    { APC_UNCONSTRAINED, -1, -1, 0, 0 },
+    0, 0
+};
+
+static long
+decode_uper(int lineno, const asn_INTEGER_specifics_t *specs,
+            const asn_per_constraints_t *ct,
+            enum asn_dec_rval_code_e expected_code,
+            const void *bytes, size_t nbytes) {
+    asn_TYPE_descriptor_t td = asn_DEF_NativeEnumerated;
+    asn_per_data_t pd;
+    asn_dec_rval_t rv;
+    long value = -1;
+    long *value_ptr = &value;
+
+    td.specifics = specs;
+    memset(&pd, 0, sizeof(pd));
+    pd.buffer = (const uint8_t *)bytes;
+    pd.nboff = 0;
+    pd.nbits = 8 * nbytes;
+
+    rv = NativeEnumerated_decode_uper(NULL, &td, ct, (void **)&value_ptr, &pd);
+    fprintf(stderr, "%d: uper decode [%02x] => code %d, value %ld\n",
+            lineno, *(const uint8_t *)bytes, (int)rv.code, value);
+    assert(rv.code == expected_code);
+    return value;
+}
+
+/*
+ * Encode "value" and, on success, return the number of whole bytes produced,
+ * copying them into out[]. Returns -1 on ENCODE_FAILED.
+ */
+static ssize_t
+encode_uper(const asn_INTEGER_specifics_t *specs,
+            const asn_per_constraints_t *ct, long value, uint8_t *out) {
+    asn_TYPE_descriptor_t td = asn_DEF_NativeEnumerated;
+    asn_per_outp_t po;
+    asn_enc_rval_t er;
+    size_t nbytes;
+
+    td.specifics = specs;
+    memset(&po, 0, sizeof(po));
+    po.buffer = po.tmpspace;
+    po.nbits = 8 * sizeof(po.tmpspace);
+
+    er = NativeEnumerated_encode_uper(&td, ct, &value, &po);
+    if(er.encoded < 0) return -1;
+    nbytes = (po.buffer - po.tmpspace) + (po.nboff ? 1 : 0);
+    if(out) memcpy(out, po.tmpspace, nbytes);
+    return (ssize_t)nbytes;
+}
+
+/* Decode "wire", then re-encode; assert the byte-identical round trip. */
+static long
+relay_ok(int lineno, const asn_INTEGER_specifics_t *specs,
+         unsigned char wire, long expect_value) {
+    unsigned char in = wire;
+    uint8_t out[8];
+    ssize_t n;
+    long v = decode_uper(lineno, specs, &ext_constraints, RC_OK, &in, 1);
+    assert(v == expect_value);
+    n = encode_uper(specs, &ext_constraints, v, out);
+    fprintf(stderr, "%d: relay 0x%02x => value %ld => re-encode %zd byte 0x%02x\n",
+            lineno, wire, v, n, n > 0 ? out[0] : 0);
+    assert(n == 1);
+    assert(out[0] == wire);
+    return v;
+}
+
+int
+main(void) {
+    long value;
+    uint8_t out[8];
+    ssize_t n;
+
+    /* ------- Known root values: decode and re-encode unchanged. ------- */
+    value = decode_uper(__LINE__, &base_specs, &ext_constraints, RC_OK, "\x00", 1);
+    assert(value == 0);                                 /* ee1 */
+    value = decode_uper(__LINE__, &base_specs, &ext_constraints, RC_OK, "\x40", 1);
+    assert(value == 1);                                 /* ee2 */
+    n = encode_uper(&base_specs, &ext_constraints, 0, out);
+    assert(n == 1 && out[0] == 0x00);
+    n = encode_uper(&base_specs, &ext_constraints, 1, out);
+    assert(n == 1 && out[0] == 0x40);
+
+    /*
+     * ------- Unknown extension values: lossless relay. -------
+     * A newer peer's ee3/ee4/ee6 arrive as extension indices 0/1/3. They must
+     * decode (RC_OK) into LONG_MAX-index (distinct per index, no aliasing) and
+     * re-encode to the identical byte.
+     */
+    relay_ok(__LINE__, &base_specs, 0x80, LONG_MAX);    /* ext index 0 */
+    relay_ok(__LINE__, &base_specs, 0x81, LONG_MAX - 1);/* ext index 1 */
+    relay_ok(__LINE__, &base_specs, 0x83, LONG_MAX - 3);/* ext index 3 (ee6) */
+
+    /* The stored value is recognised as an unknown-extension placeholder. */
+    assert(ASN_NATIVE_ENUMERATED_IS_UNKNOWN_EXT(LONG_MAX));
+    assert(ASN_NATIVE_ENUMERATED_IS_UNKNOWN_EXT(LONG_MAX - 3));
+    assert(!ASN_NATIVE_ENUMERATED_IS_UNKNOWN_EXT(0));
+    assert(!ASN_NATIVE_ENUMERATED_IS_UNKNOWN_EXT(LONG_MAX - 70000));
+
+    /*
+     * ------- Sparse enumeration { a(0), b(2), ... }: no aliasing. -------
+     * The known b(2) still decodes to 2; an unknown extension (ordinal 0 that
+     * would collide with b under an ordinal scheme) must become LONG_MAX and
+     * relay back to 0x80.
+     */
+    value = decode_uper(__LINE__, &sparse_specs, &ext_constraints, RC_OK, "\x40", 1);
+    assert(value == 2);                                 /* known b(2) */
+    value = relay_ok(__LINE__, &sparse_specs, 0x80, LONG_MAX);
+    assert(value != 2);                                 /* must not alias b(2) */
+
+    /*
+     * ------- Newer version knows the additions: byte-exact encoding. -------
+     * full encodes ee1..ee6 to 00/40/80/81/82/83 (three-tool golden), and
+     * decodes 0x81 to the real value 4 (a known extension now, not unknown).
+     */
+    {
+        static const long vals[6]        = { 0, 1, 3, 4, 5, 6 };
+        static const unsigned char gold[6] = { 0x00, 0x40, 0x80, 0x81, 0x82, 0x83 };
+        int i;
+        for(i = 0; i < 6; i++) {
+            n = encode_uper(&full_specs, &ext_constraints, vals[i], out);
+            fprintf(stderr, "full encode %ld => %zd byte 0x%02x (want 0x%02x)\n",
+                    vals[i], n, n > 0 ? out[0] : 0, gold[i]);
+            assert(n == 1 && out[0] == gold[i]);
+        }
+        value = decode_uper(__LINE__, &full_specs, &ext_constraints, RC_OK, "\x81", 1);
+        assert(value == 4);                             /* known ee4 */
+    }
+
+    /*
+     * ------- Cross-header relay. -------
+     * A value the base version could not understand (0x83) is stored by base,
+     * then handed to the full version's encoder. Even though the full version
+     * knows extension index 3 as ee6, the relay path replays the index (the
+     * index is version-stable), producing the identical 0x83.
+     */
+    value = decode_uper(__LINE__, &base_specs, &ext_constraints, RC_OK, "\x83", 1);
+    assert(value == LONG_MAX - 3);
+    n = encode_uper(&full_specs, &ext_constraints, value, out);
+    fprintf(stderr, "cross-header relay: base stored %ld => full encodes %zd byte 0x%02x\n",
+            value, n, n > 0 ? out[0] : 0);
+    assert(n == 1 && out[0] == 0x83);
+
+    /*
+     * ------- Negative cases. -------
+     * A value below the reserved region (index would exceed 65535) is not a
+     * valid relay placeholder and must fail to encode; a reserved-region value
+     * handed to a NON-extensible enumeration must also fail.
+     */
+    assert(encode_uper(&base_specs, &ext_constraints, LONG_MAX - 70000, out) == -1);
+    assert(encode_uper(&noext_specs, &noext_constraints, LONG_MAX, out) == -1);
+    /* A plain unknown integer (not a placeholder, not a known value) fails. */
+    assert(encode_uper(&base_specs, &ext_constraints, 42, out) == -1);
+
+    printf("Finished OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Problem

An extensible `ENUMERATED` value added by a newer version arrives at an older decoder as just its extension index (X.691 §14); the abstract value is unknowable. asn1c rejected the whole PDU (`ASN__DECODE_FAILED`), violating X.680 §6 ("the decoding process never signals an error" for unknown extension additions) and making every enclosing message undecodable.

## Root cause

`skeletons/NativeEnumerated.c`: the UPER decoder compared the received extension ordinal against `map_count` and returned `ASN__DECODE_FAILED` whenever it exceeded the number of extension values known to this schema version.

## Fix — evolution across the commits on this branch

1. **Accept instead of fail** (first commit): store the raw ordinal. Review found it aliases sparse maps (`{a(0), b(2), ...}`: unknown ordinal 2 reads as `b`).
2. **Collision-free sentinel**: store `max_known+1`. Still lossy — all unknown indices collapse to one value, cannot be relayed, and the "re-encoding fails cleanly" claim held only for UPER/XER (DER/OER have no map check and would silently emit the sentinel, which under implicit numbering equals the newer version's first addition — silent value substitution).
3. **Lossless relay, matching the reference toolchain** (final): store **`LONG_MAX - wire_index`** in the reserved region `[LONG_MAX-65535, LONG_MAX]`; `NativeEnumerated_encode_uper` recognises the region and re-emits the identical index (extension bit + nsnnwn). This mirrors the observable behavior of a major commercial ASN.1 toolchain, which represents an unknown enumerated locally as a MAXINT-anchored placeholder and re-encodes it for relay — verified live: it stores `INT_MAX-3` for wire byte `0x83` and re-encodes `0x83`; asn1c now does the same anchored at `LONG_MAX`.

## Why this representation

- X.680 §6/§52.1 mandate acceptance ("shall not be treated as an error during the decoding process"); X.680 §7.1 requires that values decoded through an extension-related type can be re-encoded and then decoded by further extension-related types — lossless relay under the same transfer syntax is exactly the capability the standard requires.
- The extension index is version-stable: X.680 §20.4 forces additions to ascend, so declaration order = value order = wire index, permanently. Replaying the received index is therefore correct across schema versions.
- The descending `LONG_MAX` anchor is schema/version-independent, trivially invertible (`index = LONG_MAX - stored`), sits far from any realistic enumeration value, and avoids the `max==LONG_MAX` overflow. A `-1` sentinel was rejected because negative enumeration values are legal ASN.1 (the ENUMERATED grammar, X.680 §20.1, admits `NamedNumber` with a `SignedNumber`, §19).
- Sparse maps no longer alias; distinct unknown indices stay distinct. Known values, non-extensible enumerations, and out-of-region values are unaffected / still rejected.

## Scope

UPER only. DER/OER/XER carry the abstract value, not the index, so cross-syntax transcoding of an unknown value is meaningless: XER fails the map lookup cleanly; DER/OER would emit the conspicuous near-`LONG_MAX` placeholder rather than a plausible-looking enumerator. The full application contract is documented in `NativeEnumerated.h` (`ASN_NATIVE_ENUMERATED_UNKNOWN_EXT_BASE`, `ASN_NATIVE_ENUMERATED_IS_UNKNOWN_EXT()`).

## Validation

Cross-checked against a major commercial ASN.1 toolchain (12.0, golden `.uper` vectors) and asn1tools (`pip install asn1tools` to reproduce); end-to-end corpus replay (v0/v1/v2 schema versions x all golden vectors) fully green, including a knows-SOME middle-version chain.

## Tests

- `tests/tests-skeletons/check-PER-NativeEnumerated.c` — decode/re-encode round-trips for root values, unknown extension indices 0/1/3 (byte-identical relay), sparse-map non-aliasing, reserved-region boundary, and rejection of out-of-region / non-extensible cases.
- `tests/tests-asn1c-compiler/166-uper-enum-extension-OK.asn1` + `tests/tests-c-compiler/check-src/check-166.-gen-PER.c` — through compiler-generated code, including a nested `SEQUENCE { a, en, b }` whose unknown `en` is recovered as `LONG_MAX-1` with `a`/`b` intact and the **whole message** re-encoding byte-identically.

## Behavior change & migration

- **New observable state**: an unknown ENUMERATED extension value now decodes as `LONG_MAX - wire_index` (in the reserved region `[LONG_MAX-65535, LONG_MAX]`) instead of failing decode. Test with `ASN_NATIVE_ENUMERATED_IS_UNKNOWN_EXT()` (declared in `NativeEnumerated.h`); recover the original wire index with `LONG_MAX - value`.
- **Migration safety net**: calling `asn_check_constraints()` after decode rejects a value in the reserved region exactly as the old strict decoder would have rejected the whole PDU, giving callers an equivalent opt-in "reject" checkpoint without reverting the decode behavior.
- A companion PR in this series adds a compile-time escape hatch (`ASN_REJECT_UNKNOWN_EXTENSIONS`) restoring clean `RC_FAIL` at exactly this site.

## Known limitation

The marker scheme borrows the top of the `long` value space: if a schema explicitly assigns an enumerator value inside the reserved region `[LONG_MAX-65535, LONG_MAX]` (on 32-bit `long` targets: `[0x7FFF0000, 0x7FFFFFFF]`), that value's local representation becomes indistinguishable from an unknown-extension marker — the decoder could then surface an unknown extension as that enumerator, and relay would re-encode it as the known value. No realistic schema assigns enumerator values there (the region deliberately sits at the extreme top of the range), and none of the corpora used for validation do; if reviewers prefer a hard guarantee, a decode-time lookup rejecting a computed marker that collides with a declared value is a straightforward follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)