### PR TITLE
per: leading zero-length open-type chunk performs null-pointer arithmetic

### DIFF
--- a/skeletons/per_opentype.c
+++ b/skeletons/per_opentype.c
@@ -98,7 +98,15 @@ uper_open_type_get_simple(const asn_codec_ctx_t *ctx,
 			}
 			buf = ptr;
 		}
-		if(per_get_many_bits(pd, buf + bufLen, 0, chunk_bytes << 3)) {
+		/*
+		 * A leading zero-length determinant (malformed: X.691 (02/2021)
+		 * 11.1.3 and 11.2.1 imply that a complete UPER open-type
+		 * encoding is at least one octet) leaves buf unallocated.
+		 * Avoid arithmetic on a null pointer (C17 6.5.6p8);
+		 * asn_get_many_bits() does not access dst for zero bits.
+		 */
+		if(per_get_many_bits(pd, buf ? buf + bufLen : NULL, 0,
+		                     chunk_bytes << 3)) {
 			FREEMEM(buf);
 			ASN__DECODE_STARVED;
 		}


### PR DESCRIPTION
### Problem

`uper_open_type_get_simple()` (`skeletons/per_opentype.c`, also the workhorse
behind `uper_open_type_skip()`) accumulates open-type contents chunk by chunk:

```c
uint8_t *buf = 0;
...
do {
    chunk_bytes = uper_get_length(pd, -1, 0, &repeat);
    ...
    if(bufLen + chunk_bytes > bufSize) { ... buf = REALLOC(buf, ...); ... }
    if(per_get_many_bits(pd, buf + bufLen, 0, chunk_bytes << 3)) {
```

The buffer is only allocated once a positive-length chunk arrives. If the
**first** length determinant is zero — malformed input; X.691 (02/2021) §11.1.3
and §11.2.1 imply a complete UPER open-type encoding is at least one octet,
and the conforming trailing zero-length end-of-message chunk (16 KiB-multiple
case, see `per_support.h`) only arrives after the buffer is allocated — the
call computes `NULL + 0`: undefined behavior per C17 §6.5.6p8, regardless of
the zero offset. `asn_get_many_bits()` never accesses `dst` for zero bits, so
the argument expression is the only undefined part.

Under the tested Clang 14 UBSan configuration (`./configure CC=clang`
auto-applies `-fsanitize=undefined -fno-sanitize-recover=undefined` to the
test suite), the pointer-overflow check reports at the existing check-126
test (input `data-126-06-P.out`):

```
per_opentype.c:101:6: runtime error: applying zero offset to null pointer
```

### Fix

```c
if(per_get_many_bits(pd, buf ? buf + bufLen : NULL, 0,
                     chunk_bytes << 3)) {
```

`buf == NULL` implies `bufLen == 0` implies `chunk_bytes == 0` implies zero
bits requested (any positive chunk allocates first; all failure paths return
immediately), so passing NULL is safe and behavior in ordinary builds is
unchanged: all previously defined paths are identical, and the triggering
path goes from undefined to defined with the same observable outcome.

### Tests

- check-126 under the Clang 14 sanitizer configuration: fails before
  (`applying zero offset to null pointer`), passes after with no sanitizer
  output; the other pre-existing sanitizer findings in the suite are
  byte-for-byte unchanged, i.e. the change affects exactly this defect.
- Full `tests-asn1c-compiler` / `tests-c-compiler` / `tests-skeletons` runs
  are clean with gcc.

### Relation to other PRs

Independent of #539 (same file, different function; no textual conflict) —
though note #539's new skip regression test includes a zero-byte case that
also exercises this spot under Clang UBSan, so landing this fix keeps that
test sanitizer-clean. Same discovery chain as #550 (running the test suite
under Clang UBSan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)