### PR TITLE
skeletons: avoid null + offset arithmetic in XER codec paths

### DIFF
--- a/skeletons/INTEGER.c
+++ b/skeletons/INTEGER.c
@@ -325,7 +325,7 @@ INTEGER__xer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,
 	intmax_t hex_value = 0;
 	const char *lp;
 	const char *lstart = (const char *)chunk_buf;
-	const char *lstop = lstart + chunk_size;
+	const char *lstop = lstart ? lstart + chunk_size : lstart;
 	enum {
 		ST_LEADSPACE,
 		ST_SKIPSPHEX,

--- a/skeletons/OBJECT_IDENTIFIER.c
+++ b/skeletons/OBJECT_IDENTIFIER.c
@@ -186,7 +186,8 @@ static enum xer_pbd_rval
 OBJECT_IDENTIFIER__xer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,
                                    const void *chunk_buf, size_t chunk_size) {
     OBJECT_IDENTIFIER_t *st = (OBJECT_IDENTIFIER_t *)sptr;
-	const char *chunk_end = (const char *)chunk_buf + chunk_size;
+	const char *chunk_end = chunk_buf
+		? (const char *)chunk_buf + chunk_size : (const char *)chunk_buf;
 	const char *endptr;
 	asn_oid_arc_t s_arcs[10];
 	asn_oid_arc_t *arcs = s_arcs;

--- a/skeletons/OCTET_STRING.c
+++ b/skeletons/OCTET_STRING.c
@@ -615,7 +615,7 @@ OCTET_STRING_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
 	 * Dump the contents of the buffer in hexadecimal.
 	 */
 	buf = st->buf;
-	end = buf + st->size;
+	end = buf ? buf + st->size : buf;
 	if(flags & XER_F_CANONICAL) {
 		char *scend = scratch + (sizeof(scratch) - 2);
 		for(; buf < end; buf++) {
@@ -762,7 +762,7 @@ OCTET_STRING_encode_xer_utf8(const asn_TYPE_descriptor_t *td, const void *sptr,
 		ASN__ENCODE_FAILED;
 
 	buf = st->buf;
-	end = buf + st->size;
+	end = buf ? buf + st->size : buf;
 	for(ss = buf; buf < end; buf++) {
 		unsigned int ch = *buf;
 		int s_len;	/* Special encoding sequence length */
@@ -797,7 +797,7 @@ static ssize_t OCTET_STRING__convert_hexadecimal(void *sptr, const void *chunk_b
 	OCTET_STRING_t *st = (OCTET_STRING_t *)sptr;
 	const char *chunk_stop = (const char *)chunk_buf;
 	const char *p = chunk_stop;
-	const char *pend = p + chunk_size;
+	const char *pend = p ? p + chunk_size : p;
 	unsigned int clv = 0;
 	int half = 0;	/* Half bit */
 	uint8_t *buf;
@@ -873,7 +873,7 @@ static ssize_t OCTET_STRING__convert_hexadecimal(void *sptr, const void *chunk_b
 static ssize_t OCTET_STRING__convert_binary(void *sptr, const void *chunk_buf, size_t chunk_size, int have_more) {
 	BIT_STRING_t *st = (BIT_STRING_t *)sptr;
 	const char *p = (const char *)chunk_buf;
-	const char *pend = p + chunk_size;
+	const char *pend = p ? p + chunk_size : p;
 	int bits_unused = st->bits_unused & 0x7;
 	uint8_t *buf;
 
@@ -979,7 +979,7 @@ OCTET_STRING__convert_entrefs(void *sptr, const void *chunk_buf,
                               size_t chunk_size, int have_more) {
     OCTET_STRING_t *st = (OCTET_STRING_t *)sptr;
 	const char *p = (const char *)chunk_buf;
-	const char *pend = p + chunk_size;
+	const char *pend = p ? p + chunk_size : p;
 	uint8_t *buf;
 
 	/* Reallocate buffer */
@@ -1681,7 +1681,7 @@ OCTET_STRING_print(const asn_TYPE_descriptor_t *td, const void *sptr,
 	 * Dump the contents of the buffer in hexadecimal.
 	 */
 	buf = st->buf;
-	end = buf + st->size;
+	end = buf ? buf + st->size : buf;
 	for(i = 0; buf < end; buf++, i++) {
 		if(!(i % 16) && (i || st->size > 16)) {
 			if(cb(scratch, p - scratch, app_key) < 0)

--- a/skeletons/RELATIVE-OID.c
+++ b/skeletons/RELATIVE-OID.c
@@ -117,7 +117,8 @@ static enum xer_pbd_rval
 RELATIVE_OID__xer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,
                               const void *chunk_buf, size_t chunk_size) {
     RELATIVE_OID_t *st = (RELATIVE_OID_t *)sptr;
-	const char *chunk_end = (const char *)chunk_buf + chunk_size;
+	const char *chunk_end = chunk_buf
+		? (const char *)chunk_buf + chunk_size : (const char *)chunk_buf;
 	const char *endptr;
 	asn_oid_arc_t s_arcs[6];
 	asn_oid_arc_t *arcs = s_arcs;

--- a/skeletons/UTF8String.c
+++ b/skeletons/UTF8String.c
@@ -120,8 +120,8 @@ static ssize_t
 UTF8String__process(const UTF8String_t *st, uint32_t *dst, size_t dstlen) {
 	size_t length;
 	uint8_t *buf = st->buf;
-	uint8_t *end = buf + st->size;
-	uint32_t *dstend = dst + dstlen;
+	uint8_t *end = buf ? buf + st->size : buf;
+	uint32_t *dstend = dst ? dst + dstlen : dst;
 
 	for(length = 0; buf < end; length++) {
 		int ch = *buf;

--- a/skeletons/asn_codecs_prim.c
+++ b/skeletons/asn_codecs_prim.c
@@ -225,8 +225,10 @@ xer_decode__primitive_body(void *key, const void *chunk_buf, size_t chunk_size, 
 	}
 
 	lead_wsp_size = xer_whitespace_span(chunk_buf, chunk_size);
-	chunk_buf = (const char *)chunk_buf + lead_wsp_size;
-	chunk_size -= lead_wsp_size;
+	if(lead_wsp_size) {	/* Non-zero span implies chunk_buf != NULL */
+		chunk_buf = (const char *)chunk_buf + lead_wsp_size;
+		chunk_size -= lead_wsp_size;
+	}
 
 	bret = arg->prim_body_decoder(arg->type_descriptor,
 		arg->struct_key, chunk_buf, chunk_size);

--- a/skeletons/xer_decoder.c
+++ b/skeletons/xer_decoder.c
@@ -323,7 +323,7 @@ xer_decode_general(const asn_codec_ctx_t *opt_codec_ctx,
 size_t
 xer_whitespace_span(const void *chunk_buf, size_t chunk_size) {
 	const char *p = (const char *)chunk_buf;
-	const char *pend = p + chunk_size;
+	const char *pend = p ? p + chunk_size : p;
 
 	for(; p < pend; p++) {
 		switch(*p) {

--- a/skeletons/xer_support.c
+++ b/skeletons/xer_support.c
@@ -83,7 +83,7 @@ ssize_t pxml_parse(int *stateContext, const void *xmlbuf, size_t size, pxml_call
 	pstate_e state = (pstate_e)*stateContext;
 	const char *chunk_start = (const char *)xmlbuf;
 	const char *p = chunk_start;
-	const char *end = p + size;
+	const char *end = p ? p + size : p;
 
 	for(; p < end; p++) {
 	  int C = *(const unsigned char *)p;


### PR DESCRIPTION
## Summary

clang 14 and earlier diagnose `base + offset` pointer arithmetic on a
NULL base pointer under `-fsanitize=pointer-overflow`, even when
`offset` is 0. This is undefined behavior per C17 6.5.6p8 regardless
of whether the sanitizer flags it. (Newer clang releases no longer
diagnose this particular NULL-plus-zero shape — that is a change in
sanitizer policy, not a change in the standard, so the UB itself is
still present in the source either way.)

The XER decoder represents a self-closing element's empty body (e.g.
`<INTEGER/>`) as `chunk_buf == NULL, chunk_size == 0`, produced by
`XER_GOT_EMPTY()` and reached through
`xer_decode_general -> xer_next_token -> pxml_parse`. Several XER
encode/print paths admit the same `buf == NULL, size == 0` shape for a
legitimate empty value (e.g. encoding an OCTET STRING with no
content). Both shapes reach a plain `end = buf + size;` computed
*before* the `buf < end` loop condition that would otherwise skip the
empty body — the computation itself is the UB, independent of whether
anything is later dereferenced.

**Goal (narrow):** eliminate the clang 14-and-earlier UBSan
(`-fsanitize=pointer-overflow`) diagnostic on NULL-base, zero-offset
pointer-arithmetic expressions in these paths — 13 functions, 14
pointer-addition expressions in total. For all legal internal callers
(NULL is only ever paired with a zero length in this codebase), the
guarded computation produces the same pointer value as before the
patch. This patch does not assert that every neighboring expression on
these bases is well-defined — in particular, NULL ordered-comparison
or subtraction on the same bases elsewhere in these functions is out
of scope and not reviewed here.

**Fix pattern:** `end = buf ? buf + size : buf;` — guard each
computation so a NULL base stays NULL instead of becoming an
out-of-bounds pointer value; the existing `buf < end` loop then skips
the body exactly as it already does for a non-NULL empty chunk/buffer.

Found by fuzzing the XER decoder with malformed documents.

## Fixed call sites (13 functions, 14 expressions)

| # | File / function | Expression | Reachability |
|---|---|---|---|
| 1 | `INTEGER.c`: `INTEGER__xer_body_decode()` | `lstop = lstart + chunk_size` | Self-closing empty element, e.g. `<INTEGER/>` — malformed but decoder-reachable input; the decoder still rejects it afterward, this patch only removes the UB that would otherwise fire first. |
| 2 | `OBJECT_IDENTIFIER.c`: `OBJECT_IDENTIFIER__xer_body_decode()` | `chunk_end = chunk_buf + chunk_size` | Same shape as #1, e.g. `<OBJECT_IDENTIFIER/>`. |
| 3 | `RELATIVE-OID.c`: `RELATIVE_OID__xer_body_decode()` | `chunk_end = chunk_buf + chunk_size` | Same shape as #1. |
| 4 | `OCTET_STRING.c`: `OCTET_STRING__convert_hexadecimal()` | `pend = p + chunk_size` | XER hex-content chunk converter; reachable on an empty hex chunk during decode. |
| 5 | `OCTET_STRING.c`: `OCTET_STRING__convert_binary()` | `pend = p + chunk_size` | XER binary-content chunk converter; reachable on an empty binary chunk during decode (reproduced directly via `check-OCTET_STRING`, see Verification). |
| 6 | `OCTET_STRING.c`: `OCTET_STRING__convert_entrefs()` | `pend = p + chunk_size` | XER entity-ref chunk converter; reachable on an empty chunk during decode. |
| 7 | `OCTET_STRING.c`: `OCTET_STRING_print()` | `end = buf + st->size` | Print path for an OCTET STRING with `buf == NULL, size == 0` — a legitimate empty value, not malformed input. |
| 8 | `OCTET_STRING.c`: `OCTET_STRING_encode_xer()` | `end = buf + st->size` | XER-encoding a legitimate empty OCTET STRING (`buf == NULL, size == 0`), guarded by the existing `if(!st \|\| (!st->buf && st->size))` admission check. |
| 9 | `OCTET_STRING.c`: `OCTET_STRING_encode_xer_utf8()` | `end = buf + st->size` | Same as #8, UTF-8-flavored XER encode path. |
| 10 | `UTF8String.c`: `UTF8String__process()` | `end = buf + st->size` | Reachable when `st->buf == NULL` — in the current codebase this side is defensive: both call sites into `UTF8String__process()` already guarantee `st->buf != NULL` before calling. Kept guarded for robustness against future/other callers, not because a live path hits it today. |
| 11 | `UTF8String.c`: `UTF8String__process()` | `dstend = dst + dstlen` | Reachable: every length-only caller (computing a required destination length) passes `dst == NULL, dstlen == 0`. This is the side actually exercised by `check-UTF8String` (see Verification). |
| 12 | `asn_codecs_prim.c`: `xer_decode__primitive_body()` | `chunk_buf = chunk_buf + lead_wsp_size` | Empty element body; `xer_whitespace_span()` returns 0 on a `(NULL, 0)` chunk, so the guard (`if(lead_wsp_size)`) also skips the addition when the span is 0, which is the only case a NULL `chunk_buf` can reach here. |
| 13 | `xer_decoder.c`: `xer_whitespace_span()` | `pend = p + chunk_size` | Called directly with the decoder's `(possibly NULL, 0)` chunk on an empty element. |
| 14 | `xer_support.c`: `pxml_parse()` | `end = p + size` | Called from `xer_decode_general()` with the decoder's `(buffer, size)` pair, which is `(NULL, 0)` for an empty input; this is the parser entry point streaming/empty-input case, distinct from the self-closing-tag case above. |

### Reachability categories (not to be conflated)

- **Self-closing empty element, malformed-but-reachable** (#1–#3, and
  the decode side of #4–#6, #12, #13): e.g. `<INTEGER/>`. The element
  is well-formed XML but an invalid value for the ASN.1 type; the
  decoder is expected to reject it. This patch does not change that
  outcome — it only removes the UB that would otherwise be triggered
  on the way to rejection.
- **Streaming / boundary empty input** (#14, and the top-level entry
  into #13 via `xer_decode_general`): the parser receiving a `(NULL,
  0)` buffer, e.g. at the start of decoding before any bytes have
  arrived, or on a genuinely empty input document.
- **Legitimate empty value, not malformed** (#7–#9, #11): encoding or
  printing an OCTET STRING (or computing a UTF8String length) that
  simply has no content — `buf == NULL, size == 0` is the correct,
  intended representation of "empty", not an error condition.

## Out of scope

The same NULL + offset pattern also exists in the UPER encoding path
(e.g. `OCTET_STRING_per_put_characters`'s end-pointer computation),
which is a different protocol encoder with its own call graph and
guard shapes; left for a separate patch.

## Verification

Performed on a VM with `clang-14` (`Debian clang version 14.0.6`).
Two independent lines of evidence, both comparing upstream master
`8a274c3f` (unfixed baseline) against this branch (commit
`e0842c4f0fe4b30581024c96490850fe8f17d401`).

### 1. Standalone reproducer

Compiled `skeletons/*.c` (excluding `converter-example.c`, which
requires compiler-injected `-DPDU` flags) directly with:

```
clang-14 -I<skeletons> -fsanitize=pointer-overflow -fno-sanitize-recover=all -g -O0 -c skeletons/*.c
ar rcs libasn1c.a *.o
clang-14 -I<skeletons> -fsanitize=pointer-overflow -fno-sanitize-recover=all -g -O0 \
    -o repro repro_main.c libasn1c.a -lm
```

`repro_main.c` drives two scenarios:

- **Scenario 1 (decode):** `xer_decode(0, &asn_DEF_INTEGER, (void**)&st, "<INTEGER/>", 10)`.
- **Scenario 2 (encode):** `xer_encode(&asn_DEF_OCTET_STRING, &st, XER_F_BASIC, sink_cb, 0)`
  with `st` zero-initialized (`buf == NULL, size == 0`).

Both binaries link and start; `-fno-sanitize-recover=all` makes any
triggered diagnostic abort the process (non-zero exit) instead of only
printing a warning.

**Baseline (`8a274c3f`), scenario 1:**
```
../baseline/skeletons/xer_decoder.c:326:23: runtime error: applying zero offset to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../baseline/skeletons/xer_decoder.c:326:23 in
exit=1
```

**Baseline (`8a274c3f`), scenario 2:**
```
../baseline/skeletons/OCTET_STRING.c:618:12: runtime error: applying zero offset to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../baseline/skeletons/OCTET_STRING.c:618:12 in
exit=1
```

**This branch, scenario 1:**
```
scenario1(decode empty <INTEGER/>): code=2 consumed=0
scenario 1 completed without a fatal signal
exit=0
```

**This branch, scenario 2:**
```
scenario2(encode empty OCTET STRING): encoded=30
scenario 2 completed without a fatal signal
exit=0
```

(`code=2` is `RC_FAIL` — the malformed empty `<INTEGER/>` is still
correctly rejected by the decoder; only the UB before that rejection
is gone.)

### 2. Project's own `tests-skeletons` suite

`./configure CC=clang-14 CXX=clang++-14` on this codebase
auto-detects and enables `-fsanitize=undefined
-fno-sanitize-recover=undefined` (among other sanitizer flags) when
the compiler supports them (see `configure.ac`), so a stock `make
check` build already exercises the same UBSan pointer-overflow check
without any extra reproducer code.

**Baseline (`8a274c3f`)**, `tests/tests-skeletons`: 15/17 pass, 2 fail:

```
FAIL: check-OCTET_STRING
========================
OCTET_STRING.c:876:23: runtime error: applying zero offset to null pointer
    #0 ... in OCTET_STRING__convert_binary .../skeletons/OCTET_STRING.c:876:23
    #1 ... in xer_decode_general .../skeletons/xer_decoder.c:279:4
    #2 ... in OCTET_STRING__decode_xer .../skeletons/OCTET_STRING.c:1179:9
    #3 ... in OCTET_STRING_decode_xer_binary .../skeletons/OCTET_STRING.c:1210:12
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior OCTET_STRING.c:876:23 in
FAIL check-OCTET_STRING (exit status: 1)

FAIL: check-UTF8String
======================
UTF8String.c:124:25: runtime error: applying zero offset to null pointer
    #0 ... in UTF8String__process .../skeletons/UTF8String.c:124:25
    #1 ... in UTF8String_length .../skeletons/UTF8String.c:171:10
    #2 ... in check .../tests/tests-skeletons/check-UTF8String.c:20:8
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior UTF8String.c:124:25 in
FAIL check-UTF8String (exit status: 1)
```

**This branch**, `tests/tests-skeletons`: 17/17 pass, 0 fail.

### 3. Full build + `make check` on this branch (clang-14)

```
autoreconf -iv                              # exit 0
./configure CC=clang-14 CXX=clang++-14      # exit 0
make -j8                                    # exit 0
make -j8 check                              # exit 2 (see below)
```

`make check` overall exit status is non-zero, but the only failures
are in `tests/tests-c-compiler` (`check-126.-gen-PER`,
`check-161.-fcompound-names`,
`check-161.-fcompound-names.-gen-PER`, `check-162`,
`check-164.-fcompound-names`) — none of them touch any file in this
diff. The same class of failures (a slightly different subset —
`check-60`, `check-62`, `check-70` also fail there) reproduces on
unfixed upstream master (`8a274c3f`) built the same way, confirming
they are pre-existing and environment-related (one signature seen is
an `abuf_vprintf`/`vasprintf` assertion in `asn1_buffer.c`, unrelated
to XER/UB work), not caused or affected by this change. Every other
suite (`libasn1parser`, `libasn1fix`, `asn1-tools`,
`asn1-tools/unber`, `tests-skeletons`, `tests-asn1c-compiler`,
`tests-asn1c-smoke`) passes in full on this branch.

## Scope

`skeletons/INTEGER.c`, `skeletons/OBJECT_IDENTIFIER.c`,
`skeletons/OCTET_STRING.c`, `skeletons/RELATIVE-OID.c`,
`skeletons/UTF8String.c`, `skeletons/asn_codecs_prim.c`,
`skeletons/xer_decoder.c`, `skeletons/xer_support.c` — 8 files, 19
insertions / 15 deletions. The `tests-skeletons` results above come
from the suite that already existed on both the baseline and this
branch; no test files are added or modified by this diff.
