### PR TITLE
SET: fail cleanly on null member codec, implement UPER codec in canonical tag order

### DIFF
--- a/skeletons/constr_CHOICE.c
+++ b/skeletons/constr_CHOICE.c
@@ -907,6 +907,11 @@ CHOICE_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
 	ASN_DEBUG("Discovered CHOICE %s encodes %s", td->name, elm->name);
 
 	if(ct && ct->range_bits >= 0) {
+		if(!elm->type->op->uper_decoder) {
+			ASN_DEBUG("Member %s->%s has no UPER decoder",
+				td->name, elm->name);
+			ASN__DECODE_FAILED;
+		}
 		rv = elm->type->op->uper_decoder(opt_codec_ctx, elm->type,
 			elm->encoding_constraints.per_constraints, memb_ptr2, pd);
 	} else {
@@ -997,6 +1002,12 @@ CHOICE_encode_uper(const asn_TYPE_descriptor_t *td,
     if(ct && ct->range_bits >= 0) {
         if(per_put_few_bits(po, present_enc, ct->range_bits))
             ASN__ENCODE_FAILED;
+
+        if(!elm->type->op->uper_encoder) {
+            ASN_DEBUG("Member %s->%s has no UPER encoder",
+                td->name, elm->name);
+            ASN__ENCODE_FAILED;
+        }
 
         return elm->type->op->uper_encoder(
             elm->type, elm->encoding_constraints.per_constraints, memb_ptr, po);

--- a/skeletons/constr_CHOICE_oer.c
+++ b/skeletons/constr_CHOICE_oer.c
@@ -247,6 +247,10 @@ CHOICE_decode_oer(const asn_codec_ctx_t *opt_codec_ctx,
             if(got == 0) ASN__DECODE_STARVED;
             rval.code = RC_OK;
             rval.consumed = got;
+        } else if(!elm->type->op->oer_decoder) {
+            ASN_DEBUG("Member %s->%s has no OER decoder",
+                      td->name, elm->name);
+            ASN__DECODE_FAILED;
         } else {
             rval = elm->type->op->oer_decoder(
                 opt_codec_ctx, elm->type,
@@ -367,6 +371,10 @@ CHOICE_encode_oer(const asn_TYPE_descriptor_t *td,
                                memb_ptr, cb, app_key);
         if(encoded < 0) ASN__ENCODE_FAILED;
         er.encoded = tag_len + encoded;
+    } else if(!elm->type->op->oer_encoder) {
+        ASN_DEBUG("Member %s->%s has no OER encoder",
+                  td->name, elm->name);
+        ASN__ENCODE_FAILED;
     } else {
         er = elm->type->op->oer_encoder(
             elm->type, elm->encoding_constraints.oer_constraints, memb_ptr, cb,

--- a/skeletons/constr_SEQUENCE.c
+++ b/skeletons/constr_SEQUENCE.c
@@ -1171,6 +1171,11 @@ SEQUENCE_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
 
 		if(elm->flags & ATF_OPEN_TYPE) {
 			rv = OPEN_TYPE_uper_get(opt_codec_ctx, td, st, elm, pd);
+		} else if(!elm->type->op->uper_decoder) {
+			ASN_DEBUG("Member %s->%s has no UPER decoder",
+				td->name, elm->name);
+			FREEMEM(opres);
+			ASN__DECODE_FAILED;
 		} else {
 			rv = elm->type->op->uper_decoder(opt_codec_ctx, elm->type,
 					elm->encoding_constraints.per_constraints, memb_ptr2, pd);
@@ -1456,6 +1461,11 @@ SEQUENCE_encode_uper(const asn_TYPE_descriptor_t *td,
 			continue;
 
         ASN_DEBUG("Encoding %s->%s:%s", td->name, elm->name, elm->type->name);
+        if(!elm->type->op->uper_encoder) {
+            ASN_DEBUG("Member %s->%s has no UPER encoder",
+                td->name, elm->name);
+            ASN__ENCODE_FAILED;
+        }
         er = elm->type->op->uper_encoder(
             elm->type, elm->encoding_constraints.per_constraints, *memb_ptr2,
             po);

--- a/skeletons/constr_SEQUENCE_OF.c
+++ b/skeletons/constr_SEQUENCE_OF.c
@@ -154,6 +154,12 @@ SEQUENCE_OF_encode_uper(const asn_TYPE_descriptor_t *td,
 	if(!sptr) ASN__ENCODE_FAILED;
     list = _A_CSEQUENCE_FROM_VOID(sptr);
 
+    if(list->count > 0 && !elm->type->op->uper_encoder) {
+        ASN_DEBUG("Element type %s of %s has no UPER encoder",
+                  elm->type->name, td->name);
+        ASN__ENCODE_FAILED;
+    }
+
     er.encoded = 0;
 
 	ASN_DEBUG("Encoding %s as SEQUENCE OF (%d)", td->name, list->count);

--- a/skeletons/constr_SEQUENCE_oer.c
+++ b/skeletons/constr_SEQUENCE_oer.c
@@ -197,6 +197,10 @@ SEQUENCE_decode_oer(const asn_codec_ctx_t *opt_codec_ctx,
         microphase2_decode_continues:
             if(elm->flags & ATF_OPEN_TYPE) {
                 rval = OPEN_TYPE_oer_get(opt_codec_ctx, td, st, elm, ptr, size);
+            } else if(!elm->type->op->oer_decoder) {
+                ASN_DEBUG("Member %s->%s has no OER decoder",
+                          td->name, elm->name);
+                RETURN(RC_FAIL);
             } else {
                 void *save_memb_ptr; /* Temporary reference. */
                 void **memb_ptr2;  /* Pointer to a pointer to a memmber */

--- a/skeletons/constr_SET.c
+++ b/skeletons/constr_SET.c
@@ -1061,6 +1061,349 @@ SET_compare(const asn_TYPE_descriptor_t *td, const void *aptr,
 }
 
 
+#ifndef ASN_DISABLE_PER_SUPPORT
+
+/*
+ * X.691 (#20): the UPER encoding of a SET is the same as that of a
+ * SEQUENCE, except that the root components are transmitted in the
+ * canonical order of their tags (X.680 #8.6), not in the declaration
+ * order. The (sorted) specs->tag2el map provides that order.
+ *
+ * Fill corder[0 .. td->elements_count-1] with element indices in
+ * canonical tag order. Returns 0, or -1 if the order cannot be
+ * reconstructed from the static tag map.
+ */
+static int
+SET__canonical_order(const asn_TYPE_descriptor_t *td,
+                     const asn_SET_specifics_t *specs, unsigned *corder) {
+    unsigned i;
+    unsigned n = 0;
+
+    if(specs->tag2el_count == td->elements_count) {
+        /* Each element appears exactly once: use the map directly. */
+        for(i = 0; i < specs->tag2el_count; i++) {
+            corder[i] = specs->tag2el[i].el_no;
+        }
+        return 0;
+    }
+
+    /*
+     * An element (e.g. an untagged CHOICE) may occur several times in
+     * the tag map, once per possible tag. In canonical order such an
+     * element is sorted by its smallest tag, which is its first
+     * occurrence in the (sorted) map; skip the rest.
+     */
+    for(i = 0; i < specs->tag2el_count && n < td->elements_count; i++) {
+        unsigned el_no = specs->tag2el[i].el_no;
+        unsigned j;
+        for(j = 0; j < n; j++) {
+            if(corder[j] == el_no) break;
+        }
+        if(j == n) corder[n++] = el_no;
+    }
+
+    return (n == td->elements_count) ? 0 : -1;
+}
+
+asn_dec_rval_t
+SET_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
+                const asn_TYPE_descriptor_t *td,
+                const asn_per_constraints_t *constraints, void **sptr,
+                asn_per_data_t *pd) {
+    const asn_SET_specifics_t *specs = (const asn_SET_specifics_t *)td->specifics;
+	void *st = *sptr;	/* Target structure. */
+	uint8_t *opres;		/* Presence of optional root members */
+	asn_per_data_t opmd;
+	asn_dec_rval_t rv;
+	unsigned *corder;	/* Canonical tag order of the members */
+	size_t roms_count;	/* Number of optional root members */
+	size_t edx;
+	size_t i;
+
+	(void)constraints;
+
+	if(ASN__STACK_OVERFLOW_CHECK(opt_codec_ctx))
+		ASN__DECODE_FAILED;
+
+	if(!st) {
+		st = *sptr = CALLOC(1, specs->struct_size);
+		if(!st) ASN__DECODE_FAILED;
+	}
+
+	ASN_DEBUG("Decoding %s as SET (UPER)", td->name);
+
+	if(specs->extensible) {
+		/*
+		 * Only extension-free SETs are supported (root-only): the SET
+		 * specifics do not record which members are extension
+		 * additions, so an extensible SET cannot be decoded reliably.
+		 * Fail cleanly rather than misinterpret the bit stream.
+		 */
+		ASN_DEBUG("Extensible SET %s is not PER-decodable", td->name);
+		ASN__DECODE_FAILED;
+	}
+
+	/* Reconstruct the canonical tag order of the members */
+	if(td->elements_count) {
+		corder = (unsigned *)MALLOC(td->elements_count * sizeof(*corder));
+		if(!corder) ASN__DECODE_FAILED;
+		if(SET__canonical_order(td, specs, corder)) {
+			FREEMEM(corder);
+			ASN__DECODE_FAILED;
+		}
+	} else {
+		corder = 0;
+	}
+
+	/* Number of optional root members */
+	roms_count = 0;
+	for(edx = 0; edx < td->elements_count; edx++)
+		if(td->elements[edx].optional)
+			roms_count++;
+
+	/* Prepare a place and read-in the presence bitmap */
+	memset(&opmd, 0, sizeof(opmd));
+	if(roms_count) {
+		opres = (uint8_t *)MALLOC(((roms_count + 7) >> 3) + 1);
+		if(!opres) {
+			FREEMEM(corder);
+			ASN__DECODE_FAILED;
+		}
+		/* Get the presence map */
+		if(per_get_many_bits(pd, opres, 0, roms_count)) {
+			FREEMEM(opres);
+			FREEMEM(corder);
+			ASN__DECODE_STARVED;
+		}
+		opmd.buffer = opres;
+		opmd.nbits = roms_count;
+		ASN_DEBUG("Read in presence bitmap for %s of %d bits (%x..)",
+			td->name, (int)roms_count, *opres);
+	} else {
+		opres = 0;
+	}
+
+	/*
+	 * Get the SET root elements, in canonical tag order.
+	 */
+	for(i = 0; i < td->elements_count; i++) {
+		asn_TYPE_member_t *elm;
+		void *memb_ptr;		/* Pointer to the member */
+		void **memb_ptr2;	/* Pointer to that pointer */
+
+		edx = corder[i];
+		elm = &td->elements[edx];
+
+		/* Fetch the pointer to this member */
+		if(elm->flags & ATF_POINTER) {
+			memb_ptr2 = (void **)((char *)st + elm->memb_offset);
+		} else {
+			memb_ptr = (char *)st + elm->memb_offset;
+			memb_ptr2 = &memb_ptr;
+		}
+
+		/* Deal with optionality */
+		if(elm->optional) {
+			int present = per_get_few_bits(&opmd, 1);
+			ASN_DEBUG("Member %s->%s is optional, p=%d (%d->%d)",
+				td->name, elm->name, present,
+				(int)opmd.nboff, (int)opmd.nbits);
+			if(present == 0) {
+				/* This element is not present */
+				if(elm->default_value_set) {
+					/* Fill-in DEFAULT */
+					if(elm->default_value_set(memb_ptr2)) {
+						FREEMEM(opres);
+						FREEMEM(corder);
+						ASN__DECODE_FAILED;
+					}
+					ASN_DEBUG("Filled-in default");
+					ASN_SET_MKPRESENT((char *)st + specs->pres_offset,
+						edx);
+				}
+				/* The member is just not present */
+				continue;
+			}
+			/* Fall through */
+		}
+
+		/* Fetch the member from the stream */
+		ASN_DEBUG("Decoding member \"%s\" in %s", elm->name, td->name);
+
+		if(!elm->type->op->uper_decoder) {
+			ASN_DEBUG("Member %s->%s has no UPER decoder",
+				td->name, elm->name);
+			FREEMEM(opres);
+			FREEMEM(corder);
+			ASN__DECODE_FAILED;
+		}
+
+		rv = elm->type->op->uper_decoder(opt_codec_ctx, elm->type,
+				elm->encoding_constraints.per_constraints, memb_ptr2, pd);
+		if(rv.code != RC_OK) {
+			ASN_DEBUG("Failed decode %s in %s",
+				elm->name, td->name);
+			FREEMEM(opres);
+			FREEMEM(corder);
+			return rv;
+		}
+
+		ASN_SET_MKPRESENT((char *)st + specs->pres_offset, edx);
+	}
+
+	FREEMEM(opres);
+	FREEMEM(corder);
+
+	rv.consumed = 0;
+	rv.code = RC_OK;
+	return rv;
+}
+
+asn_enc_rval_t
+SET_encode_uper(const asn_TYPE_descriptor_t *td,
+                const asn_per_constraints_t *constraints, const void *sptr,
+                asn_per_outp_t *po) {
+    const asn_SET_specifics_t *specs = (const asn_SET_specifics_t *)td->specifics;
+	asn_enc_rval_t er;
+	unsigned *corder;	/* Canonical tag order of the members */
+	size_t edx;
+	size_t i;
+
+	(void)constraints;
+
+	if(!sptr)
+		ASN__ENCODE_FAILED;
+
+	er.encoded = 0;
+
+	ASN_DEBUG("Encoding %s as SET (UPER)", td->name);
+
+	if(specs->extensible) {
+		/*
+		 * Only extension-free SETs are supported (root-only): the SET
+		 * specifics do not record which members are extension
+		 * additions, so the extension bit and the root/addition split
+		 * cannot be encoded reliably. Fail cleanly rather than
+		 * produce a wrong encoding.
+		 */
+		ASN_DEBUG("Extensible SET %s is not PER-encodable", td->name);
+		ASN__ENCODE_FAILED;
+	}
+
+	/* Reconstruct the canonical tag order of the members */
+	if(td->elements_count) {
+		corder = (unsigned *)MALLOC(td->elements_count * sizeof(*corder));
+		if(!corder) ASN__ENCODE_FAILED;
+		if(SET__canonical_order(td, specs, corder)) {
+			FREEMEM(corder);
+			ASN__ENCODE_FAILED;
+		}
+	} else {
+		corder = 0;
+	}
+
+#undef SET__UPER_ENCODE_FAILED
+#define SET__UPER_ENCODE_FAILED do {	\
+		FREEMEM(corder);	\
+		ASN__ENCODE_FAILED;	\
+	} while(0)
+
+	/*
+	 * Encode the presence bitmap of the optional members,
+	 * in canonical tag order (X.691 #20.2, #18.2).
+	 */
+	for(i = 0; i < td->elements_count; i++) {
+		asn_TYPE_member_t *elm;
+		const void *memb_ptr;		/* Pointer to the member */
+		const void *const *memb_ptr2;	/* Pointer to that pointer */
+		int present;
+
+		edx = corder[i];
+		elm = &td->elements[edx];
+
+		if(!elm->optional) continue;
+
+		/* Fetch the pointer to this member */
+		if(elm->flags & ATF_POINTER) {
+			memb_ptr2 =
+				(const void *const *)((const char *)sptr + elm->memb_offset);
+			present = (*memb_ptr2 != 0);
+		} else {
+			memb_ptr = (const void *)((const char *)sptr + elm->memb_offset);
+			memb_ptr2 = &memb_ptr;
+			present = 1;
+		}
+
+		/* Eliminate default values */
+		if(present && elm->default_value_cmp
+		   && elm->default_value_cmp(*memb_ptr2) == 0)
+			present = 0;
+
+		ASN_DEBUG("Element %s %s %s->%s is %s",
+			elm->flags & ATF_POINTER ? "ptr" : "inline",
+			elm->default_value_cmp ? "def" : "wtv",
+			td->name, elm->name, present ? "present" : "absent");
+		if(per_put_few_bits(po, present, 1))
+			SET__UPER_ENCODE_FAILED;
+	}
+
+	/*
+	 * Encode the SET root elements, in canonical tag order.
+	 */
+	for(i = 0; i < td->elements_count; i++) {
+		asn_TYPE_member_t *elm;
+		const void *memb_ptr;		/* Pointer to the member */
+		const void *const *memb_ptr2;	/* Pointer to that pointer */
+
+		edx = corder[i];
+		elm = &td->elements[edx];
+
+		ASN_DEBUG("About to encode %s", elm->type->name);
+
+		/* Fetch the pointer to this member */
+		if(elm->flags & ATF_POINTER) {
+			memb_ptr2 =
+				(const void *const *)((const char *)sptr + elm->memb_offset);
+			if(!*memb_ptr2) {
+				ASN_DEBUG("Element %s %" ASN_PRI_SIZE " not present",
+					elm->name, edx);
+				if(elm->optional)
+					continue;
+				/* Mandatory element is missing */
+				SET__UPER_ENCODE_FAILED;
+			}
+		} else {
+			memb_ptr = (const void *)((const char *)sptr + elm->memb_offset);
+			memb_ptr2 = &memb_ptr;
+		}
+
+		/* Eliminate default values */
+		if(elm->default_value_cmp && elm->default_value_cmp(*memb_ptr2) == 0)
+			continue;
+
+		ASN_DEBUG("Encoding %s->%s:%s", td->name, elm->name, elm->type->name);
+		if(!elm->type->op->uper_encoder) {
+			ASN_DEBUG("Member %s->%s has no UPER encoder",
+				td->name, elm->name);
+			SET__UPER_ENCODE_FAILED;
+		}
+		er = elm->type->op->uper_encoder(
+			elm->type, elm->encoding_constraints.per_constraints, *memb_ptr2,
+			po);
+		if(er.encoded == -1) {
+			FREEMEM(corder);
+			return er;
+		}
+	}
+
+#undef SET__UPER_ENCODE_FAILED
+
+	FREEMEM(corder);
+	ASN__ENCODED_OK(er);
+}
+
+#endif  /* ASN_DISABLE_PER_SUPPORT */
+
 asn_TYPE_operation_t asn_OP_SET = {
 	SET_free,
 	SET_print,
@@ -1071,8 +1414,13 @@ asn_TYPE_operation_t asn_OP_SET = {
 	SET_encode_xer,
 	0,	/* SET_decode_oer */
 	0,	/* SET_encode_oer */
-	0,	/* SET_decode_uper */
-	0,	/* SET_encode_uper */
+#ifdef ASN_DISABLE_PER_SUPPORT
+	0,
+	0,
+#else
+	SET_decode_uper,
+	SET_encode_uper,
+#endif /* ASN_DISABLE_PER_SUPPORT */
 	SET_random_fill,
 	0	/* Use generic outmost tag fetcher */
 };

--- a/skeletons/constr_SET_OF.c
+++ b/skeletons/constr_SET_OF.c
@@ -930,12 +930,6 @@ SET_OF_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
 	}
 	list = _A_SET_FROM_VOID(st);
 
-	if(!elm->type->op->uper_decoder) {
-		ASN_DEBUG("Element type %s of %s has no UPER decoder",
-			elm->type->name, td->name);
-		ASN__DECODE_FAILED;
-	}
-
 	/* Figure out which constraints to use */
 	if(constraints) ct = &constraints->size;
 	else if(td->encoding_constraints.per_constraints)
@@ -966,6 +960,12 @@ SET_OF_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
             ASN_DEBUG("Got to decode %" ASN_PRI_SSIZE " elements (eff %d)",
                       nelems, (int)(ct ? ct->effective_bits : -1));
             if(nelems < 0) ASN__DECODE_STARVED;
+		}
+
+		if(nelems > 0 && !elm->type->op->uper_decoder) {
+			ASN_DEBUG("Element type %s of %s has no UPER decoder",
+				elm->type->name, td->name);
+			ASN__DECODE_FAILED;
 		}
 
 		for(i = 0; i < nelems; i++) {

--- a/skeletons/constr_SET_OF.c
+++ b/skeletons/constr_SET_OF.c
@@ -927,8 +927,14 @@ SET_OF_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
 	if(!st) {
 		st = *sptr = CALLOC(1, specs->struct_size);
 		if(!st) ASN__DECODE_FAILED;
-	}                                                                       
+	}
 	list = _A_SET_FROM_VOID(st);
+
+	if(!elm->type->op->uper_decoder) {
+		ASN_DEBUG("Element type %s of %s has no UPER decoder",
+			elm->type->name, td->name);
+		ASN__DECODE_FAILED;
+	}
 
 	/* Figure out which constraints to use */
 	if(constraints) ct = &constraints->size;

--- a/skeletons/constr_SET_OF_oer.c
+++ b/skeletons/constr_SET_OF_oer.c
@@ -170,6 +170,12 @@ SET_OF_decode_oer(const asn_codec_ctx_t *opt_codec_ctx,
 
         ASN_DEBUG("OER SET OF %s Decoding PHASE 1", td->name);
 
+        if(ctx->left > 0 && !elm->type->op->oer_decoder) {
+            ASN_DEBUG("Element type %s of %s has no OER decoder",
+                      elm->type->name, td->name);
+            RETURN(RC_FAIL);
+        }
+
         for(; ctx->left > 0; ctx->left--) {
             asn_dec_rval_t rv = elm->type->op->oer_decoder(
                 opt_codec_ctx, elm->type,
@@ -255,6 +261,12 @@ SET_OF_encode_oer(const asn_TYPE_descriptor_t *td,
 
     elm = td->elements;
     list = _A_CSET_FROM_VOID(sptr);
+
+    if(list->count > 0 && !elm->type->op->oer_encoder) {
+        ASN_DEBUG("Element type %s of %s has no OER encoder",
+                  elm->type->name, td->name);
+        ASN__ENCODE_FAILED;
+    }
 
     qty_len = oer_put_quantity(list->count, cb, app_key);
     if(qty_len < 0) {

--- a/skeletons/oer_decoder.c
+++ b/skeletons/oer_decoder.c
@@ -33,6 +33,13 @@ oer_decode(const asn_codec_ctx_t *opt_codec_ctx,
 	/*
 	 * Invoke type-specific decoder.
 	 */
+	if(!type_descriptor->op->oer_decoder) {
+		asn_dec_rval_t rv;
+		ASN_DEBUG("No OER decoder for type %s", type_descriptor->name);
+		rv.code = RC_FAIL;
+		rv.consumed = 0;
+		return rv;
+	}
 	return type_descriptor->op->oer_decoder(opt_codec_ctx, type_descriptor, 0,
 		struct_ptr,	/* Pointer to the destination structure */
 		ptr, size	/* Buffer and its size */
@@ -80,6 +87,11 @@ oer_open_type_get(const asn_codec_ctx_t *opt_codec_ctx,
     if(size - len_len < container_len) {
         /* More data is expected */
         return 0;
+    }
+
+    if(!td->op->oer_decoder) {
+        ASN_DEBUG("No OER decoder for open type %s", td->name);
+        return -1;
     }
 
     dr = td->op->oer_decoder(opt_codec_ctx, td, constraints, struct_ptr,

--- a/skeletons/oer_encoder.c
+++ b/skeletons/oer_encoder.c
@@ -16,6 +16,14 @@ oer_encode(const asn_TYPE_descriptor_t *type_descriptor, const void *struct_ptr,
     /*
      * Invoke type-specific encoder.
      */
+    if(!type_descriptor->op->oer_encoder) {
+        asn_enc_rval_t er;
+        er.encoded = -1;
+        er.failed_type = type_descriptor;
+        er.structure_ptr = struct_ptr;
+        ASN_DEBUG("No OER encoder for type %s", type_descriptor->name);
+        return er;
+    }
     return type_descriptor->op->oer_encoder(
         type_descriptor, 0,
         struct_ptr, /* Pointer to the destination structure */
@@ -123,6 +131,11 @@ oer_open_type_put(const asn_TYPE_descriptor_t *td,
     size_t serialized_byte_count = 0;
     asn_enc_rval_t er;
     ssize_t len_len;
+
+    if(!td->op->oer_encoder) {
+        ASN_DEBUG("No OER encoder for open type %s", td->name);
+        return -1;
+    }
 
     er = td->op->oer_encoder(td, constraints, sptr, oer__count_bytes,
                              &serialized_byte_count);

--- a/skeletons/per_opentype.c
+++ b/skeletons/per_opentype.c
@@ -108,6 +108,12 @@ uper_open_type_get_simple(const asn_codec_ctx_t *ctx,
 	ASN_DEBUG("Getting open type %s encoded in %ld bytes", td->name,
 		(long)bufLen);
 
+	if(!td->op->uper_decoder) {
+		ASN_DEBUG("No UPER decoder for open type %s", td->name);
+		FREEMEM(buf);
+		ASN__DECODE_FAILED;
+	}
+
 	memset(&spd, 0, sizeof(spd));
 	spd.buffer = buf;
 	spd.nbits = bufLen << 3;

--- a/tests/tests-asn1c-compiler/169-set-nested-OK.asn1
+++ b/tests/tests-asn1c-compiler/169-set-nested-OK.asn1
@@ -19,6 +19,14 @@
 --         (a [1], b [2]); exercises the tag2el-driven reordering.
 --   S3:   DEFAULT + OPTIONAL members; exercises the presence bitmap
 --         and the canonical DEFAULT value elimination.
+--   S4/CH: untagged CHOICE member of a SET; the tag map (tag2el) then
+--         carries one entry per possible CHOICE tag and the canonical
+--         order must sort the CHOICE by its smallest tag (c [3]
+--         before n [5], although n is declared first).
+--   EmptyOD: unconstrained SEQUENCE OF; the regression driver uses it
+--         (simulating an element type without UPER codec) to pin down
+--         that the null-codec guard in the SET OF/SEQUENCE OF decoder
+--         only fires when there is at least one element to decode.
 
 ModuleSetNested
 	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
@@ -50,5 +58,27 @@ BEGIN
 		b BOOLEAN OPTIONAL,
 		c INTEGER(0..255)
 	}
+
+	-- The untagged CHOICE member c makes tag2el carry one entry per
+	-- CHOICE alternative tag ([3] and [4], both mapping to c), so
+	-- tag2el_count > elements_count and the canonical-order
+	-- reconstruction must de-duplicate. Canonical order is c (by its
+	-- smallest tag [3]), then n [5]; declaration order is n first.
+	S4 ::= SET {
+		n [5] INTEGER(0..255),
+		c CH
+	}
+
+	CH ::= CHOICE {
+		x [3] INTEGER(0..255),
+		y [4] BOOLEAN
+	}
+
+	-- Used by the regression driver to verify that when the element
+	-- type has no UPER codec (simulated there by nulling the element
+	-- operation slots), an *empty* collection still decodes and
+	-- encodes fine (the element codec is never invoked), while a
+	-- non-empty one fails cleanly instead of crashing.
+	EmptyOD ::= SEQUENCE OF ObjectDescriptor
 
 END

--- a/tests/tests-asn1c-compiler/169-set-nested-OK.asn1
+++ b/tests/tests-asn1c-compiler/169-set-nested-OK.asn1
@@ -4,18 +4,21 @@
 -- .spelio.software.asn1c.test (9363.1.5.1)
 -- .169
 
--- asn1c has no PER/OER codec implementation for the SET type
--- (skeletons/constr_SET.c's asn_OP_SET leaves uper_decoder, uper_encoder,
--- oer_decoder and oer_encoder as null function pointers). A SET used at
--- the outermost PDU level is already guarded (per_decoder.c checks
--- td->op->uper_decoder before calling it), but a SET nested as a member
--- of an enclosing SEQUENCE (or CHOICE, or *_OF) was not: the member-level
--- call sites invoked the null function pointer directly, causing a
--- SIGSEGV instead of a clean decode/encode failure (issue #12).
+-- asn1c had no PER codec implementation for the SET type
+-- (skeletons/constr_SET.c's asn_OP_SET left uper_decoder and uper_encoder
+-- as null function pointers), so a SET nested inside a PER-encoded PDU
+-- crashed with SIGSEGV at the unguarded member-level call sites
+-- (issue #12). The UPER codec for extension-free SETs is now implemented
+-- per X.691 #20: same as SEQUENCE, but the root components are
+-- transmitted in the canonical order of their tags.
 --
--- This module reproduces the minimal nested case: M is a SEQUENCE whose
--- single member s is of type S, a SET. Decoding or encoding M in UPER
--- (or OER) must fail cleanly (RC_FAIL / encoded == -1) rather than crash.
+-- Types in this module:
+--   M/S:  the original issue #12 reproducer, a SET nested in a
+--         SEQUENCE. {s {a 1, b TRUE}} must encode as 01 80.
+--   S2:   declaration order (b, a) differs from canonical tag order
+--         (a [1], b [2]); exercises the tag2el-driven reordering.
+--   S3:   DEFAULT + OPTIONAL members; exercises the presence bitmap
+--         and the canonical DEFAULT value elimination.
 
 ModuleSetNested
 	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
@@ -30,6 +33,22 @@ BEGIN
 	S ::= SET {
 		a INTEGER(0..255),
 		b BOOLEAN
+	}
+
+	-- Declaration order differs from the canonical tag order:
+	-- b is declared first but has the greater tag [2], so in UPER
+	-- the components are transmitted as a [1], then b [2].
+	S2 ::= SET {
+		b [2] BOOLEAN,
+		a [1] INTEGER(0..255)
+	}
+
+	-- Presence bitmap (2 bits: a, b in canonical order) plus
+	-- canonical DEFAULT value elimination for a.
+	S3 ::= SET {
+		a INTEGER(0..7) DEFAULT 5,
+		b BOOLEAN OPTIONAL,
+		c INTEGER(0..255)
 	}
 
 END

--- a/tests/tests-asn1c-compiler/169-set-nested-OK.asn1
+++ b/tests/tests-asn1c-compiler/169-set-nested-OK.asn1
@@ -1,0 +1,35 @@
+-- OK: Everything is fine
+
+-- iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+-- .spelio.software.asn1c.test (9363.1.5.1)
+-- .169
+
+-- asn1c has no PER/OER codec implementation for the SET type
+-- (skeletons/constr_SET.c's asn_OP_SET leaves uper_decoder, uper_encoder,
+-- oer_decoder and oer_encoder as null function pointers). A SET used at
+-- the outermost PDU level is already guarded (per_decoder.c checks
+-- td->op->uper_decoder before calling it), but a SET nested as a member
+-- of an enclosing SEQUENCE (or CHOICE, or *_OF) was not: the member-level
+-- call sites invoked the null function pointer directly, causing a
+-- SIGSEGV instead of a clean decode/encode failure (issue #12).
+--
+-- This module reproduces the minimal nested case: M is a SEQUENCE whose
+-- single member s is of type S, a SET. Decoding or encoding M in UPER
+-- (or OER) must fail cleanly (RC_FAIL / encoded == -1) rather than crash.
+
+ModuleSetNested
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 169 }
+	DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+	M ::= SEQUENCE {
+		s S
+	}
+
+	S ::= SET {
+		a INTEGER(0..255),
+		b BOOLEAN
+	}
+
+END

--- a/tests/tests-c-compiler/Makefile.am
+++ b/tests/tests-c-compiler/Makefile.am
@@ -67,6 +67,7 @@ TESTS += check-src/check-161.-fcompound-names.c
 TESTS += check-src/check-161.-fcompound-names.-gen-PER.c
 TESTS += check-src/check-162.c
 TESTS += check-src/check-164.-fcompound-names.c
+TESTS += check-src/check-169.-gen-PER.c
 
 if TEST_64BIT
 TESTS += check-src/check64-134.-gen-PER.c

--- a/tests/tests-c-compiler/check-src/check-169.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-169.-gen-PER.c
@@ -1,19 +1,24 @@
 /*
- * Regression for issue #12: asn1c has no PER/OER codec implementation for
- * the SET type (asn_OP_SET's uper_decoder/uper_encoder/oer_decoder/
- * oer_encoder are null). Decoding or encoding a *top-level* SET in UPER
- * already failed cleanly (per_decoder.c checks the function pointer before
- * calling it), but a SET nested as a member of an enclosing SEQUENCE was
- * not guarded at the member-level call sites (constr_SEQUENCE.c,
- * per_opentype.c), so asn1c called through a null function pointer and
- * crashed with SIGSEGV instead of returning a decode/encode failure.
+ * Regression for issue #12: asn1c had no PER codec implementation for the
+ * SET type (asn_OP_SET's uper_decoder/uper_encoder were null), so a SET
+ * nested inside a PER-encoded PDU crashed with SIGSEGV at the unguarded
+ * member-level call sites (stage 1 of the fix added the null checks; this
+ * test originally asserted the clean RC_FAIL). Stage 2 implements the
+ * UPER codec for extension-free SETs per X.691 #20: identical to the
+ * SEQUENCE encoding, except that the root components are transmitted in
+ * the canonical order of their tags (X.680 #8.6), taken from the
+ * statically sorted specs->tag2el map.
  *
- * This is a stage-1 "stop the bleeding" fix: it does not implement PER/OER
- * for SET, it just makes every member-level call site check the function
- * pointer first and fail cleanly (RC_FAIL / encoded == -1) instead of
- * dereferencing NULL. Before the fix, this test dies with SIGSEGV
- * (exit via signal, not via a normal exit code). After the fix, it
- * completes normally, asserting clean failures both ways.
+ * All the expected byte strings below are golden bytes produced by a
+ * commercial ASN.1 toolchain's (the project's interoperability reference)
+ * UPER encoder from the same values (and the reference toolchain
+ * decodes every asn1c-produced encoding back to the same values); they
+ * were additionally cross-checked against asn1tools 0.167 (Python).
+ * The single encoder divergence is intentional and covered below: for a
+ * DEFAULT member explicitly set to its default value, the reference
+ * toolchain (BASIC-PER encoder's choice, X.691 #19.2 NOTE) may encode the member as present
+ * (S3: ec 24), while asn1c always applies the CANONICAL-PER elimination
+ * (61 20). Both are valid UPER; asn1c must decode both.
  */
 #undef	NDEBUG
 #include <stdio.h>
@@ -22,50 +27,225 @@
 #include <assert.h>
 
 #include <M.h>
+#include <S2.h>
+#include <S3.h>
 
-int main() {
+static void
+check_M_roundtrip(void) {
+	/*
+	 * The original issue #12 reproducer: a SET nested in a SEQUENCE.
+	 * M { s { a 1, b TRUE } } = a (8 bits, 00000001) + b (1 bit, 1),
+	 * padded: 01 80. Decoding this used to SIGSEGV through the null
+	 * uper_decoder slot of asn_OP_SET.
+	 */
+	static const unsigned char enc[] = { 0x01, 0x80 };
+	unsigned char buf[8];
+	asn_enc_rval_t er;
+	asn_dec_rval_t rv;
+	M_t *m = 0;
+	M_t src;
+
+	rv = uper_decode(0, &asn_DEF_M, (void **)&m, enc, sizeof enc, 0, 0);
+	assert(rv.code == RC_OK);
+	assert(m->s.a == 1);
+	assert(m->s.b == 1);
+	ASN_STRUCT_FREE(asn_DEF_M, m);
+
+	memset(&src, 0, sizeof(src));
+	src.s.a = 1;
+	src.s.b = 1;
+	er = uper_encode_to_buffer(&asn_DEF_M, 0, &src, buf, sizeof buf);
+	assert(er.encoded == 9);
+	assert(buf[0] == 0x01 && buf[1] == 0x80);
+}
+
+static void
+check_S2_canonical_order(void) {
+	/*
+	 * S2 declares b [2] BOOLEAN before a [1] INTEGER(0..255), but the
+	 * canonical tag order is a [1], then b [2]. { a 1, b TRUE } must
+	 * therefore encode exactly like S { a 1, b TRUE }: 01 80. An
+	 * encoder that (incorrectly) walked the declaration order would
+	 * emit 80 80 instead.
+	 */
+	static const unsigned char enc[] = { 0x01, 0x80 };
+	unsigned char buf[8];
+	asn_enc_rval_t er;
+	asn_dec_rval_t rv;
+	S2_t *s2 = 0;
+	S2_t src;
+
+	memset(&src, 0, sizeof(src));
+	src.a = 1;
+	src.b = 1;
+	er = uper_encode_to_buffer(&asn_DEF_S2, 0, &src, buf, sizeof buf);
+	assert(er.encoded == 9);
+	assert(buf[0] == 0x01 && buf[1] == 0x80);
+
+	rv = uper_decode(0, &asn_DEF_S2, (void **)&s2, enc, sizeof enc, 0, 0);
+	assert(rv.code == RC_OK);
+	assert(s2->a == 1);
+	assert(s2->b == 1);
+
+	/* Re-encode what was decoded: must be byte-identical. */
+	er = uper_encode_to_buffer(&asn_DEF_S2, 0, s2, buf, sizeof buf);
+	assert(er.encoded == 9);
+	assert(buf[0] == 0x01 && buf[1] == 0x80);
+	ASN_STRUCT_FREE(asn_DEF_S2, s2);
+}
+
+static void
+check_S3_presence_and_default(void) {
+	/*
+	 * S3 ::= SET { a INTEGER(0..7) DEFAULT 5, b BOOLEAN OPTIONAL,
+	 *              c INTEGER(0..255) }. The preamble is a 2-bit
+	 * presence map (a, b in canonical order) followed by the present
+	 * members.
+	 */
+	unsigned char buf[8];
 	asn_enc_rval_t er;
 	asn_dec_rval_t rv;
 
 	/*
-	 * UPER decode of a two-byte buffer into the nested-SET-bearing M.
-	 * Before the fix: decoding the SEQUENCE root member "s" (type S,
-	 * a SET) calls S's (null) uper_decoder directly and segfaults.
-	 * After the fix: the null check in constr_SEQUENCE.c's member
-	 * decode loop makes it fail cleanly with RC_FAIL.
+	 * { c 9 }: a and b absent -> presence 00, c = 00001001;
+	 * 00 00001001 (10 bits) -> 02 40.
 	 */
 	{
-		static const unsigned char enc[] = { 0x2a, 0x80 };
-		M_t *m = 0;
+		static const unsigned char enc[] = { 0x02, 0x40 };
+		S3_t *s3 = 0;
+		S3_t src;
 
-		rv = uper_decode(0, &asn_DEF_M, (void **)&m, enc, sizeof enc, 0, 0);
-		assert(rv.code != RC_OK);
+		memset(&src, 0, sizeof(src));
+		src.c = 9;
+		er = uper_encode_to_buffer(&asn_DEF_S3, 0, &src, buf, sizeof buf);
+		assert(er.encoded == 10);
+		assert(buf[0] == 0x02 && buf[1] == 0x40);
 
-		/*
-		 * Whatever partial structure may have been allocated before
-		 * the failure must still be freeable.
-		 */
-		if(m) ASN_STRUCT_FREE(asn_DEF_M, m);
+		rv = uper_decode(0, &asn_DEF_S3, (void **)&s3, enc, sizeof enc,
+				 0, 0);
+		assert(rv.code == RC_OK);
+		assert(s3->a && *s3->a == 5);	/* DEFAULT filled in */
+		assert(s3->b == 0);		/* OPTIONAL absent */
+		assert(s3->c == 9);
+		ASN_STRUCT_FREE(asn_DEF_S3, s3);
 	}
 
 	/*
-	 * UPER encode of a fully-populated M (with its nested SET member
-	 * filled in). Before the fix: encoding the SEQUENCE root member
-	 * "s" calls S's (null) uper_encoder directly and segfaults. After
-	 * the fix: the null check in constr_SEQUENCE.c's member encode
-	 * loop makes it fail cleanly with encoded == -1.
+	 * { a 5, b TRUE, c 9 } with a *explicitly* equal to its DEFAULT:
+	 * canonical elimination reports a as absent -> presence 01,
+	 * b = 1, c = 00001001; 01 1 00001001 (11 bits) -> 61 20.
 	 */
 	{
-		M_t m;
-		unsigned char buf[16];
+		static const unsigned char enc[] = { 0x61, 0x20 };
+		S3_t *s3 = 0;
+		S3_t src;
+		long a = 5;
+		BOOLEAN_t b = 1;
 
-		memset(&m, 0, sizeof(m));
-		m.s.a = 7;
-		m.s.b = 1;
+		memset(&src, 0, sizeof(src));
+		src.a = &a;
+		src.b = &b;
+		src.c = 9;
+		er = uper_encode_to_buffer(&asn_DEF_S3, 0, &src, buf, sizeof buf);
+		assert(er.encoded == 11);
+		assert(buf[0] == 0x61 && buf[1] == 0x20);
 
-		er = uper_encode_to_buffer(&asn_DEF_M, 0, &m, buf, sizeof buf);
-		assert(er.encoded == -1);
+		rv = uper_decode(0, &asn_DEF_S3, (void **)&s3, enc, sizeof enc,
+				 0, 0);
+		assert(rv.code == RC_OK);
+		assert(s3->a && *s3->a == 5);
+		assert(s3->b && *s3->b != 0);
+		assert(s3->c == 9);
+		ASN_STRUCT_FREE(asn_DEF_S3, s3);
 	}
+
+	/*
+	 * Reference toolchain interop, decode-only: the reference toolchain
+	 * (BASIC-PER encoder's choice) may encode a DEFAULT member even when
+	 * it carries the default value: presence 11, a = 101 (5), b = 1,
+	 * c = 00001001; 11 101 1 00001001 (14 bits) -> ec 24, as produced by
+	 * the reference toolchain for { a 5, b TRUE, c 9 }. asn1c must decode
+	 * it, and its own re-encoding must collapse to the canonical
+	 * form 61 20 checked above.
+	 */
+	{
+		static const unsigned char enc[] = { 0xec, 0x24 };
+		S3_t *s3 = 0;
+
+		rv = uper_decode(0, &asn_DEF_S3, (void **)&s3, enc, sizeof enc,
+				 0, 0);
+		assert(rv.code == RC_OK);
+		assert(s3->a && *s3->a == 5);
+		assert(s3->b && *s3->b != 0);
+		assert(s3->c == 9);
+
+		er = uper_encode_to_buffer(&asn_DEF_S3, 0, s3, buf, sizeof buf);
+		assert(er.encoded == 11);
+		assert(buf[0] == 0x61 && buf[1] == 0x20);
+		ASN_STRUCT_FREE(asn_DEF_S3, s3);
+	}
+
+	/*
+	 * { a 3, c 9 }: a non-default (3 bits, 011), b absent ->
+	 * presence 10, a = 011, c = 00001001;
+	 * 10 011 00001001 (13 bits) -> 98 48.
+	 */
+	{
+		static const unsigned char enc[] = { 0x98, 0x48 };
+		S3_t *s3 = 0;
+		S3_t src;
+		long a = 3;
+
+		memset(&src, 0, sizeof(src));
+		src.a = &a;
+		src.c = 9;
+		er = uper_encode_to_buffer(&asn_DEF_S3, 0, &src, buf, sizeof buf);
+		assert(er.encoded == 13);
+		assert(buf[0] == 0x98 && buf[1] == 0x48);
+
+		rv = uper_decode(0, &asn_DEF_S3, (void **)&s3, enc, sizeof enc,
+				 0, 0);
+		assert(rv.code == RC_OK);
+		assert(s3->a && *s3->a == 3);
+		assert(s3->b == 0);
+		assert(s3->c == 9);
+		ASN_STRUCT_FREE(asn_DEF_S3, s3);
+	}
+
+	/*
+	 * { a 3, b FALSE, c 255 }: everything present ->
+	 * presence 11, a = 011, b = 0, c = 11111111;
+	 * 11 011 0 11111111 (14 bits) -> db fc.
+	 */
+	{
+		static const unsigned char enc[] = { 0xdb, 0xfc };
+		S3_t *s3 = 0;
+		S3_t src;
+		long a = 3;
+		BOOLEAN_t b = 0;
+
+		memset(&src, 0, sizeof(src));
+		src.a = &a;
+		src.b = &b;
+		src.c = 255;
+		er = uper_encode_to_buffer(&asn_DEF_S3, 0, &src, buf, sizeof buf);
+		assert(er.encoded == 14);
+		assert(buf[0] == 0xdb && buf[1] == 0xfc);
+
+		rv = uper_decode(0, &asn_DEF_S3, (void **)&s3, enc, sizeof enc,
+				 0, 0);
+		assert(rv.code == RC_OK);
+		assert(s3->a && *s3->a == 3);
+		assert(s3->b && *s3->b == 0);
+		assert(s3->c == 255);
+		ASN_STRUCT_FREE(asn_DEF_S3, s3);
+	}
+}
+
+int main() {
+	check_M_roundtrip();
+	check_S2_canonical_order();
+	check_S3_presence_and_default();
 
 	printf("Finished OK\n");
 	return 0;

--- a/tests/tests-c-compiler/check-src/check-169.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-169.-gen-PER.c
@@ -1,0 +1,72 @@
+/*
+ * Regression for issue #12: asn1c has no PER/OER codec implementation for
+ * the SET type (asn_OP_SET's uper_decoder/uper_encoder/oer_decoder/
+ * oer_encoder are null). Decoding or encoding a *top-level* SET in UPER
+ * already failed cleanly (per_decoder.c checks the function pointer before
+ * calling it), but a SET nested as a member of an enclosing SEQUENCE was
+ * not guarded at the member-level call sites (constr_SEQUENCE.c,
+ * per_opentype.c), so asn1c called through a null function pointer and
+ * crashed with SIGSEGV instead of returning a decode/encode failure.
+ *
+ * This is a stage-1 "stop the bleeding" fix: it does not implement PER/OER
+ * for SET, it just makes every member-level call site check the function
+ * pointer first and fail cleanly (RC_FAIL / encoded == -1) instead of
+ * dereferencing NULL. Before the fix, this test dies with SIGSEGV
+ * (exit via signal, not via a normal exit code). After the fix, it
+ * completes normally, asserting clean failures both ways.
+ */
+#undef	NDEBUG
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include <M.h>
+
+int main() {
+	asn_enc_rval_t er;
+	asn_dec_rval_t rv;
+
+	/*
+	 * UPER decode of a two-byte buffer into the nested-SET-bearing M.
+	 * Before the fix: decoding the SEQUENCE root member "s" (type S,
+	 * a SET) calls S's (null) uper_decoder directly and segfaults.
+	 * After the fix: the null check in constr_SEQUENCE.c's member
+	 * decode loop makes it fail cleanly with RC_FAIL.
+	 */
+	{
+		static const unsigned char enc[] = { 0x2a, 0x80 };
+		M_t *m = 0;
+
+		rv = uper_decode(0, &asn_DEF_M, (void **)&m, enc, sizeof enc, 0, 0);
+		assert(rv.code != RC_OK);
+
+		/*
+		 * Whatever partial structure may have been allocated before
+		 * the failure must still be freeable.
+		 */
+		if(m) ASN_STRUCT_FREE(asn_DEF_M, m);
+	}
+
+	/*
+	 * UPER encode of a fully-populated M (with its nested SET member
+	 * filled in). Before the fix: encoding the SEQUENCE root member
+	 * "s" calls S's (null) uper_encoder directly and segfaults. After
+	 * the fix: the null check in constr_SEQUENCE.c's member encode
+	 * loop makes it fail cleanly with encoded == -1.
+	 */
+	{
+		M_t m;
+		unsigned char buf[16];
+
+		memset(&m, 0, sizeof(m));
+		m.s.a = 7;
+		m.s.b = 1;
+
+		er = uper_encode_to_buffer(&asn_DEF_M, 0, &m, buf, sizeof buf);
+		assert(er.encoded == -1);
+	}
+
+	printf("Finished OK\n");
+	return 0;
+}

--- a/tests/tests-c-compiler/check-src/check-169.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-169.-gen-PER.c
@@ -29,6 +29,9 @@
 #include <M.h>
 #include <S2.h>
 #include <S3.h>
+#include <S4.h>
+#include <EmptyOD.h>
+#include <ObjectDescriptor.h>
 
 static void
 check_M_roundtrip(void) {
@@ -242,10 +245,154 @@ check_S3_presence_and_default(void) {
 	}
 }
 
+static void
+check_S4_untagged_choice_order(void) {
+	/*
+	 * S4 ::= SET { n [5] INTEGER(0..255), c CH } with CH an untagged
+	 * CHOICE { x [3] ..., y [4] ... }. The tag map carries one entry
+	 * per possible CHOICE tag ([3]->c, [4]->c, [5]->n), so the
+	 * canonical-order reconstruction must de-duplicate and sort c by
+	 * its smallest tag: c is transmitted first although n is
+	 * declared first. Golden bytes from the reference toolchain.
+	 */
+	unsigned char buf[8];
+	asn_enc_rval_t er;
+	asn_dec_rval_t rv;
+
+	/*
+	 * { n 7, c x:1 }: c = CHOICE index 0 (1 bit) + x (8 bits),
+	 * n = 00000111; 0 00000001 00000111 (17 bits) -> 00 83 80.
+	 */
+	{
+		static const unsigned char enc[] = { 0x00, 0x83, 0x80 };
+		S4_t *s4 = 0;
+		S4_t src;
+
+		memset(&src, 0, sizeof(src));
+		src.n = 7;
+		src.c.present = CH_PR_x;
+		src.c.choice.x = 1;
+		er = uper_encode_to_buffer(&asn_DEF_S4, 0, &src, buf, sizeof buf);
+		assert(er.encoded == 17);
+		assert(buf[0] == 0x00 && buf[1] == 0x83 && buf[2] == 0x80);
+
+		rv = uper_decode(0, &asn_DEF_S4, (void **)&s4, enc, sizeof enc,
+				 0, 0);
+		assert(rv.code == RC_OK);
+		assert(s4->n == 7);
+		assert(s4->c.present == CH_PR_x);
+		assert(s4->c.choice.x == 1);
+		ASN_STRUCT_FREE(asn_DEF_S4, s4);
+	}
+
+	/*
+	 * { n 7, c y:TRUE }: c = CHOICE index 1 (1 bit) + y (1 bit),
+	 * n = 00000111; 1 1 00000111 (10 bits) -> c1 c0.
+	 */
+	{
+		static const unsigned char enc[] = { 0xc1, 0xc0 };
+		S4_t *s4 = 0;
+		S4_t src;
+
+		memset(&src, 0, sizeof(src));
+		src.n = 7;
+		src.c.present = CH_PR_y;
+		src.c.choice.y = 1;
+		er = uper_encode_to_buffer(&asn_DEF_S4, 0, &src, buf, sizeof buf);
+		assert(er.encoded == 10);
+		assert(buf[0] == 0xc1 && buf[1] == 0xc0);
+
+		rv = uper_decode(0, &asn_DEF_S4, (void **)&s4, enc, sizeof enc,
+				 0, 0);
+		assert(rv.code == RC_OK);
+		assert(s4->n == 7);
+		assert(s4->c.present == CH_PR_y);
+		assert(s4->c.choice.y != 0);
+		ASN_STRUCT_FREE(asn_DEF_S4, s4);
+	}
+}
+
+static void
+check_EmptyOD_null_codec_gating(void) {
+	/*
+	 * Regression: the null-codec guard in SET_OF_decode_uper()
+	 * (shared by SEQUENCE OF via SEQUENCE_OF_decode_uper) must only
+	 * fire when there is at least one element to decode. An empty
+	 * collection never invokes the element codec, so it must decode
+	 * and encode fine (a single zero length determinant, 00) even if
+	 * the element type has no UPER codec; only a non-empty one must
+	 * fail cleanly.
+	 *
+	 * Since every generated type now has a UPER codec, the
+	 * codec-less element is simulated by pointing the element type's
+	 * operation table at a copy with the UPER slots nulled -- which
+	 * is exactly the situation a SET member used to be in before the
+	 * SET UPER codec existed.
+	 */
+	asn_TYPE_operation_t op_no_uper;
+	asn_TYPE_operation_t *saved_op = asn_DEF_ObjectDescriptor.op;
+	unsigned char buf[8];
+	asn_enc_rval_t er;
+	asn_dec_rval_t rv;
+
+	op_no_uper = *asn_DEF_ObjectDescriptor.op;
+	op_no_uper.uper_decoder = 0;
+	op_no_uper.uper_encoder = 0;
+	asn_DEF_ObjectDescriptor.op = &op_no_uper;
+
+	/* Empty: decode 00 -> RC_OK with zero elements. */
+	{
+		static const unsigned char enc[] = { 0x00 };
+		EmptyOD_t *e = 0;
+
+		rv = uper_decode(0, &asn_DEF_EmptyOD, (void **)&e, enc,
+				 sizeof enc, 0, 0);
+		assert(rv.code == RC_OK);
+		assert(e->list.count == 0);
+
+		/* Empty encode must succeed as well. */
+		er = uper_encode_to_buffer(&asn_DEF_EmptyOD, 0, e, buf,
+					   sizeof buf);
+		assert(er.encoded == 8);
+		assert(buf[0] == 0x00);
+		ASN_STRUCT_FREE(asn_DEF_EmptyOD, e);
+	}
+
+	/* Non-empty: must fail cleanly (RC_FAIL), not crash. */
+	{
+		static const unsigned char enc[] = { 0x01, 0x00 };
+		EmptyOD_t *e = 0;
+
+		rv = uper_decode(0, &asn_DEF_EmptyOD, (void **)&e, enc,
+				 sizeof enc, 0, 0);
+		assert(rv.code != RC_OK);
+		if(e) ASN_STRUCT_FREE(asn_DEF_EmptyOD, e);
+	}
+
+	asn_DEF_ObjectDescriptor.op = saved_op;
+
+	/*
+	 * With the real ObjectDescriptor codec back in place, an empty
+	 * round-trip must (still) work.
+	 */
+	{
+		static const unsigned char enc[] = { 0x00 };
+		EmptyOD_t *e = 0;
+
+		rv = uper_decode(0, &asn_DEF_EmptyOD, (void **)&e, enc,
+				 sizeof enc, 0, 0);
+		assert(rv.code == RC_OK);
+		assert(e->list.count == 0);
+		ASN_STRUCT_FREE(asn_DEF_EmptyOD, e);
+	}
+}
+
 int main() {
 	check_M_roundtrip();
 	check_S2_canonical_order();
 	check_S3_presence_and_default();
+	check_S4_untagged_choice_order();
+	check_EmptyOD_null_codec_gating();
 
 	printf("Finished OK\n");
 	return 0;


### PR DESCRIPTION
## Problem

`asn_OP_SET` leaves its UPER/OER codec slots null. A top-level SET decode was already guarded (`per_decoder.c`), but a SET **nested** as a member of a SEQUENCE / CHOICE / SET OF / SEQUENCE OF crashed with SIGSEGV: the member-level call sites invoked the null function pointer directly — a remotely triggerable DoS for any application whose schema nests a SET inside a PER/OER PDU.

## Root cause

A full audit of `op->uper_{decoder,encoder}` / `op->oer_{decoder,encoder}` call sites in `skeletons/` found 13 unguarded sites (member paths in `constr_SEQUENCE.c`, `constr_CHOICE.c`, `constr_SEQUENCE_OF.c`, `constr_SET_OF.c`, `per_opentype.c`, their OER twins, plus the OER top-level entry points `oer_decode`/`oer_encode` and open-type helpers, which had the same pattern). None of them checked the function pointer was non-null before calling through it.

## Fix, in three commits

**Commit 1 — stop the bleeding: fail cleanly on null member codec.** All 13 sites now check the pointer first and fail cleanly (`RC_FAIL` / `encoded == -1`) using each file's existing failure idiom.

**Commit 2 — implement the UPER codec for SET (root components, canonical tag order).** Per X.691 §21, the UPER encoding of a SET is the same as a SEQUENCE except the root components are transmitted in the **canonical order of their tags** (X.680 §8.6). `SET_decode_uper`/`SET_encode_uper` reuse the SEQUENCE root logic (presence bitmap for OPTIONAL/DEFAULT, DEFAULT fill-in on decode, canonical DEFAULT elimination on encode, per-member null-codec guards) and iterate through the statically sorted `specs->tag2el` map; an element with several candidate tags (untagged CHOICE) is ordered by its smallest tag (first occurrence in the sorted map).

Scope is root-only: `asn_SET_specifics_t` does not record which members are extension additions, so an **extensible** SET fails cleanly in both directions rather than misinterpret the bit stream. OER slots remain null (covered by commit 1's guards).

**Commit 3 — review hardening.** The SET OF / SEQUENCE OF decode-side null-codec guard is gated on the wire element count (an empty collection decodes fine regardless of the element codec, matching the other guards' gating), and test coverage is extended with a SET containing an untagged CHOICE member (exercising the multi-tag canonical-order dedup, golden bytes from the reference toolchain) plus an empty-collection decode regression.

## Validation

A major commercial ASN.1 toolchain (12.0) is the authoritative reference (asn1tools 0.167, `pip install asn1tools`, as an independent third-party cross-check). Cross matrix, all green:

| Vector | Reference toolchain | asn1c | Cross-decode |
|---|---|---|---|
| `M {s:{a:1,b:TRUE}}` (issue repro, nested SET, AUTOMATIC TAGS) | `01 80` | `01 80` | both ways OK |
| `S2 {a:1,b:TRUE}` (declaration order ≠ tag order) | `01 80` | `01 80` | both ways OK |
| `S3` OPTIONAL/DEFAULT bitmap vectors (4 value combinations) | = | = | both ways OK |
| `S3` with DEFAULT member explicitly at its default | `ec 24` (reference toolchain's BASIC-PER encoder's choice) | `61 20` (canonical) | asn1c decodes both forms; reference toolchain decodes asn1c's |

The declaration-order trap is load-bearing: encoding `S2` in declaration order would give `80 80`; all references agree on `01 80`, proving the `tag2el` reordering.

Red → green on master: the nested-SET decode of `2a 80` SIGSEGVs (exit 139); with commit 1 it fails cleanly; with commit 2 the full encode/decode round-trips pass.

## Tests

Fixture 169 (`169-set-nested-OK.asn1` + `check-169.-gen-PER.c`) asserts all of the above against the reference-toolchain-produced golden bytes, including the decode-only `ec 24` vector.

Regression: `tests-skeletons` and `tests-c-compiler` `make check` failure sets are name-for-name identical to the master baseline — zero new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
