### PR TITLE
UPER: omit DEFAULT extension addition equal to its default

### DIFF
--- a/skeletons/constr_SEQUENCE.c
+++ b/skeletons/constr_SEQUENCE.c
@@ -1331,6 +1331,11 @@ SEQUENCE__handle_extensions(const asn_TYPE_descriptor_t *td, const void *sptr,
 			present = 1;
 		}
 
+        /* Eliminate default values */
+        if(present && elm->default_value_cmp
+           && elm->default_value_cmp(*memb_ptr2) == 0)
+            present = 0;
+
         ASN_DEBUG("checking %s:%s (@%" ASN_PRI_SIZE ") present => %d", elm->name,
                   elm->type->name, edx, present);
         exts_count++;

--- a/tests/tests-asn1c-compiler/168-sequence-default-ext-OK.asn1
+++ b/tests/tests-asn1c-compiler/168-sequence-default-ext-OK.asn1
@@ -1,0 +1,34 @@
+-- OK: Everything is fine
+
+-- iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+-- .spelio.software.asn1c.test (9363.1.5.1)
+-- .168
+
+-- UPER canonical encoding of a DEFAULT-valued SEQUENCE member (X.691
+-- #18.2 / #18.4): when the actual value equals the DEFAULT, the member
+-- must be omitted (root: skip the field after "present" bit; extension
+-- addition group: report it as absent so it does not contribute to the
+-- extension presence bit-map / count / open-type list). asn1c already
+-- did this correctly for root-position DEFAULT members but not for
+-- DEFAULT members appearing as extension additions after "...".
+
+ModuleSequenceDefaultExtension
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 168 }
+	DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+	-- Root-position DEFAULT, used as a control/reference.
+	R1 ::= SEQUENCE {
+		x INTEGER(0..15),
+		y INTEGER(0..15) DEFAULT 5
+	}
+
+	-- DEFAULT as an extension addition.
+	R2 ::= SEQUENCE {
+		x INTEGER(0..15),
+		...,
+		y INTEGER(0..15) DEFAULT 5
+	}
+
+END

--- a/tests/tests-c-compiler/Makefile.am
+++ b/tests/tests-c-compiler/Makefile.am
@@ -67,6 +67,7 @@ TESTS += check-src/check-161.-fcompound-names.c
 TESTS += check-src/check-161.-fcompound-names.-gen-PER.c
 TESTS += check-src/check-162.c
 TESTS += check-src/check-164.-fcompound-names.c
+TESTS += check-src/check-168.-gen-PER.c
 
 if TEST_64BIT
 TESTS += check-src/check64-134.-gen-PER.c

--- a/tests/tests-c-compiler/check-src/check-168.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-168.-gen-PER.c
@@ -1,0 +1,136 @@
+/*
+ * UPER canonical encoding of a DEFAULT-valued SEQUENCE extension addition
+ * (X.691 #18.2 / #18.4): when the actual value equals the DEFAULT, the
+ * member must not contribute to the extension addition group -- it must
+ * not set the extension presence bit, must not be counted towards the
+ * extension bit-map length, and must not be emitted as an open type
+ * field. asn1c already did this correctly for a DEFAULT member in the
+ * SEQUENCE root (see R1 below, used as a control) but, before the fix
+ * in SEQUENCE__handle_extensions() (skeletons/constr_SEQUENCE.c), it did
+ * not apply the same elimination to a DEFAULT member appearing after the
+ * "..." extension marker (R2), producing a non-canonical encoding with a
+ * needless extension bit-map and open type field.
+ */
+#undef	NDEBUG
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include <R1.h>
+#include <R2.h>
+
+int main() {
+	asn_enc_rval_t er;
+	asn_dec_rval_t rv;
+	unsigned char buf[8];
+
+	/*
+	 * Control: root-position DEFAULT already omits the member when it
+	 * equals the default. R1 { x: 1 } (y defaulted to 5, left unset)
+	 * encodes as a presence bit (0) followed by x (4 bits) = 00001,
+	 * padded to a single octet 0x08.
+	 */
+	{
+		R1_t r1;
+		memset(&r1, 0, sizeof(r1));
+		r1.x = 1;
+		er = uper_encode_to_buffer(&asn_DEF_R1, 0, &r1, buf, sizeof buf);
+		assert(er.encoded == 5);
+		assert(er.encoded > 0 && (er.encoded + 7) / 8 == 1);
+		assert(buf[0] == 0x08);
+	}
+
+	/*
+	 * R2 { x: 1 }, y left unset (absent -> defaults to 5 on decode).
+	 * Canonical UPER: no extension bit-map is needed at all, since the
+	 * only extension addition (y) is absent. Extension bit (0) + x (4
+	 * bits) = 00001, padded to 0x08 -- the same bytes as R1 above.
+	 */
+	{
+		R2_t r2;
+		memset(&r2, 0, sizeof(r2));
+		r2.x = 1;
+		er = uper_encode_to_buffer(&asn_DEF_R2, 0, &r2, buf, sizeof buf);
+		assert(er.encoded == 5);
+		assert(buf[0] == 0x08);
+	}
+
+	/*
+	 * R2 { x: 1, y: 5 } with y *explicitly* set to the DEFAULT value.
+	 * This is the regression this fixture guards: before the fix,
+	 * SEQUENCE__handle_extensions() treated any non-NULL extension
+	 * pointer as "present" regardless of its value, so this would
+	 * encode a spurious extension bit-map and open type field
+	 * (0x88 0x08 0x0a 0x80, 29 bits) instead of collapsing to the
+	 * same canonical 0x08 as the "y absent" case above.
+	 */
+	{
+		R2_t r2;
+		long y = 5;
+		memset(&r2, 0, sizeof(r2));
+		r2.x = 1;
+		r2.y = &y;
+		er = uper_encode_to_buffer(&asn_DEF_R2, 0, &r2, buf, sizeof buf);
+		assert(er.encoded == 5);
+		assert(buf[0] == 0x08);
+	}
+
+	/*
+	 * R2 { x: 1, y: 7 }, y explicitly non-default. The extension
+	 * addition group must still be encoded normally: extension bit
+	 * (1) + x (0001) + ext bit-map length (0000000, count-1=0) + ext
+	 * presence bit (1) + open type length octet (00000001) + y=7
+	 * padded to an octet (01110000) = 29 bits -> 0x88 0x08 0x0b 0x80.
+	 * This must be unaffected by the DEFAULT-elimination fix.
+	 */
+	{
+		R2_t r2;
+		long y = 7;
+		memset(&r2, 0, sizeof(r2));
+		r2.x = 1;
+		r2.y = &y;
+		er = uper_encode_to_buffer(&asn_DEF_R2, 0, &r2, buf, sizeof buf);
+		assert(er.encoded == 29);
+		assert(buf[0] == 0x88 && buf[1] == 0x08 && buf[2] == 0x0b
+		       && buf[3] == 0x80);
+	}
+
+	/*
+	 * Decode round-trip (guard: decode direction was already correct).
+	 * Decoding the canonical 0x08 (extension bit 0) must recover x=1
+	 * and y defaulted to 5.
+	 */
+	{
+		static const unsigned char enc[] = { 0x08 };
+		R2_t *r2 = 0;
+		rv = uper_decode(0, &asn_DEF_R2, (void **)&r2, enc, sizeof enc, 0, 0);
+		assert(rv.code == RC_OK);
+		assert(r2->x == 1);
+		assert(r2->y != 0);
+		assert(*r2->y == 5);
+		ASN_STRUCT_FREE(asn_DEF_R2, r2);
+	}
+
+	/*
+	 * Decode round-trip of the non-default extension encoding: must
+	 * recover x=1, y=7, and re-encode byte-for-byte identically.
+	 */
+	{
+		static const unsigned char enc[] = { 0x88, 0x08, 0x0b, 0x80 };
+		R2_t *r2 = 0;
+		rv = uper_decode(0, &asn_DEF_R2, (void **)&r2, enc, sizeof enc, 0, 0);
+		assert(rv.code == RC_OK);
+		assert(r2->x == 1);
+		assert(r2->y != 0);
+		assert(*r2->y == 7);
+		er = uper_encode_to_buffer(&asn_DEF_R2, 0, r2, buf, sizeof buf);
+		assert(er.encoded == 29);
+		assert(buf[0] == 0x88 && buf[1] == 0x08 && buf[2] == 0x0b
+		       && buf[3] == 0x80);
+		ASN_STRUCT_FREE(asn_DEF_R2, r2);
+	}
+
+	printf("Finished OK\n");
+	return 0;
+}


