### PR TITLE
OER: skip full open type content and unknown CHOICE extension alternatives

### DIFF
--- a/skeletons/constr_CHOICE_oer.c
+++ b/skeletons/constr_CHOICE_oer.c
@@ -200,11 +200,42 @@ CHOICE_decode_oer(const asn_codec_ctx_t *opt_codec_ctx,
                     ber_tlv_tag_string(tlv_tag), td->name);
                 RETURN(RC_FAIL);
             } else {
-                /* Skip open type extension */
+                /*
+                 * Unknown extension alternative: the peer selected a
+                 * CHOICE alternative added in a newer version of the
+                 * type. X.696 wraps that alternative in an Open Type;
+                 * consume the tag and skip the Open Type (length
+                 * determinant plus contents), then present the CHOICE
+                 * as having no recognized alternative selected, so that
+                 * an enclosing type can keep decoding subsequent fields
+                 * instead of failing the whole message (forward
+                 * compatibility, mirroring the UPER fix in
+                 * constr_CHOICE.c's CHOICE_decode_uper()).
+                 */
+                ssize_t skipped;
                 ASN_DEBUG(
-                    "Not implemented skipping open type extension for tag %s",
-                    ber_tlv_tag_string(tlv_tag));
-                RETURN(RC_FAIL);
+                    "Skipping unknown open type extension for tag %s "
+                    "in extensible CHOICE %s",
+                    ber_tlv_tag_string(tlv_tag), td->name);
+                /*
+                 * Do not ADVANCE() until the whole Open Type is known to
+                 * be available: on RC_WMORE nothing must be consumed
+                 * yet, since ctx->phase stays at 0 and a retry re-parses
+                 * the tag from the same (now longer) buffer from
+                 * scratch.
+                 */
+                skipped = oer_open_type_skip((const char *)ptr + tag_len,
+                                             size - tag_len);
+                if(skipped < 0) {
+                    RETURN(RC_FAIL);
+                } else if(skipped == 0) {
+                    RETURN(RC_WMORE);
+                }
+                ADVANCE(tag_len);
+                ADVANCE(skipped);
+                CHOICE_variant_set_presence(td, st, 0);
+                SET_PHASE(ctx, 2); /* Already decoded everything */
+                RETURN(RC_OK);
             }
         } while(0);
 

