### PR TITLE
Fix variable shadowing (and related bugs) in fallback vasprintf()

### DIFF
--- a/libasn1common/asn1_buffer.c
+++ b/libasn1common/asn1_buffer.c
@@ -129,8 +129,15 @@ int abuf_vprintf(abuf *ab, const char *fmt, va_list ap) {
     char *str = 0;
 
     ret = vasprintf(&str, fmt, ap);
-    assert(ret >= 0);
-    assert(str != NULL);
+    if(ret < 0 || str == NULL) {
+        /* vasprintf() failed. POSIX leaves *strp undefined on error, so
+         * don't free str or pass it on. Without this, an NDEBUG build
+         * (asserts compiled out) would call abuf_add_bytes() with a
+         * negative ret, whose size_t length parameter wraps to a huge
+         * value and reads far out of bounds. Check ret first so str is
+         * never inspected when it may be indeterminate. */
+        return -1;
+    }
 
     abuf_add_bytes(ab, str, ret);
 
@@ -149,22 +156,29 @@ vasprintf(char **ret, const char *fmt, va_list args) {
 
     int suggested = vsnprintf(NULL, 0, fmt, args);
     if(suggested >= 0) {
-        *ret = malloc(suggested + 1);
+        /* (size_t)suggested + 1: with a plain int, suggested == INT_MAX
+         * would overflow (undefined behavior) before the widening. */
+        *ret = malloc((size_t)suggested + 1);
         if(*ret) {
-            int actual_length = vsnprintf(*ret, suggested + 1, fmt, copy);
-            if(actual_length >= 0) {
-                assert(actual_length == suggested);
+            actual_length = vsnprintf(*ret, (size_t)suggested + 1, fmt, copy);
+            if(actual_length >= 0 && actual_length <= suggested) {
                 assert((*ret)[actual_length] == '\0');
             } else {
+                /* The second vsnprintf() call failed, or reported a length
+                 * larger than the buffer allocated from the first call's
+                 * size. Don't trust the buffer, and don't let an NDEBUG
+                 * build hand a mismatched (buffer, length) pair to the
+                 * caller. */
                 free(*ret);
                 *ret = 0;
+                actual_length = -1;
             }
         }
     } else {
         *ret = NULL;
         assert(suggested >= 0); /* Can't function like this */
     }
-    va_end(args);
+    va_end(copy);
 
     return actual_length;
 }


### PR DESCRIPTION
## Summary

`libasn1common/asn1_buffer.c` ships a fallback `vasprintf()`, compiled in
when `configure` decides `HAVE_DECL_VASPRINTF == 0`. It has a
variable-shadowing bug: an inner block re-declares `actual_length`, so the
function always returns the outer variable's initial value of `-1`, even on
success. `abuf_vprintf()` itself asserts `ret >= 0`, so in
assertion-enabled builds any successful call into this fallback aborts the
process:

```
asn1c: asn1_buffer.c:132: abuf_vprintf: Assertion `ret >= 0' failed.
```

Not a corner case: on this reproduction environment (Debian 12, glibc 2.36,
gcc 12.2) `configure` decides `HAVE_DECL_VASPRINTF=0` (see "Bug B" below),
so the buggy fallback is compiled into every build here, and a clean
`./configure && make check` already has pre-existing failures caused by it.

Four smaller, related bugs in the same file are fixed alongside it (see
"Also fixed" below).

## Root cause (headline bug)

Introduced in a06b1b4d ("Solaris does not have vasnprintf()", 2017-10-05).

```c
int
vasprintf(char **ret, const char *fmt, va_list args) {
    int actual_length = -1;                      /* outer, returned at the end */
    ...
    if(suggested >= 0) {
        *ret = malloc(suggested + 1);
        if(*ret) {
            int actual_length = vsnprintf(...);  /* BUG: shadows the outer variable */
            ...
        }
    }
    ...
    return actual_length;   /* always the outer -1, even on success */
}
```

All the `if(actual_length >= 0)` checks below operate on the *inner*
variable and behave correctly, but the function always returns the *outer*
variable, never updated from its initial `-1`.

Trigger path: `abuf_vprintf()` (asn1_buffer.c:127) calls the fallback
`vasprintf()`, gets `-1` regardless of success, and its
`assert(ret >= 0)` (asn1_buffer.c:132) aborts in assertion-enabled builds
(under NDEBUG the negative length instead flowed on unchecked — see "Also
fixed"). `abuf_vprintf` is reached via
`safe_printf()`'s `GLOBAL_BUFFER` path, exercised by the `-Wdebug-compiler`
diagnostic printer on schemas with information-object-set / open-type
constructs.

## Fix

```diff
--- a/libasn1common/asn1_buffer.c
+++ b/libasn1common/asn1_buffer.c
@@ -129,8 +129,15 @@ int abuf_vprintf(abuf *ab, const char *fmt, va_list ap) {
     char *str = 0;

     ret = vasprintf(&str, fmt, ap);
-    assert(ret >= 0);
-    assert(str != NULL);
+    if(ret < 0 || str == NULL) {
+        /* vasprintf() failed. POSIX leaves *strp undefined on error, so
+         * don't free str or pass it on. Without this, an NDEBUG build
+         * (asserts compiled out) would call abuf_add_bytes() with a
+         * negative ret, whose size_t length parameter wraps to a huge
+         * value and reads far out of bounds. Check ret first so str is
+         * never inspected when it may be indeterminate. */
+        return -1;
+    }

     abuf_add_bytes(ab, str, ret);

@@ -149,22 +156,29 @@ vasprintf(char **ret, const char *fmt, va_list args) {

     int suggested = vsnprintf(NULL, 0, fmt, args);
     if(suggested >= 0) {
-        *ret = malloc(suggested + 1);
+        /* (size_t)suggested + 1: with a plain int, suggested == INT_MAX
+         * would overflow (undefined behavior) before the widening. */
+        *ret = malloc((size_t)suggested + 1);
         if(*ret) {
-            int actual_length = vsnprintf(*ret, suggested + 1, fmt, copy);
-            if(actual_length >= 0) {
-                assert(actual_length == suggested);
+            actual_length = vsnprintf(*ret, (size_t)suggested + 1, fmt, copy);
+            if(actual_length >= 0 && actual_length <= suggested) {
                 assert((*ret)[actual_length] == '\0');
             } else {
+                /* The second vsnprintf() call failed, or reported a length
+                 * larger than the buffer allocated from the first call's
+                 * size. Don't trust the buffer, and don't let an NDEBUG
+                 * build hand a mismatched (buffer, length) pair to the
+                 * caller. */
                 free(*ret);
                 *ret = 0;
+                actual_length = -1;
             }
         }
     } else {
         *ret = NULL;
         assert(suggested >= 0); /* Can't function like this */
     }
-    va_end(args);
+    va_end(copy);

     return actual_length;
 }
```

### Also fixed (same file, same PR)

- **The shadowing bug** (the headline fix): removing the inner `int` makes
  the assignment target the outer variable, so the function returns the
  actual byte count on success and `-1` only on genuine failure.

- **`va_end()` on the wrong `va_list`**: the function calls `va_copy(copy,
  args)` but was ending `args` (the caller's list, owned by `abuf_vprintf()`
  via `safe_printf()`) instead of `copy` (the list this function created and
  is responsible for ending). Ending `args` here fails to pair the
  `va_copy()` and may improperly end the caller's `va_list` state. Fixed to
  `va_end(copy)`.

- **`assert()`-only length handling inside the fallback**: the original code
  used `assert(actual_length == suggested)`, which compiles out entirely
  under `NDEBUG`. If the second `vsnprintf()` failed or reported a length
  larger than the buffer allocated from the first call's size
  (`actual_length > suggested`), an `NDEBUG` build would hand the caller a
  length exceeding the allocation. Replaced with a runtime check: free the
  buffer and return `-1` if the second call fails or needs more space than
  was allocated. A shorter result (`actual_length < suggested`) is accepted
  — it fits within the buffer.

- **`abuf_vprintf()` trusted the return only via `assert`**: it checked
  `vasprintf()`'s result with `assert(ret >= 0)` / `assert(str != NULL)`.
  Under `NDEBUG` those vanish, and a failure return of `(-1)` flowed into
  `abuf_add_bytes(ab, str, ret)`, whose `size_t` length parameter wraps a
  negative `ret` to a huge value and reads far out of bounds. POSIX also
  leaves `*strp` undefined on `vasprintf()` error, so `str` must not be
  trusted or freed on the failure path. Added a runtime guard that returns
  `-1` on failure before touching `str` (checking `ret` first). This closes
  the fallback-`vasprintf()` length fix end-to-end: even with the fallback
  now correctly returning `(NULL, -1)`, the caller no longer propagates it
  into an out-of-bounds `memcpy`.

- **Signed overflow in `suggested + 1`**: with `suggested == INT_MAX`
  (a format expansion of exactly `INT_MAX` bytes), the `int` addition in
  `malloc(suggested + 1)` and in the second `vsnprintf()`'s size argument
  overflowed — undefined behavior — before widening to `size_t`. Both now
  compute `(size_t)suggested + 1`, so the widening happens first.

## Evidence

### Before: reproduction (parent commit, `HEAD` at `8a274c3f`)

```
$ asn1c -S <skeletons> -no-gen-OER -no-gen-PER -Wdebug-compiler \
    tests/tests-asn1c-compiler/161-open-type-no-type-OK.asn1
DEBUG: Compiling ProcedureCode at line 23
DEBUG: emit tag vectors for ProcedureCode 0, 1, 1
DEBUG: Compiling UnsuccessfulOutcome at line 24
asn1c: asn1_buffer.c:132: abuf_vprintf: Assertion `ret >= 0' failed.
Aborted            # asn1c aborts with SIGABRT (process exit 134)
```

Reproduced identically for three schemas that exercise the open-type /
information-object-set diagnostic path:

| Schema | Pre-fix asn1c exit | Post-fix asn1c exit |
|---|---|---|
| `161-open-type-no-type-OK.asn1` | 134 (SIGABRT) | 0 |
| `162-open-type-ioc-fuzz-OK.asn1` | 134 (SIGABRT) | 0 |
| `164-ios-valueset-behavior-OK.asn1` (needs `-fcompound-names`) | 134 (SIGABRT) | 0 |

### This already breaks `make check` on this environment

These three schemas are compiled with `-Wdebug-compiler` as part of the
`tests-c-compiler` generation step (not a hand-constructed repro). On this
Debian 12 environment, a clean `./configure && make check` on the parent
commit already has 4 `FAIL`s in `tests-c-compiler`, all this exact abort.
(The automake harness reports each as `exit status: 2`; the inner `asn1c`
process it spawns is what aborts with `SIGABRT` / exit 134 — the two layers'
codes differ.)

```
FAIL: check-src/check-161.-fcompound-names.c
FAIL: check-src/check-161.-fcompound-names.-gen-PER.c
FAIL: check-src/check-162.c
FAIL: check-src/check-164.-fcompound-names.c
# TOTAL: 47  # PASS: 42  # FAIL: 4  # ERROR: 0   (tests-c-compiler)
```

Each `FAIL` in `test-suite.log` contains the exact `Assertion 'ret >= 0'
failed` + `Aborted` text, confirming the same root cause in all four.
After the fix, a full `./configure && make check` on this commit is clean
across every suite (exit 0):

```
libasn1parser 1/0   libasn1fix 2/0   unber 1/0   asn1-tools 1/0
tests-asn1c-compiler 1/0   tests-skeletons 17/0   tests-asn1c-smoke 1/0
tests-c-compiler   TOTAL 47  PASS 46  XFAIL 1  FAIL 0   (the 4 aborts now PASS)
tests-randomized   TOTAL 19  PASS 19  FAIL 0
------------------------------------------------------------
total 90 cases: 89 PASS, 1 pre-existing unrelated XFAIL, 0 FAIL, 0 ERROR
```

(No claim is made here about whether these 4 also fail in upstream CI —
that hasn't been checked; the claim is limited to this reproduction
environment.)

### Value-level correctness (not just "doesn't abort")

A standalone probe compiling the exact fixed fallback body (renamed to
avoid clashing with libc's real `vasprintf`) confirms the return value now
equals the actual bytes written, not merely "non-negative":

```
case1: fmt={ ret=1 out=[{]
case2: ret=16 out=[hello world, 42!] strlen=16
VALUE-LEVEL CHECK: PASS (ret == actual bytes written, matches strlen(out))
```

The same probe built from the *unfixed* body aborts immediately
(`Assertion 'ret == 1' failed`), confirming the shadowing bug is exactly
what's being fixed.

### Caller guard (the `abuf_vprintf()` fix) is exercised under NDEBUG

Built `-DNDEBUG -fsanitize=address,undefined` with a directed probe that
drives `vasprintf()` to a failure return: without the guard,
`abuf_add_bytes()` performs an out-of-bounds read (ASan report); with the
guard, the call returns `-1` cleanly and ASan is silent. (Exact output in
the review notes.)

## Bug B (not included in this PR): `configure` misdetects `HAVE_DECL_VASPRINTF`

`configure.ac:283` has a bare `AC_CHECK_DECLS(vasprintf)`. The generated
conftest *does* include `<stdio.h>` (via the standard `AC_INCLUDES_DEFAULT`
+ `HAVE_STDIO_H` guard) — so the earlier theory that the header was
missing is wrong. The actual cause, confirmed by direct compilation on this
environment:

```
$ printf '#include <stdio.h>\nint main(void){(void)vasprintf;return 0;}\n' > t.c
$ gcc -std=gnu99 -c t.c        # fails: 'vasprintf' undeclared
$ gcc -std=gnu99 -D_GNU_SOURCE -c t.c   # succeeds
```

On this glibc (2.36, Debian 12), `vasprintf`'s declaration in `<stdio.h>`
is gated behind `_GNU_SOURCE`, and `-std=gnu99` alone does not define it.
`AC_CHECK_DECLS`'s conftest doesn't define `_GNU_SOURCE` either, so the
check comes back negative here (`ac_cv_have_decl_vasprintf=no` ->
`HAVE_DECL_VASPRINTF 0`), compiling in the fallback. This appears to be
glibc-version-dependent, not universal — reported (not independently
verified here) that a newer glibc (2.41) detects it as declared without
extra flags.

Possible fixes: use `AC_CHECK_FUNCS([vasprintf])` (link-based, not
declaration-based), or add `_GNU_SOURCE` to the `AC_CHECK_DECLS` conftest.
Left for a separate, independent follow-up PR — this PR's fix makes the
fallback (and its caller) correct regardless of which way `configure`
decides, which is the smaller and safer change to land first.

---

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