### PR DESCRIPTION
## Problem

`SEQUENCE__handle_extensions()` computed extension-addition presence as mere non-NULL (`present = (*memb_ptr2 != 0)`), with no `default_value_cmp` elimination — unlike the root-optional bitmap path and unlike the OER encoder. A DEFAULT extension addition equal to its default was therefore encoded (extension bit + additions bitmap + open type), producing a non-canonical UPER encoding not byte-identical to a major commercial ASN.1 toolchain or asn1tools (`pip install asn1tools` to reproduce): `R2 ::= SEQUENCE { x INTEGER(0..15), ..., y INTEGER(0..15) DEFAULT 5 }` encoding `{x:1}` gave `88 08 0a 80` instead of `08`.

Decode direction was already correct (peer-omitted defaults are filled in), so this is a canonical-encoding / byte-identity conformance fix only.

## Root cause

`skeletons/constr_SEQUENCE.c`, `SEQUENCE__handle_extensions()`: the presence computation for an extension-addition member only checked whether the member pointer was non-NULL. It never consulted `elm->default_value_cmp`, so a DEFAULT extension addition explicitly set to its default value (or implicitly present with that value) was always treated as "present" and encoded.

## Fix

One elimination added after the presence computation, mirroring the root-DEFAULT case:

```c
/* Eliminate default values */
if(present && elm->default_value_cmp
   && elm->default_value_cmp(*memb_ptr2) == 0)
    present = 0;
```

`SEQUENCE__handle_extensions()` is the single deterministic source used by all three UPER encoding passes (count, presence bitmap, open types), so the counts stay consistent; when the only addition equals its default, `n_extensions` becomes 0 and the overall extension bit is 0.

X.691 §19.5 mandates canonical elimination of DEFAULT values equal to their default for **root** components. Clause 19 does not spell out the same rule verbatim for extension additions; this fix extrapolates the same canonical-encoding principle to extension additions, matching the observed behavior of a major commercial ASN.1 toolchain and of asn1tools on the same schema.

## Validation

Regression: `tests-skeletons` and `tests-c-compiler` `make check` failure sets are name-for-name identical to a clean master baseline built in the same environment — zero new failures; the new fixture is the only delta (new PASS).

## Tests

New end-to-end fixture 168 (`168-sequence-default-ext-OK.asn1` + `check-168.-gen-PER.c`):
- root-DEFAULT control (`R1 {x:1}` → `08`, already passing);
- `R2 {x:1}` with y unset and with y explicitly = 5 → `08` (fails on master with `88 08 0a 80`, 29 bits; passes with fix);
- `R2 {x:1, y:7}` non-default → `88 08 0b 80` unchanged by the fix;
- decode round-trips for both encodings (guards the already-correct decode direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
