### PR TITLE
UPER: emit X.691 §11.6 long-form flag bit in uper_put_nsnnwn()/uper_put_nslength()

### DIFF
--- a/skeletons/per_support.c
+++ b/skeletons/per_support.c
@@ -96,24 +96,35 @@ uper_get_nsnnwn(asn_per_data_t *pd) {
 /*
  * X.691-11/2008, #11.6
  * Encoding of a normally small non-negative whole number
+ *
+ * This is the strict inverse of uper_get_nsnnwn() above: for n <= 63,
+ * emit a single 7-bit field whose top bit (the "0" flag) is naturally
+ * zero, followed by 6 bits of n (#11.6, short form referencing #11.5).
+ * For n >= 64, emit an explicit 1-bit "1" flag, followed by a
+ * short-form general length determinant octet (#11.9.3.6) giving the
+ * number of octets ("bytes") used to encode n, followed by that many
+ * octets of n itself. uper_get_nsnnwn() only understands 1- or 2-octet
+ * long forms (n up to 65535), so we fail cleanly rather than emitting
+ * a stream our own decoder (or any compliant peer) cannot read back.
  */
 int
 uper_put_nsnnwn(asn_per_outp_t *po, int n) {
 	int bytes;
 
+	if(n < 0) return -1;
 	if(n <= 63) {
-		if(n < 0) return -1;
 		return per_put_few_bits(po, n, 7);
 	}
 	if(n < 256)
 		bytes = 1;
 	else if(n < 65536)
 		bytes = 2;
-	else if(n < 256 * 65536)
-		bytes = 3;
 	else
-		return -1;	/* This is not a "normally small" value */
-	if(per_put_few_bits(po, bytes, 8))
+		return -1;	/* Not supported by uper_get_nsnnwn() either */
+
+	if(per_put_few_bits(po, 1, 1))	/* Long-form flag bit, #11.6 */
+		return -1;
+	if(per_put_few_bits(po, bytes, 8)) /* Length determinant, #11.9.3.6 */
 		return -1;
 
 	return per_put_few_bits(po, n, 8 * bytes);
@@ -196,15 +207,25 @@ uper_put_length(asn_per_outp_t *po, size_t length, int *need_eom) {
  * Put the normally small length "n" into the stream.
  * This procedure used to encode length of extensions bit-maps
  * for SET and SEQUENCE types.
+ *
+ * This is the strict inverse of uper_get_nslength() above: short form
+ * (length <= 64) is a "0" flag bit folded into a 7-bit field together
+ * with (length - 1). Long form (length > 64) requires an explicit
+ * "1" flag bit before the general length determinant of #11.9 --
+ * without it, uper_get_nslength() cannot tell the two forms apart.
  */
 int
 uper_put_nslength(asn_per_outp_t *po, size_t length) {
+    if(length == 0) return -1; /* #11.9.3.4 */
     if(length <= 64) {
-        /* #11.9.3.4 */
-        if(length == 0) return -1;
+        /* #11.9.3.4: "0" flag bit + 6-bit (length - 1) */
         return per_put_few_bits(po, length - 1, 7) ? -1 : 0;
     } else {
         int need_eom = 0;
+        /* Long-form flag bit, mirrors uper_get_nslength()'s
+         * per_get_few_bits(pd, 1) branch test. */
+        if(per_put_few_bits(po, 1, 1))
+            return -1;
         if(uper_put_length(po, length, &need_eom) != (ssize_t)length
            || need_eom) {
             /* This might happen in case of >16K extensions */

--- a/tests/tests-asn1c-compiler/172-enum-large-ext-OK.asn1
+++ b/tests/tests-asn1c-compiler/172-enum-large-ext-OK.asn1
@@ -1,0 +1,32 @@
+-- OK: Everything is fine
+
+-- iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+-- .spelio.software.asn1c.test (9363.1.5.1)
+-- .172
+
+ModuleEnumLargeExt
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 172 }
+	DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+	-- An extensible ENUMERATED with 70 extension additions, so that
+	-- the UPER extension index (normally small non-negative whole
+	-- number, X.691 #11.6) crosses the short/long form boundary at 64.
+	-- Exercises the long-form "1" flag bit emitted by
+	-- uper_put_nsnnwn() (fix for issue #16).
+	E ::= ENUMERATED {
+		zero,
+		...,
+		add0, add1, add2, add3, add4, add5, add6, add7, add8, add9,
+		add10, add11, add12, add13, add14, add15, add16, add17,
+		add18, add19, add20, add21, add22, add23, add24, add25,
+		add26, add27, add28, add29, add30, add31, add32, add33,
+		add34, add35, add36, add37, add38, add39, add40, add41,
+		add42, add43, add44, add45, add46, add47, add48, add49,
+		add50, add51, add52, add53, add54, add55, add56, add57,
+		add58, add59, add60, add61, add62, add63, add64, add65,
+		add66, add67, add68, add69
+	}
+
+END

--- a/tests/tests-c-compiler/Makefile.am
+++ b/tests/tests-c-compiler/Makefile.am
@@ -67,6 +67,7 @@ TESTS += check-src/check-161.-fcompound-names.c
 TESTS += check-src/check-161.-fcompound-names.-gen-PER.c
 TESTS += check-src/check-162.c
 TESTS += check-src/check-164.-fcompound-names.c
+TESTS += check-src/check-172.-gen-PER.c
 
 if TEST_64BIT
 TESTS += check-src/check64-134.-gen-PER.c

--- a/tests/tests-c-compiler/check-src/check-172.-gen-PER.c
+++ b/tests/tests-c-compiler/check-src/check-172.-gen-PER.c
@@ -1,0 +1,86 @@
+/*
+ * UPER encoding of large ENUMERATED extension indices (X.691 #11.6).
+ * The normally small non-negative whole number carrying the extension
+ * index switches to the long form at 64, which must start with a "1"
+ * flag bit before the general length determinant.  uper_put_nsnnwn()
+ * used to omit that flag bit (issue #16), producing byte streams that
+ * no compliant decoder -- including asn1c's own uper_get_nsnnwn() --
+ * could read back (e.g. add65 encoded as 80 a0 80 and silently decoded
+ * as extension index 0).
+ *
+ * The golden byte streams below were produced by a reference encoder
+ * (a commercial ASN.1 toolchain's UPER encoder, the project's
+ * interoperability reference) from this same module:
+ *   add63 (ext idx 63) -> bf         (short form boundary)
+ *   add64 (ext idx 64) -> c0 50 00   (long form threshold)
+ *   add65 (ext idx 65) -> c0 50 40
+ *   add69 (ext idx 69) -> c0 51 40
+ */
+#undef	NDEBUG
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include <E.h>
+
+static void
+check_vector(long value, const unsigned char *expected, size_t expected_len) {
+	unsigned char buf[8];
+	E_t enc_value = value;
+	E_t *dec_value = 0;
+	asn_enc_rval_t er;
+	asn_dec_rval_t rv;
+	size_t i;
+
+	/* Encode and compare byte-for-byte against the reference toolchain's golden bytes. */
+	er = uper_encode_to_buffer(&asn_DEF_E, 0, &enc_value,
+			buf, sizeof(buf));
+	assert(er.encoded >= 0);
+	assert((size_t)(er.encoded + 7) / 8 == expected_len);
+	fprintf(stderr, "E=%ld =>", value);
+	for(i = 0; i < expected_len; i++)
+		fprintf(stderr, " %02x", buf[i]);
+	fprintf(stderr, " (expected");
+	for(i = 0; i < expected_len; i++)
+		fprintf(stderr, " %02x", expected[i]);
+	fprintf(stderr, ")\n");
+	assert(memcmp(buf, expected, expected_len) == 0);
+
+	/* Decode our own bytes back: must recover the original value. */
+	rv = uper_decode(0, &asn_DEF_E, (void *)&dec_value,
+			buf, expected_len, 0, 0);
+	assert(rv.code == RC_OK);
+	assert(*dec_value == value);
+
+	/* Re-encode the decoded value: must be idempotent. */
+	{
+		unsigned char buf2[8];
+		asn_enc_rval_t er2 = uper_encode_to_buffer(&asn_DEF_E, 0,
+				dec_value, buf2, sizeof(buf2));
+		assert(er2.encoded == er.encoded);
+		assert(memcmp(buf2, expected, expected_len) == 0);
+	}
+
+	ASN_STRUCT_FREE(asn_DEF_E, dec_value);
+}
+
+int main() {
+	/* Reference toolchain golden bytes (its UPER encoder). */
+	static const unsigned char ref_add63[] = { 0xbf };
+	static const unsigned char ref_add64[] = { 0xc0, 0x50, 0x00 };
+	static const unsigned char ref_add65[] = { 0xc0, 0x50, 0x40 };
+	static const unsigned char ref_add69[] = { 0xc0, 0x51, 0x40 };
+	static const unsigned char ref_zero[]  = { 0x00 };
+
+	check_vector(E_add63, ref_add63, sizeof(ref_add63));
+	check_vector(E_add64, ref_add64, sizeof(ref_add64));
+	check_vector(E_add65, ref_add65, sizeof(ref_add65));
+	check_vector(E_add69, ref_add69, sizeof(ref_add69));
+
+	/* Root value sanity baseline. */
+	check_vector(E_zero, ref_zero, sizeof(ref_zero));
+
+	printf("Finished %s\n", __FILE__);
+	return 0;
+}

--- a/tests/tests-skeletons/Makefile.am
+++ b/tests/tests-skeletons/Makefile.am
@@ -17,7 +17,8 @@ check_PROGRAMS =            \
     check-OER-NativeEnumerated \
     check-PER-support       \
     check-PER-UniversalString  \
-    check-PER-INTEGER
+    check-PER-INTEGER      \
+    check-PER-nsnnwn
 
 if EXPLICIT_M32
 check_PROGRAMS +=                   \
@@ -37,7 +38,8 @@ check_PROGRAMS +=                   \
     check-32-OER-NativeEnumerated   \
     check-32-PER-support            \
     check-32-PER-UniversalString    \
-    check-32-PER-INTEGER
+    check-32-PER-INTEGER            \
+    check-32-PER-nsnnwn
 
 check_32_ber_tlv_tag_CFLAGS=$(CFLAGS_M32)
 check_32_ber_tlv_tag_LDADD=$(LDADD_32)
@@ -90,6 +92,9 @@ check_32_PER_UniversalString_SOURCES=check-PER-UniversalString.c
 check_32_PER_INTEGER_CFLAGS=$(CFLAGS_M32)
 check_32_PER_INTEGER_LDADD=$(LDADD_32)
 check_32_PER_INTEGER_SOURCES=check-PER-INTEGER.c
+check_32_PER_nsnnwn_CFLAGS=$(CFLAGS_M32)
+check_32_PER_nsnnwn_LDADD=$(LDADD_32)
+check_32_PER_nsnnwn_SOURCES=check-PER-nsnnwn.c
 
 LDADD_32 = -lm $(top_builddir)/skeletons/libasn1cskeletons_c89_32.la
 endif

--- a/tests/tests-skeletons/check-PER-nsnnwn.c
+++ b/tests/tests-skeletons/check-PER-nsnnwn.c
@@ -1,0 +1,289 @@
+/*
+ * Regression test for uper_put_nsnnwn()/uper_put_nslength() (per_support.c).
+ *
+ * X.691 #11.6 requires the long form (value/length >= 64) to begin with
+ * an explicit "1" flag bit before the general length determinant. The
+ * old uper_put_nsnnwn() emitted a bare byte-count octet plus the value,
+ * with no flag bit at all; the old uper_put_nslength() called
+ * uper_put_length() directly for length > 64, also skipping the flag
+ * bit. Both bugs make the encoder's own output undecodable by
+ * uper_get_nsnnwn()/uper_get_nslength() -- values silently come back
+ * wrong instead of failing loudly.
+ *
+ * This test round-trips put -> get for a range of values that span the
+ * short/long-form boundary, and additionally pins down the exact bit
+ * pattern the long form must produce, derived by hand from the (correct)
+ * uper_get_nsnnwn()/uper_get_nslength() decode logic.
+ */
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <asn_application.h>
+#include <per_support.h>
+
+/* ------------------------------------------------------------------ */
+/* uper_put_nsnnwn() / uper_get_nsnnwn() round trip                    */
+/* ------------------------------------------------------------------ */
+
+static void
+check_nsnnwn_roundtrip(long n, int expect_fail) {
+    asn_per_outp_t po;
+    asn_per_data_t pd;
+    int ret;
+    ssize_t got;
+    size_t total_bits;
+
+    memset(&po, 0, sizeof(po));
+    po.buffer = po.tmpspace;
+    po.nbits = 8 * sizeof(po.tmpspace);
+
+    ret = uper_put_nsnnwn(&po, (int)n);
+    fprintf(stderr, "put_nsnnwn(%ld) => %d\n", n, ret);
+
+    if(expect_fail) {
+        assert(ret == -1);
+        return;
+    }
+    assert(ret == 0);
+
+    memset(&pd, 0, sizeof(pd));
+    pd.buffer = po.tmpspace;
+    pd.nboff = 0;
+    /* NOTE: pd.nbits is not a fixed "total length" -- asn_get_few_bits()
+     * shrinks it in lockstep with pd.buffer as it normalizes past whole
+     * consumed octets (mirroring the encoder side). Save the true total
+     * up front and compare uper_get_nsnnwn()'s pd.moved against that,
+     * not against the (mutated) post-decode pd.nbits. */
+    total_bits = 8 * (po.buffer - po.tmpspace) + po.nboff;
+    pd.nbits = total_bits;
+
+    got = uper_get_nsnnwn(&pd);
+    fprintf(stderr, "  get_nsnnwn() => %zd (moved %zu of %zu total bits)\n",
+            got, pd.moved, total_bits);
+    assert(got == n);
+
+    /* The value must be the *only* thing encoded: no leftover bits that
+     * would silently bleed into a following field. */
+    assert(pd.moved == total_bits);
+}
+
+/*
+ * Bit-exact check for the long form. Verified against uper_get_nsnnwn()'s
+ * decode logic by hand:
+ *   1 flag bit "1"
+ *   + 8-bit length-determinant octet (short form, #11.9.3.6): byte count
+ *     of the value (1 or 2 -- uper_get_nsnnwn() rejects byte counts >= 3)
+ *   + that many 8-bit octets of the value, big-endian.
+ */
+static void
+check_nsnnwn_bits(long n, const uint8_t *expected, size_t expected_bytes,
+                   size_t expected_bits) {
+    asn_per_outp_t po;
+    int ret;
+
+    memset(&po, 0, sizeof(po));
+    po.buffer = po.tmpspace;
+    po.nbits = 8 * sizeof(po.tmpspace);
+
+    ret = uper_put_nsnnwn(&po, (int)n);
+    assert(ret == 0);
+
+    size_t produced_bits = 8 * (po.buffer - po.tmpspace) + po.nboff;
+    fprintf(stderr, "bits_nsnnwn(%ld): produced %zu bits, expected %zu\n", n,
+            produced_bits, expected_bits);
+    assert(produced_bits == expected_bits);
+
+    size_t produced_bytes = (produced_bits + 7) / 8;
+    assert(produced_bytes == expected_bytes);
+    assert(memcmp(po.tmpspace, expected, expected_bytes) == 0);
+}
+
+static void
+check_nsnnwn_all(void) {
+    /* Short form: n <= 63, 7 bits total, top bit implicitly 0. */
+    check_nsnnwn_roundtrip(0, 0);
+    check_nsnnwn_roundtrip(1, 0);
+    check_nsnnwn_roundtrip(63, 0);
+
+    /* Long form boundary and beyond. */
+    check_nsnnwn_roundtrip(64, 0);
+    check_nsnnwn_roundtrip(65, 0);
+    check_nsnnwn_roundtrip(100, 0);
+    check_nsnnwn_roundtrip(255, 0);
+    check_nsnnwn_roundtrip(256, 0);
+    check_nsnnwn_roundtrip(1000, 0);
+    check_nsnnwn_roundtrip(65535, 0);
+
+    /* Beyond what uper_get_nsnnwn() can parse back (byte count >= 3):
+     * must fail cleanly rather than emit an unreadable stream. */
+    check_nsnnwn_roundtrip(65536, 1);
+    check_nsnnwn_roundtrip(1000000, 1);
+
+    check_nsnnwn_roundtrip(-1, 1);
+
+    /*
+     * Hand-derived (cross-checked with a Python bit-string simulation of
+     * uper_get_nsnnwn()'s decode logic) expected bit patterns for the
+     * long form. Trailing pad bits emitted by asn_put_few_bits() are 0.
+     *
+     * n=64:  flag=1, length-octet=00000001 (1 byte), value=01000000
+     *        -> bits: 1 00000001 01000000  (17 bits -> padded to 3 bytes)
+     *        -> "10000000" "10100000" "0"+7 pad zeros
+     *                0x80       0xA0       0x00
+     */
+    {
+        static const uint8_t expected64[] = {0x80, 0xA0, 0x00};
+        check_nsnnwn_bits(64, expected64, sizeof(expected64), 17);
+    }
+    /*
+     * n=65:  flag=1, length-octet=00000001, value=01000001
+     *        bits: 1 00000001 01000001  (17 bits)
+     *        -> "10000000" "10100000" "1"+7 pad zeros
+     *                0x80       0xA0       0x80
+     */
+    {
+        static const uint8_t expected65[] = {0x80, 0xA0, 0x80};
+        check_nsnnwn_bits(65, expected65, sizeof(expected65), 17);
+    }
+    /*
+     * n=255: flag=1, length-octet=00000001, value=11111111
+     *        bits: 1 00000001 11111111  (17 bits)
+     *        -> "10000000" "10111111" "1"+7 pad zeros
+     *                0x80       0xFF       0x80
+     */
+    {
+        static const uint8_t expected255[] = {0x80, 0xFF, 0x80};
+        check_nsnnwn_bits(255, expected255, sizeof(expected255), 17);
+    }
+    /*
+     * n=256: flag=1, length-octet=00000010 (2 bytes), value=0000000100000000
+     *        bits: 1 00000010 0000000100000000  (25 bits -> 4 bytes)
+     *        -> 0x81 0x00 0x80 0x00
+     */
+    {
+        static const uint8_t expected256[] = {0x81, 0x00, 0x80, 0x00};
+        check_nsnnwn_bits(256, expected256, sizeof(expected256), 25);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* uper_put_nslength() / uper_get_nslength() round trip                */
+/* ------------------------------------------------------------------ */
+
+static void
+check_nslength_roundtrip(size_t length, int expect_fail) {
+    asn_per_outp_t po;
+    asn_per_data_t pd;
+    int ret;
+    ssize_t got;
+    size_t total_bits;
+
+    memset(&po, 0, sizeof(po));
+    po.buffer = po.tmpspace;
+    po.nbits = 8 * sizeof(po.tmpspace);
+
+    ret = uper_put_nslength(&po, length);
+    fprintf(stderr, "put_nslength(%zu) => %d\n", length, ret);
+
+    if(expect_fail) {
+        assert(ret == -1);
+        return;
+    }
+    assert(ret == 0);
+
+    memset(&pd, 0, sizeof(pd));
+    pd.buffer = po.tmpspace;
+    pd.nboff = 0;
+    /* See check_nsnnwn_roundtrip() for why total_bits must be captured
+     * separately from pd.nbits, which mutates during decode. */
+    total_bits = 8 * (po.buffer - po.tmpspace) + po.nboff;
+    pd.nbits = total_bits;
+
+    got = uper_get_nslength(&pd);
+    fprintf(stderr, "  get_nslength() => %zd (moved %zu of %zu total bits)\n",
+            got, pd.moved, total_bits);
+    assert(got == (ssize_t)length);
+    assert(pd.moved == total_bits);
+}
+
+static void
+check_nslength_bits(size_t length, const uint8_t *expected,
+                     size_t expected_bytes, size_t expected_bits) {
+    asn_per_outp_t po;
+    int ret;
+
+    memset(&po, 0, sizeof(po));
+    po.buffer = po.tmpspace;
+    po.nbits = 8 * sizeof(po.tmpspace);
+
+    ret = uper_put_nslength(&po, length);
+    assert(ret == 0);
+
+    size_t produced_bits = 8 * (po.buffer - po.tmpspace) + po.nboff;
+    fprintf(stderr, "bits_nslength(%zu): produced %zu bits, expected %zu\n",
+            length, produced_bits, expected_bits);
+    assert(produced_bits == expected_bits);
+
+    size_t produced_bytes = (produced_bits + 7) / 8;
+    assert(produced_bytes == expected_bytes);
+    assert(memcmp(po.tmpspace, expected, expected_bytes) == 0);
+}
+
+static void
+check_nslength_all(void) {
+    /* nslength lower bound is 1; 0 is invalid. */
+    check_nslength_roundtrip(0, 1);
+
+    /* Short form: 1 <= length <= 64, 7 bits total ("0" flag + 6-bit
+     * (length-1)). */
+    check_nslength_roundtrip(1, 0);
+    check_nslength_roundtrip(63, 0);
+    check_nslength_roundtrip(64, 0);
+
+    /* Long form: length > 64. */
+    check_nslength_roundtrip(65, 0);
+    check_nslength_roundtrip(100, 0);
+    check_nslength_roundtrip(127, 0);
+    check_nslength_roundtrip(128, 0);
+    check_nslength_roundtrip(1000, 0);
+    check_nslength_roundtrip(16383, 0);
+
+    /* length >= 16384 hits a separate, pre-existing limitation of
+     * uper_put_length()/uper_put_nslength(): a single call cannot
+     * express a length that would require an end-of-message-marker
+     * continuation (uper_put_length() only ever emits one 16K block
+     * count per call and the caller here never loops for EOM). This is
+     * outside the scope of the #11.6 long-form flag-bit fix -- confirm
+     * it still fails cleanly rather than emitting an unreadable stream. */
+    check_nslength_roundtrip(16384, 1);
+
+    /*
+     * Hand-derived expected bit pattern for length=65:
+     * flag "1" + short-form length determinant octet (#11.9.3.6) with
+     * value 65: 0_1000001
+     * bits: 1 01000001  (9 bits)
+     * bytes: 1010_0000  1000_0000
+     *         0xA0       0x80
+     */
+    {
+        static const uint8_t expected65[] = {0xA0, 0x80};
+        check_nslength_bits(65, expected65, sizeof(expected65), 9);
+    }
+    /*
+     * length=64 (short form, no flag bit involved at all):
+     * "0" flag + 6-bit(63) = 0 111111 = 0111111
+     * bits: 0111111 (7 bits) -> byte 0111_1110 = 0x7E (padded)
+     */
+    {
+        static const uint8_t expected64[] = {0x7E};
+        check_nslength_bits(64, expected64, sizeof(expected64), 7);
+    }
+}
+
+int
+main(void) {
+    check_nsnnwn_all();
+    check_nslength_all();
+    return 0;
+}


### PR DESCRIPTION
## Problem

X.691 §11.6 requires the long form (value/length ≥ 64) of a normally-small non-negative whole number to begin with a `1` flag bit before the general length determinant, so a decoder can tell it apart from the 7-bit short form.

- `uper_put_nsnnwn()` (ENUMERATED extension indices and CHOICE extension alternative indices ≥ 64) emitted a bare byte-count octet plus value octets with **no flag bit**.
- `uper_put_nslength()` (SEQUENCE/SET extension bitmap lengths > 64) called `uper_put_length()` directly, likewise skipping the flag bit its own `uper_get_nslength()` checks for.

## Root cause

`skeletons/per_support.c`: the getters (`uper_get_nsnnwn()`, `uper_get_nslength()`) are spec-correct and check for the `1` flag bit before reading a long-form length determinant, but the corresponding putters never emitted it. The encoder's output was undecodable even by asn1c itself: encoding extension index 65 of a 70-value ENUMERATED produced `80 a0 80`, which asn1c's own decoder silently misreads as index 0 — silent value substitution at the 64 threshold, in any asn1c-to-anyone direction. This also capped the reliable extension-index range of the unknown-value relay added earlier in this series.

## Fix

Both putters are now the strict bitwise inverse of their (already-correct) getters: short form unchanged; long form emits the `1` flag bit, then the length determinant octet, then the value. `uper_put_nsnnwn()` is additionally capped to the 1–2 octet long forms (n ≤ 65535) that `uper_get_nsnnwn()` understands, replacing a 3-octet branch that produced streams the getter rejects. This cap is an asn1c implementation-level symmetry constraint between putter and getter, not a prohibition in X.691 itself — asn1c's own `uper_get_nsnnwn()` only implements the 1–2 octet long forms, so the old 3-octet branch emitted bytes no asn1c decoder could ever read back. Out-of-range values now fail cleanly instead of encoding garbage.

## Validation

A major commercial ASN.1 toolchain (12.0, authoritative, `asn1 -uper`), 70-value all-extension ENUMERATED, extension indices spanning the boundary:

| ext index | reference toolchain = asn1c (fixed) | asn1c (master) |
|---|---|---|
| 63 (short form) | `bf` | `bf` (unaffected) |
| 64 | `c0 50 00` | `80 a0 00` (wrong) |
| 65 | `c0 50 40` | `80 a0 80` (wrong, decodes back as index 0) |
| 69 | `c0 51 40` | `80 a2 80` (wrong) |

Fixed asn1c is byte-identical to the reference toolchain on every vector and decodes them to the correct values, closing the bidirectional round trip.

## Tests

- **Unit**: `tests/tests-skeletons/check-PER-nsnnwn.c` — put→get round trips across the boundary (0…65535 for nsnnwn, 1…16383 for nslength), hand-derived bit-exact assertions for the long forms, and failure-mode checks (n > 65535, n < 0, length 0). Aborts on master (put(64) reads back as 0), passes with the fix.
- **End-to-end**: fixture 172 (`172-enum-large-ext-OK.asn1` + `check-172.-gen-PER.c`) — full compiler → generated code → `NativeEnumerated_encode_uper()` path, asserting the reference-toolchain golden table above plus decode round-trip and re-encode idempotence per vector. Fails on master (`80 a0 00` vs `c0 50 00`), passes with the fix. The CHOICE ≥64 path uses the same `uper_put_nsnnwn()` helper and is covered by the unit test.

Regression: `tests-skeletons` and `tests-c-compiler` failure sets identical to the master baseline — zero new failures (the new fixture is the only delta, new PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