--- a/skeletons/oer_decoder.c
+++ b/skeletons/oer_decoder.c
@@ -41,12 +41,31 @@ oer_decode(const asn_codec_ctx_t *opt_codec_ctx,
 
 /*
  * Open Type is encoded as a length (#8.6) followed by that number of bytes.
- * Since we're just skipping, reading the length would be enough.
+ * RETURN VALUES:
+ *       0:     More data expected than bufptr contains.
+ *      -1:     Fatal error deciphering length.
+ *      >0:     Number of bytes to skip, i.e. the length determinant itself
+ *              plus the Open Type contents it describes.
  */
 ssize_t
 oer_open_type_skip(const void *bufptr, size_t size) {
     size_t len = 0;
-    return oer_fetch_length(bufptr, size, &len);
+    ssize_t len_len = oer_fetch_length(bufptr, size, &len);
+
+    if(len_len <= 0) {
+        return len_len; /* Error or more data expected */
+    }
+
+    /*
+     * len_len can't be bigger than size, but size without len_len
+     * should be bigger or equal to the content length.
+     */
+    if(size - len_len < len) {
+        /* More data is expected */
+        return 0;
+    }
+
+    return len_len + len;
 }
 
 /*

--- a/tests/tests-asn1c-compiler/170-oer-ext-skip-OK.asn1
+++ b/tests/tests-asn1c-compiler/170-oer-ext-skip-OK.asn1
@@ -1,0 +1,61 @@
+-- OK: Everything is fine
+
+-- iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+-- .spelio.software.asn1c.test (9363.1.5.1)
+-- .170
+
+-- OER forward compatibility with extension additions (issues #14, #15).
+--
+-- This module is the "v1" view of types whose "v2" peers carry extension
+-- additions unknown to us.  A v1 decoder must skip the unknown extension
+-- material and keep decoding the enclosing type, instead of silently
+-- shifting subsequent fields (#14: oer_open_type_skip() used to skip only
+-- the open type length determinant, not its contents) or failing the
+-- whole PDU (#15: an unknown CHOICE extension alternative used to return
+-- RC_FAIL).
+--
+-- Types in this module:
+--   M/Inner: SEQUENCE with an extensible inner SEQUENCE.  The v2 peer is
+--            Inner ::= SEQUENCE { x INTEGER(0..255), ..., y INTEGER(0..255) }
+--            (and a v3 peer additionally has z INTEGER(0..255)).
+--            Decoding v2/v3 bytes must recover a, x and b.
+--   C:       extensible CHOICE; the v2 peer adds c2 INTEGER(0..255) after
+--            the extension marker.  Decoding a v2 selection of c2 must
+--            succeed with no alternative selected (C_PR_NOTHING).
+--   MC:      C nested between two fields; proves that fields after an
+--            unknown CHOICE alternative are still recovered.
+--
+-- The golden v2/v3 byte streams in check-170.-gen-OER.c were produced by
+-- a commercial ASN.1 toolchain's OER codec (the project's interoperability reference)
+-- and cross-checked with asn1tools; the reference toolchain's v1 decoder gracefully skips
+-- all of them, which is the behavior this fixture pins down for asn1c.
+
+ModuleOerExtSkip
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 170 }
+	DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+	M ::= SEQUENCE {
+		a INTEGER(0..255),
+		inner Inner,
+		b INTEGER(0..255)
+	}
+
+	Inner ::= SEQUENCE {
+		x INTEGER(0..255),
+		...
+	}
+
+	C ::= CHOICE {
+		c1 INTEGER(0..255),
+		...
+	}
+
+	MC ::= SEQUENCE {
+		pre INTEGER(0..255),
+		c C,
+		post INTEGER(0..255)
+	}
+
+END

--- a/tests/tests-c-compiler/Makefile.am
+++ b/tests/tests-c-compiler/Makefile.am
@@ -67,6 +67,7 @@ TESTS += check-src/check-161.-fcompound-names.c
 TESTS += check-src/check-161.-fcompound-names.-gen-PER.c
 TESTS += check-src/check-162.c
 TESTS += check-src/check-164.-fcompound-names.c
+TESTS += check-src/check-170.-gen-OER.c
 
 if TEST_64BIT
 TESTS += check-src/check64-134.-gen-PER.c

--- a/tests/tests-c-compiler/check-src/check-170.-gen-OER.c
+++ b/tests/tests-c-compiler/check-src/check-170.-gen-OER.c
@@ -1,0 +1,198 @@
+/*
+ * Verify OER forward compatibility with extension additions.
+ *
+ * A decoder built from the v1 module (170-oer-ext-skip-OK.asn1) is fed
+ * byte streams produced by v2/v3 peers whose types carry extension
+ * additions unknown to v1:
+ *
+ *   v2:  Inner ::= SEQUENCE { x INTEGER(0..255), ..., y INTEGER(0..255) }
+ *   v3:  Inner ::= SEQUENCE { x INTEGER(0..255), ...,
+ *                             y INTEGER(0..255), z INTEGER(0..255) }
+ *   v2:  C ::= CHOICE { c1 INTEGER(0..255), ..., c2 INTEGER(0..255) }
+ *
+ * Issue #14: oer_open_type_skip() only skipped the open type length
+ * determinant, not the contents, so every unknown extension addition
+ * silently shifted all subsequent fields of the enclosing SEQUENCE.
+ * Issue #15: an unknown CHOICE extension alternative failed the whole
+ * PDU with RC_FAIL instead of being skipped.
+ *
+ * All golden byte vectors below were produced by a commercial ASN.1
+ * toolchain's (the project's interoperability reference) OER codec from
+ * the v2/v3 modules, and independently cross-checked with asn1tools
+ * (Python); both tools emit identical bytes.  The reference toolchain's
+ * v1 decoder gracefully
+ * skips every one of these streams (M: a=1 x=2 b=4; MC: pre=1
+ * choice=<none> post=4), which is the contract asserted here.
+ * The per-byte derivation is documented next to each vector.
+ */
+#undef	NDEBUG
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <string.h>
+#include <assert.h>
+
+#include <M.h>
+#include <MC.h>
+#include <C.h>
+
+/*
+ * v2 encoding of M {a 1, inner {x 2, y 3}, b 4}:
+ *   01           a = 1
+ *   80           Inner preamble: extension bit set
+ *   02           x = 2
+ *   02 07 80     extension presence bitmap: length 2, 7 unused bits,
+ *                bit 1 (y) present
+ *   01 03        open type: length 1, contents y = 3
+ *   04           b = 4
+ */
+static const uint8_t v2_seq[] = {
+    0x01, 0x80, 0x02, 0x02, 0x07, 0x80, 0x01, 0x03, 0x04
+};
+
+/*
+ * v3 encoding of M {a 1, inner {x 2, y 3, z 5}, b 4}:
+ *   01           a = 1
+ *   80           Inner preamble: extension bit set
+ *   02           x = 2
+ *   02 06 C0     extension presence bitmap: length 2, 6 unused bits,
+ *                bits 1..2 (y, z) present
+ *   01 03        open type: length 1, contents y = 3
+ *   01 05        open type: length 1, contents z = 5
+ *   04           b = 4
+ * Exercises consecutive unknown open types: with #14 unfixed, the first
+ * skipped content byte (03) is misread as the next length determinant.
+ */
+static const uint8_t v3_seq[] = {
+    0x01, 0x80, 0x02, 0x02, 0x06, 0xC0, 0x01, 0x03, 0x01, 0x05, 0x04
+};
+
+/*
+ * v1 encodings (root alternatives only), as emitted by the reference
+ * toolchain from the very same v1 module this test is compiled from;
+ * pins down the encode-side interoperability so the reference toolchain
+ * can decode what asn1c emits.
+ *   M {a 1, inner {x 2}, b 4}:   01 00 02 04
+ *                                (00 = Inner preamble, no extensions)
+ *   MC {pre 1, c c1 : 7, post 4}: 01 80 07 04 (80 = tag [0] of c1)
+ */
+static const uint8_t v1_seq[] = { 0x01, 0x00, 0x02, 0x04 };
+static const uint8_t v1_mc[] = { 0x01, 0x80, 0x07, 0x04 };
+
+/*
+ * Zero max_stack_size disables the stack-depth checker: sanitizer builds
+ * (ASAN/UBSAN) inflate stack frames enough to trip the default limit,
+ * which would mask the codec behavior under test with an unrelated
+ * RC_FAIL.
+ */
+static asn_codec_ctx_t s_no_stack_limit; /* zero-initialized */
+
+/* Unknown SEQUENCE extension addition is skipped; b is not shifted. */
+static void
+check_seq_skip(void) {
+    M_t *m = 0;
+    asn_dec_rval_t dr =
+        oer_decode(&s_no_stack_limit, &asn_DEF_M, (void **)&m, v2_seq, sizeof(v2_seq));
+
+    fprintf(stderr, "SEQ skip: code=%d consumed=%zu\n", dr.code, dr.consumed);
+    assert(dr.code == RC_OK);
+    fprintf(stderr, "SEQ skip: a=%ld x=%ld b=%ld\n", m->a, m->inner.x, m->b);
+    assert(dr.consumed == sizeof(v2_seq));
+    assert(m->a == 1);
+    assert(m->inner.x == 2);
+    assert(m->b == 4);  /* Unfixed #14 misdecodes b as 3 (the y payload) */
+
+    ASN_STRUCT_FREE(asn_DEF_M, m);
+}
+
+/* Two consecutive unknown extension additions are both skipped. */
+static void
+check_seq_skip_two_extensions(void) {
+    M_t *m = 0;
+    asn_dec_rval_t dr =
+        oer_decode(&s_no_stack_limit, &asn_DEF_M, (void **)&m, v3_seq, sizeof(v3_seq));
+
+    fprintf(stderr, "SEQ skip x2: code=%d consumed=%zu\n",
+            dr.code, dr.consumed);
+    assert(dr.code == RC_OK);
+    fprintf(stderr, "SEQ skip x2: a=%ld x=%ld b=%ld\n",
+            m->a, m->inner.x, m->b);
+    assert(dr.consumed == sizeof(v3_seq));
+    assert(m->a == 1);
+    assert(m->inner.x == 2);
+    assert(m->b == 4);
+
+    ASN_STRUCT_FREE(asn_DEF_M, m);
+}
+
+/*
+ * Input truncated inside the open type contents must starve (RC_WMORE),
+ * never read out of bounds or misdecode trailing fields.
+ * The 7-byte prefix of v2_seq ends right after the open type length
+ * determinant (01) with the announced content byte missing.
+ */
+static void
+check_seq_truncated(void) {
+    size_t cut;
+
+    for(cut = 7; cut < sizeof(v2_seq); cut++) {
+        /* Copy into an exactly-sized heap buffer so ASAN/valgrind would
+         * catch any read past the truncation point. */
+        uint8_t *buf = malloc(cut);
+        M_t *m = 0;
+        asn_dec_rval_t dr;
+
+        assert(buf);
+        memcpy(buf, v2_seq, cut);
+        dr = oer_decode(&s_no_stack_limit, &asn_DEF_M, (void **)&m, buf, cut);
+
+        fprintf(stderr, "SEQ truncated at %zu: code=%d consumed=%zu\n",
+                cut, dr.code, dr.consumed);
+        assert(dr.code == RC_WMORE);
+
+        ASN_STRUCT_FREE(asn_DEF_M, m);
+        free(buf);
+    }
+}
+
+/*
+ * Encode-side interop: asn1c's v1 encodings must be byte-identical to
+ * the reference toolchain's v1 encodings (it decodes both back to the
+ * same values).
+ */
+static void
+check_v1_encode_interop(void) {
+    uint8_t buf[16];
+
+    {
+        M_t m;
+        asn_enc_rval_t er;
+        memset(&m, 0, sizeof(m));
+        m.a = 1; m.inner.x = 2; m.b = 4;
+        er = oer_encode_to_buffer(&asn_DEF_M, 0, &m, buf, sizeof(buf));
+        fprintf(stderr, "v1 M encode: encoded=%zd\n", er.encoded);
+        assert(er.encoded == (ssize_t)sizeof(v1_seq));
+        assert(memcmp(buf, v1_seq, sizeof(v1_seq)) == 0);
+    }
+    {
+        MC_t mc;
+        asn_enc_rval_t er;
+        memset(&mc, 0, sizeof(mc));
+        mc.pre = 1;
+        mc.c.present = C_PR_c1;
+        mc.c.choice.c1 = 7;
+        mc.post = 4;
+        er = oer_encode_to_buffer(&asn_DEF_MC, 0, &mc, buf, sizeof(buf));
+        fprintf(stderr, "v1 MC encode: encoded=%zd\n", er.encoded);
+        assert(er.encoded == (ssize_t)sizeof(v1_mc));
+        assert(memcmp(buf, v1_mc, sizeof(v1_mc)) == 0);
+    }
+}
+
+int main() {
+    check_seq_skip();
+    check_seq_skip_two_extensions();
+    check_seq_truncated();
+    check_v1_encode_interop();
+    return 0;
+}

--- a/tests/tests-c-compiler/check-src/check-170.-gen-OER.c
+++ b/tests/tests-c-compiler/check-src/check-170.-gen-OER.c
@@ -68,6 +68,22 @@ static const uint8_t v3_seq[] = {
 };
 
 /*
+ * v2 encoding of C: c2 5 (extracted from the reference-toolchain-encoded MC below;
+ * a lone CHOICE PDU is encoded identically):
+ *   81           tag [1] (context class, automatic tag of c2)
+ *   01 05        open type: length 1, contents c2 = 5
+ */
+static const uint8_t v2_choice[] = { 0x81, 0x01, 0x05 };
+
+/*
+ * v2 encoding of MC {pre 1, c c2 : 5, post 4}:
+ *   01           pre = 1
+ *   81 01 05     c (see v2_choice above)
+ *   04           post = 4
+ */
+static const uint8_t v2_mc[] = { 0x01, 0x81, 0x01, 0x05, 0x04 };
+
+/*
  * v1 encodings (root alternatives only), as emitted by the reference
  * toolchain from the very same v1 module this test is compiled from;
  * pins down the encode-side interoperability so the reference toolchain
@@ -80,12 +96,20 @@ static const uint8_t v1_seq[] = { 0x01, 0x00, 0x02, 0x04 };
 static const uint8_t v1_mc[] = { 0x01, 0x80, 0x07, 0x04 };
 
 /*
- * Zero max_stack_size disables the stack-depth checker: sanitizer builds
- * (ASAN/UBSAN) inflate stack frames enough to trip the default limit,
- * which would mask the codec behavior under test with an unrelated
- * RC_FAIL.
+ * ASN__STACK_OVERFLOW_CHECK() estimates stack depth from the address
+ * spread between nested stack frames; under ASan's fake-stack frame
+ * allocation that spread can spuriously exceed ASN__DEFAULT_STACK_MAX
+ * (30000) after only a couple of calls. Passing a codec context with
+ * max_stack_size == 0 disables the check, matching how other ASan-built
+ * check-src drivers in this test suite avoid the same false positive.
  */
 static asn_codec_ctx_t s_no_stack_limit; /* zero-initialized */
+
+static int
+consume_bytes_dropper(const void *data, size_t size, void *app_key) {
+    (void)data; (void)size; (void)app_key;
+    return 0;
+}
 
 /* Unknown SEQUENCE extension addition is skipped; b is not shifted. */
 static void
@@ -155,6 +179,72 @@ check_seq_truncated(void) {
     }
 }
 
