### PR TITLE
codegen: permitted-alphabet constraint checks perform null-pointer arithmetic on empty values

### DIFF
--- a/libasn1compiler/asn1c_constraint.c
+++ b/libasn1compiler/asn1c_constraint.c
@@ -464,7 +464,8 @@ emit_alphabet_check_loop(arg_t *arg, asn1cnst_range_t *range) {
 	switch(terminal->expr_type) {
 	case ASN_STRING_UTF8String:
 		OUT("const uint8_t *ch = st->buf;\n");
-		OUT("const uint8_t *end = ch + st->size;\n");
+		OUT("const uint8_t *end = ch ? ch + st->size : ch;\n");
+		OUT("if(!ch) return st->size ? -1 : 0;\n");
 		OUT("\n");
 		OUT("for(; ch < end; ch++) {\n");
 			INDENT(+1);
@@ -474,7 +475,8 @@ emit_alphabet_check_loop(arg_t *arg, asn1cnst_range_t *range) {
 		break;
 	case ASN_STRING_UniversalString:
 		OUT("const uint8_t *ch = st->buf;\n");
-		OUT("const uint8_t *end = ch + st->size;\n");
+		OUT("const uint8_t *end = ch ? ch + st->size : ch;\n");
+		OUT("if(!ch) return st->size ? -1 : 0;\n");
 		OUT("\n");
 		OUT("if(st->size %% 4) return -1; /* (size%%4)! */\n");
 		OUT("for(; ch < end; ch += 4) {\n");
@@ -488,7 +490,8 @@ emit_alphabet_check_loop(arg_t *arg, asn1cnst_range_t *range) {
 		break;
 	case ASN_STRING_BMPString:
 		OUT("const uint8_t *ch = st->buf;\n");
-		OUT("const uint8_t *end = ch + st->size;\n");
+		OUT("const uint8_t *end = ch ? ch + st->size : ch;\n");
+		OUT("if(!ch) return st->size ? -1 : 0;\n");
 		OUT("\n");
 		OUT("if(st->size %% 2) return -1; /* (size%%2)! */\n");
 		OUT("for(; ch < end; ch += 2) {\n");
@@ -501,7 +504,8 @@ emit_alphabet_check_loop(arg_t *arg, asn1cnst_range_t *range) {
 	case ASN_BASIC_OCTET_STRING:
 	default:
 		OUT("const uint8_t *ch = st->buf;\n");
-		OUT("const uint8_t *end = ch + st->size;\n");
+		OUT("const uint8_t *end = ch ? ch + st->size : ch;\n");
+		OUT("if(!ch) return st->size ? -1 : 0;\n");
 		OUT("\n");
 		OUT("for(; ch < end; ch++) {\n");
 			INDENT(+1);

--- a/tests/tests-asn1c-compiler/119-per-strings-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/119-per-strings-OK.asn1.-Pgen-PER
@@ -78,7 +78,8 @@ static int check_permitted_alphabet_5(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -91,7 +92,8 @@ static int check_permitted_alphabet_6(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -117,7 +119,8 @@ static int check_permitted_alphabet_7(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -130,7 +133,8 @@ static int check_permitted_alphabet_9(const void *sptr) {
 	/* The underlying type is VisibleString */
 	const VisibleString_t *st = (const VisibleString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -143,7 +147,8 @@ static int check_permitted_alphabet_10(const void *sptr) {
 	/* The underlying type is VisibleString */
 	const VisibleString_t *st = (const VisibleString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -169,7 +174,8 @@ static int check_permitted_alphabet_11(const void *sptr) {
 	/* The underlying type is VisibleString */
 	const VisibleString_t *st = (const VisibleString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -182,7 +188,8 @@ static int check_permitted_alphabet_13(const void *sptr) {
 	/* The underlying type is PrintableString */
 	const PrintableString_t *st = (const PrintableString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -208,7 +215,8 @@ static int check_permitted_alphabet_14(const void *sptr) {
 	/* The underlying type is PrintableString */
 	const PrintableString_t *st = (const PrintableString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -221,7 +229,8 @@ static int check_permitted_alphabet_16(const void *sptr) {
 	/* The underlying type is NumericString */
 	const NumericString_t *st = (const NumericString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -234,7 +243,8 @@ static int check_permitted_alphabet_17(const void *sptr) {
 	/* The underlying type is NumericString */
 	const NumericString_t *st = (const NumericString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -258,7 +268,8 @@ static int check_permitted_alphabet_18(const void *sptr) {
 	/* The underlying type is NumericString */
 	const NumericString_t *st = (const NumericString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -281,7 +292,8 @@ static int check_permitted_alphabet_21(const void *sptr) {
 	/* The underlying type is UTF8String */
 	const UTF8String_t *st = (const UTF8String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -295,7 +307,8 @@ static int check_permitted_alphabet_23(const void *sptr) {
 	/* The underlying type is BMPString */
 	const BMPString_t *st = (const BMPString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	if(st->size % 2) return -1; /* (size%2)! */
 	for(; ch < end; ch += 2) {
@@ -310,7 +323,8 @@ static int check_permitted_alphabet_24(const void *sptr) {
 	/* The underlying type is BMPString */
 	const BMPString_t *st = (const BMPString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	if(st->size % 2) return -1; /* (size%2)! */
 	for(; ch < end; ch += 2) {
@@ -325,7 +339,8 @@ static int check_permitted_alphabet_25(const void *sptr) {
 	/* The underlying type is BMPString */
 	const BMPString_t *st = (const BMPString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	if(st->size % 2) return -1; /* (size%2)! */
 	for(; ch < end; ch += 2) {
@@ -353,7 +368,8 @@ static int check_permitted_alphabet_26(const void *sptr) {
 	/* The underlying type is BMPString */
 	const BMPString_t *st = (const BMPString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	if(st->size % 2) return -1; /* (size%2)! */
 	for(; ch < end; ch += 2) {
@@ -369,7 +385,8 @@ static int check_permitted_alphabet_28(const void *sptr) {
 	/* The underlying type is UniversalString */
 	const UniversalString_t *st = (const UniversalString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	if(st->size % 4) return -1; /* (size%4)! */
 	for(; ch < end; ch += 4) {
@@ -386,7 +403,8 @@ static int check_permitted_alphabet_29(const void *sptr) {
 	/* The underlying type is UniversalString */
 	const UniversalString_t *st = (const UniversalString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	if(st->size % 4) return -1; /* (size%4)! */
 	for(; ch < end; ch += 4) {
@@ -403,7 +421,8 @@ static int check_permitted_alphabet_30(const void *sptr) {
 	/* The underlying type is UniversalString */
 	const UniversalString_t *st = (const UniversalString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	if(st->size % 4) return -1; /* (size%4)! */
 	for(; ch < end; ch += 4) {
@@ -433,7 +452,8 @@ static int check_permitted_alphabet_31(const void *sptr) {
 	/* The underlying type is UniversalString */
 	const UniversalString_t *st = (const UniversalString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	if(st->size % 4) return -1; /* (size%4)! */
 	for(; ch < end; ch += 4) {

--- a/tests/tests-asn1c-compiler/137-oer-string-OK.asn1.-Pgen-OER
+++ b/tests/tests-asn1c-compiler/137-oer-string-OK.asn1.-Pgen-OER
@@ -40,7 +40,8 @@ static int check_permitted_alphabet_7(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -53,7 +54,8 @@ static int check_permitted_alphabet_9(const void *sptr) {
 	/* The underlying type is UniversalString */
 	const UniversalString_t *st = (const UniversalString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	if(st->size % 4) return -1; /* (size%4)! */
 	for(; ch < end; ch += 4) {

--- a/tests/tests-asn1c-compiler/19-param-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/19-param-OK.asn1.-Pfwide-types
@@ -344,7 +344,8 @@ static int check_permitted_alphabet_2(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;

--- a/tests/tests-asn1c-compiler/50-constraint-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/50-constraint-OK.asn1.-Pfwide-types
@@ -504,7 +504,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -605,7 +606,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -695,7 +697,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -782,7 +785,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -869,7 +873,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -956,7 +961,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -1043,7 +1049,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -1130,7 +1137,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -1217,7 +1225,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -1307,7 +1316,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -1397,7 +1407,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -1577,7 +1588,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is UTF8String */
 	const UTF8String_t *st = (const UTF8String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -1812,7 +1824,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is VisibleString */
 	const VisibleString_t *st = (const VisibleString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -2484,7 +2497,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is VisibleString */
 	const VisibleString_t *st = (const VisibleString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;

--- a/tests/tests-asn1c-compiler/50-constraint-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/50-constraint-OK.asn1.-Pgen-PER
@@ -545,7 +545,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -659,7 +660,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -770,7 +772,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -868,7 +871,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -965,7 +969,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -1062,7 +1067,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -1159,7 +1165,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -1256,7 +1263,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -1353,7 +1361,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -1453,7 +1462,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -1553,7 +1563,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -1753,7 +1764,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is UTF8String */
 	const UTF8String_t *st = (const UTF8String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -2018,7 +2030,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is VisibleString */
 	const VisibleString_t *st = (const VisibleString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -2752,7 +2765,8 @@ static int check_permitted_alphabet_1(const void *sptr) {
 	/* The underlying type is VisibleString */
 	const VisibleString_t *st = (const VisibleString_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;

--- a/tests/tests-asn1c-compiler/73-circular-OK.asn1.-Pfwide-types
+++ b/tests/tests-asn1c-compiler/73-circular-OK.asn1.-Pfwide-types
@@ -364,7 +364,8 @@ static int check_permitted_alphabet_6(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;
@@ -377,7 +378,8 @@ static int check_permitted_alphabet_7(const void *sptr) {
 	/* The underlying type is IA5String */
 	const IA5String_t *st = (const IA5String_t *)sptr;
 	const uint8_t *ch = st->buf;
-	const uint8_t *end = ch + st->size;
+	const uint8_t *end = ch ? ch + st->size : ch;
+	if(!ch) return st->size ? -1 : 0;
 	
 	for(; ch < end; ch++) {
 		uint8_t cv = *ch;

--- a/tests/tests-c-compiler/check-src/check-50.c
+++ b/tests/tests-c-compiler/check-src/check-50.c
@@ -8,16 +8,64 @@
 #include <Int5.h>
 #include <Str4.h>
 #include <Utf8-4.h>
+#include <PER-Visible.h>
 #include <VisibleIdentifier.h>
+
+static int
+check_constraints(const asn_TYPE_descriptor_t *td, const void *sptr) {
+	char errbuf[128];
+	size_t errlen = sizeof(errbuf);
+	int ret = asn_check_constraints(td, sptr, errbuf, &errlen);
+	if(ret) {
+		fprintf(stderr, "%s: %s\n", td->name, errbuf);
+	}
+	return ret;
+}
 
 int
 main(int ac, char **av) {
+	/* PER-Visible ::= IA5String (FROM("A".."F")), no SIZE constraint */
+	PER_Visible_t st = {0};
+	uint8_t empty[1] = {0};
+	uint8_t good[] = {'A', 'B', 'F'};
+	uint8_t bad[] = {'G'};
+
 	(void)ac;	/* Unused argument */
 	(void)av;	/* Unused argument */
 
 	/*
-	 * No plans to fill it up: just checking whether it compiles or not.
+	 * The empty string is a valid abstract value of a
+	 * permitted-alphabet constrained string type without a lower
+	 * SIZE bound, and this generated subtype constraint is intended
+	 * to accept its buffer-less representation (buf=NULL, size=0).
+	 * The constraint checking code must handle it without pointer
+	 * arithmetic or ordered comparison on a null pointer
+	 * (C17 6.5.6p8, 6.5.8p5).
 	 */
+	assert(st.buf == NULL);
+	assert(st.size == 0);
+	assert(check_constraints(&asn_DEF_PER_Visible, &st) == 0);
+
+	/* A buffer-less value with a non-zero size is not a valid
+	 * representation and must be rejected. */
+	st.buf = NULL;
+	st.size = 1;
+	assert(check_constraints(&asn_DEF_PER_Visible, &st) != 0);
+
+	/* A non-NULL backing buffer with logical size zero. */
+	st.buf = empty;
+	st.size = 0;
+	assert(check_constraints(&asn_DEF_PER_Visible, &st) == 0);
+
+	/* A value within the permitted alphabet. */
+	st.buf = good;
+	st.size = sizeof(good);
+	assert(check_constraints(&asn_DEF_PER_Visible, &st) == 0);
+
+	/* A value outside the permitted alphabet. */
+	st.buf = bad;
+	st.size = sizeof(bad);
+	assert(check_constraints(&asn_DEF_PER_Visible, &st) != 0);
 
 	return 0;
 }


### PR DESCRIPTION
### Problem

`check_permitted_alphabet_N()` functions emitted by the compiler compute `end = ch + st->size` and iterate with `ch < end`. For a buffer-less empty value (`buf == NULL`, `size == 0` — e.g. a zero-initialized structure passed to `asn_check_constraints()`), that is:

- pointer arithmetic on a null pointer — undefined behavior per C17 6.5.6p8 (even with a zero offset);
- an ordered comparison of two null pointers — undefined behavior per C17 6.5.8p5.

The empty string is a valid abstract value of a permitted-alphabet constrained string type with no lower SIZE bound (X.680; FROM does not constrain length), and this generated check accepted the buffer-less representation before — but via the UB path.

Under Clang 14 with `-fsanitize=undefined -fno-sanitize-recover=undefined` (the configuration `./configure CC=clang` selects for the test suite), the pointer-overflow check reports:

```
E.c:14:26: runtime error: applying zero offset to null pointer
```

and fails the run. Note this surfaced through the check-176 regression test introduced in #548, which is the first test to exercise these generated functions at runtime at all; the template itself dates back to 2004. (WG14 N3322, accepted into the C2y working draft, defines both operations in future C — which is also a good indication that today's standards do not.)

### Fix

All four template branches in `asn1c_constraint.c` now emit:

```c
const uint8_t *ch = st->buf;
const uint8_t *end = ch ? ch + st->size : ch;
if(!ch) return st->size ? -1 : 0;
```

- Non-NULL buffers: unchanged behavior.
- `buf==NULL, size==0`: accepted, as before, now through defined behavior.
- `buf==NULL, size>0`: **the one intentional behavior change** — this malformed representation is now deterministically rejected, consistent with the runtime invariant used elsewhere (e.g. `OCTET_STRING.c`'s XER encoder rejects `!st->buf && st->size`).

The guard sits after the declarations, so the emitted code remains valid C90.

### Tests

- check-50 upgraded from a compile-only stub to a runtime constraint test over `PER-Visible ::= IA5String (FROM("A".."F"))`: buffer-less empty value accepted, `NULL/size=1` rejected, zero-size backing buffer accepted, in-alphabet accepted, out-of-alphabet rejected.
- The six affected compiler reference outputs are regenerated with the new compiler (all four template branches are covered textually by fixtures 50/119/137/19/73).
- Full `tests-asn1c-compiler`, `tests-c-compiler`, `tests-skeletons` runs are clean with gcc, and with the Clang 14 sanitizer configuration the previously failing case now passes with no sanitizer output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)