+/* Unknown CHOICE extension alternative: RC_OK, nothing selected. */
+static void
+check_choice_skip(void) {
+    C_t *c = 0;
+    asn_enc_rval_t er;
+    asn_dec_rval_t dr =
+        oer_decode(&s_no_stack_limit, &asn_DEF_C, (void **)&c, v2_choice, sizeof(v2_choice));
+
+    fprintf(stderr, "CHOICE skip: code=%d consumed=%zu\n",
+            dr.code, dr.consumed);
+    assert(dr.code == RC_OK);  /* Unfixed #15 returns RC_FAIL */
+    fprintf(stderr, "CHOICE skip: present=%d\n", (int)c->present);
+    assert(dr.consumed == sizeof(v2_choice));
+    assert(c->present == C_PR_NOTHING);
+
+    /* Re-encoding an unknown alternative is unsupported and must fail
+     * cleanly (no crash, no bytes emitted as if it were valid). */
+    er = oer_encode(&asn_DEF_C, c, consume_bytes_dropper, 0);
+    fprintf(stderr, "CHOICE re-encode: encoded=%zd\n", er.encoded);
+    assert(er.encoded == -1);
+
+    ASN_STRUCT_FREE(asn_DEF_C, c);
+}
+
+/* Fields following an unknown CHOICE alternative are still recovered. */
+static void
+check_choice_skip_nested(void) {
+    MC_t *mc = 0;
+    asn_dec_rval_t dr =
+        oer_decode(&s_no_stack_limit, &asn_DEF_MC, (void **)&mc, v2_mc, sizeof(v2_mc));
+
+    fprintf(stderr, "MC skip: code=%d consumed=%zu\n", dr.code, dr.consumed);
+    assert(dr.code == RC_OK);
+    fprintf(stderr, "MC skip: pre=%ld present=%d post=%ld\n",
+            mc->pre, (int)mc->c.present, mc->post);
+    assert(dr.consumed == sizeof(v2_mc));
+    assert(mc->pre == 1);
+    assert(mc->c.present == C_PR_NOTHING);
+    assert(mc->post == 4);
+
+    ASN_STRUCT_FREE(asn_DEF_MC, mc);
+}
+
+/* CHOICE truncated inside the open type contents must starve cleanly. */
+static void
+check_choice_truncated(void) {
+    size_t cut;
+
+    for(cut = 1; cut < sizeof(v2_choice); cut++) {
+        uint8_t *buf = malloc(cut);
+        C_t *c = 0;
+        asn_dec_rval_t dr;
+
+        assert(buf);
+        memcpy(buf, v2_choice, cut);
+        dr = oer_decode(&s_no_stack_limit, &asn_DEF_C, (void **)&c, buf, cut);
+
+        fprintf(stderr, "CHOICE truncated at %zu: code=%d consumed=%zu\n",
+                cut, dr.code, dr.consumed);
+        assert(dr.code == RC_WMORE);
+
+        ASN_STRUCT_FREE(asn_DEF_C, c);
+        free(buf);
+    }
+}
+
 /*
  * Encode-side interop: asn1c's v1 encodings must be byte-identical to
  * the reference toolchain's v1 encodings (it decodes both back to the
@@ -193,6 +283,9 @@ int main() {
     check_seq_skip();
     check_seq_skip_two_extensions();
     check_seq_truncated();
+    check_choice_skip();
+    check_choice_skip_nested();
+    check_choice_truncated();
     check_v1_encode_interop();
     return 0;
 }

--- a/tests/tests-c-compiler/check-src/check-170.-gen-OER.c
+++ b/tests/tests-c-compiler/check-src/check-170.-gen-OER.c
@@ -100,8 +100,9 @@ static const uint8_t v1_mc[] = { 0x01, 0x80, 0x07, 0x04 };
  * spread between nested stack frames; under ASan's fake-stack frame
  * allocation that spread can spuriously exceed ASN__DEFAULT_STACK_MAX
  * (30000) after only a couple of calls. Passing a codec context with
- * max_stack_size == 0 disables the check, matching how other ASan-built
- * check-src drivers in this test suite avoid the same false positive.
+ * max_stack_size == 0 disables the check entirely (per its own guard),
+ * so the assertions below test the codec logic rather than the
+ * environment-dependent stack estimate.
  */
 static asn_codec_ctx_t s_no_stack_limit; /* zero-initialized */
 
@@ -173,6 +174,10 @@ check_seq_truncated(void) {
         fprintf(stderr, "SEQ truncated at %zu: code=%d consumed=%zu\n",
                 cut, dr.code, dr.consumed);
         assert(dr.code == RC_WMORE);
+        /* The SEQUENCE decoder reports partial progress on RC_WMORE
+         * (its saved context supports resuming mid-PDU), but it must
+         * never claim to have consumed more than it was given. */
+        assert(dr.consumed <= cut);
 
         ASN_STRUCT_FREE(asn_DEF_M, m);
         free(buf);
@@ -239,6 +244,10 @@ check_choice_truncated(void) {
         fprintf(stderr, "CHOICE truncated at %zu: code=%d consumed=%zu\n",
                 cut, dr.code, dr.consumed);
         assert(dr.code == RC_WMORE);
+        /* The unknown-alternative skip path must not consume anything
+         * (not even the tag) before the whole Open Type is available:
+         * a retry re-parses the tag from scratch. */
+        assert(dr.consumed == 0);
 
         ASN_STRUCT_FREE(asn_DEF_C, c);
         free(buf);


### PR DESCRIPTION
## Problem

The OER twins of the UPER forward-compatibility fixes earlier in this series, in two commits (the second depends on the first).

**Commit 1**: `oer_open_type_skip()` skipped only the length determinant. It returned the result of `oer_fetch_length()` (the determinant byte count) and discarded the content length, so the SEQUENCE OER decoder's unknown-extension skip (PHASE 4) advanced past the determinant but never past the contents — every field after an unknown extension addition was silently decoded from shifted offsets.

Reproduced on master: a v2 peer's `M{a:1, inner{x:2, y:3}, b:4}` (`01 80 02 02 07 80 01 03 04`) decodes on v1 with **RC_OK and b=3** (the extension's payload byte); with two unknown additions a content byte is even consumed as the next length determinant (b=1).

**Commit 2**: `CHOICE_decode_oer()` hit an explicit "Not implemented" `RC_FAIL` when the tag matched no known alternative in an extensible CHOICE, failing the whole PDU on an unknown extension alternative.

## Root cause

- `skeletons/oer_decoder.c`: `oer_open_type_skip()`'s return value only accounted for the length determinant, not determinant + content, so the caller's cursor advance was short by exactly the content length on every unknown extension.
- `skeletons/constr_CHOICE_oer.c`: an unrecognized extension alternative tag in `CHOICE_decode_oer()` hit an explicit "Not implemented" `RC_FAIL` rather than skipping the Open Type wrapper. Per X.696 §20.2 (with the Open Type wrapping itself specified in X.696 clause 30), an extension addition alternative is carried as an open type exactly like UPER's, so the same skip-and-report-absent treatment applies.

## Fix

**Commit 1**: mirrors `oer_open_type_get()`'s arithmetic — return determinant + content size, keep the `oer_fetch_length` contract (0 = want more, −1 = fatal), and return 0 (WMORE) if the announced contents exceed the remaining buffer. The caller already maps 0/−1/positive correctly.

**Commit 2**: now mirrors the UPER fix — consume the tag, skip the Open Type wrapper (via the fixed `oer_open_type_skip`), set presence to 0 (`<Type>_PR_NOTHING`), return RC_OK. Nothing is consumed before the whole Open Type is available — on RC_WMORE the phase stays at 0 and a retry re-parses the tag from scratch. Re-encoding a present==0 CHOICE already fails cleanly in `CHOICE_encode_oer` (asserted, no encoder change needed).

Same application contract as the UPER fix: decode succeeds, surrounding fields recovered, unknown alternative not re-encodable.

## Validation

A major commercial ASN.1 toolchain (12.0) is the authoritative reference (asn1tools byte-identical on all vectors as independent third-party cross-check, `pip install asn1tools`). Bidirectional matrix, all green:

| Vector | Encoder | Bytes | Decoders | Result |
|---|---|---|---|---|
| v2 `M {1,{2,y:3},4}` | reference toolchain v2 | `01 80 02 02 07 80 01 03 04` | reference toolchain v1, asn1c v1 (fixed) | a=1 x=2 b=4 |
| v3 `M {1,{2,3,5},4}` (two unknown additions) | reference toolchain v3 | `01 80 02 02 06 c0 01 03 01 05 04` | reference toolchain v1, asn1c v1 | a=1 x=2 b=4 |
| v2 `MC {1, c2:5, 4}` (unknown CHOICE alternative) | reference toolchain v2 | `01 81 01 05 04` | reference toolchain v1 (choice absent), asn1c v1 (present==NOTHING) | pre=1 post=4 |
| v1 `M`, v1 `MC` | asn1c v1 | `01 00 02 04` / `01 80 07 04` | reference toolchain v1 and v2 | values match, byte-identical to reference toolchain |

Red → green on master: single unknown extension → silent corruption (b=3); double → cascade misparse (b=1); unknown CHOICE alternative → whole PDU RC_FAIL. All pass after the two commits.

## Tests

Fixture 170 (`170-oer-ext-skip-OK.asn1` + `check-170.-gen-OER.c`) pins all of the above plus truncation robustness: cutting the stream inside the Open Type returns RC_WMORE (the CHOICE path consumes nothing so a retry re-parses the tag from scratch; the SEQUENCE path may report partial progress, never beyond the truncated buffer, supporting resumed decode) — no out-of-bounds reads under ASAN/UBSAN (the skip path is network-facing attack surface).

Regression: `tests-skeletons` and `tests-c-compiler` `make check` failure sets name-for-name identical to the master baseline (zero new failures; the new fixture is the only delta, new PASS).

## Behavior change & migration

- **New observable state**: an OER CHOICE that decodes an unknown extension alternative now reports presence `<Type>_PR_NOTHING` (the same value used for "no alternative selected") instead of failing the whole decode, exactly mirroring the UPER CHOICE fix earlier in this series.
- **Migration safety net**: `asn_check_constraints()` after decode reports "no CHOICE element given" for this state, and OER/DER/XER re-encoding fail cleanly (an absent selection is not encodable) — an equivalent way to recover the old reject semantics for callers that need it.
- A companion PR in this series adds a compile-time escape hatch (`ASN_REJECT_UNKNOWN_EXTENSIONS`) restoring clean `RC_FAIL` at exactly this site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
